### PR TITLE
fix!: add wakemeops prefix to repo url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ publish:
 	-H 'Content-Type: application/json' --data \
 	"{\"ForceOverwrite\":true, \"Signing\" : \
 	{\"GpgKey\":\"wakemebot@protonmail.com\", \"Batch\":true}}" \
-	"http://_/api/publish/s3:wakemeops-eu-west-3:./stable"
+	"http://_/api/publish/s3:wakemeops-eu-west-3:wakemeops/stable"
 
 exec:
 	@docker run --pull=always -uroot -it  --rm -w /wakemeops -v $$(pwd):/wakemeops upciti/wakemebot:main bash

--- a/assets/install_repository
+++ b/assets/install_repository
@@ -120,7 +120,7 @@ M1isGcqM+C+T2AMf+LSoI18ao7+aDUlvojZwJyVEwkiJ3SyoD5P/cBxVH5mVNXUS
 EOF
 
 cat <<EOF > /etc/apt/sources.list.d/wakemeops.list
-deb http://deb.wakemeops.com/ stable ${@-"dev devops secops terminal desktop"}
+deb http://deb.wakemeops.com/wakemeops/ stable ${@-"dev devops secops terminal desktop"}
 EOF
 
 apt-get update -yq


### PR DESCRIPTION
This change makes the configuration of `apt-cacher-ng` a lot easier and is
a good practice of debian repositories.

The new repo url is: http://deb.wakemeops.com/wakemeops/.

The old url is still supported using a redirection rule.

As a result the repo Origin and Label have changed and users need to
manually accept those changes.