### PR TITLE
fix(ci): use ubuntu 20.04 instead of 21.04

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ stages:
   parallel:
     matrix:
       - DISTRO: ubuntu
-        VERSION: ["latest", "rolling", "21.04", "18.04"]
+        VERSION: ["latest", "rolling", "20.04", "18.04"]
       - DISTRO: debian
         VERSION:
           ["latest", "bookworm", "bookworm-slim", "bullseye", "bullseye-slim", "buster", "buster-slim"]


### PR DESCRIPTION
Use Ubuntu 20.04 (LTS) instead of Ubuntu 21.04 (standards)