### PR TITLE
chore(ci): remove debian:buster and debian:bullseye from test matrix

### DIFF
--- a/.github/workflows/check_blueprints.yml
+++ b/.github/workflows/check_blueprints.yml
@@ -66,14 +66,12 @@ jobs:
       matrix:
         distribution:
           - debian:bookworm-slim
-          - debian:bullseye-slim
-          - debian:buster-slim
+          - minideb:bullseye
+          - minideb:buster
           - ubuntu:rolling
           - ubuntu:22.04
           - ubuntu:20.04
           - ubuntu:18.04
-          - minideb:bullseye
-          - minideb:buster
     container: wakemeops/${{ matrix.distribution }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Minideb uses the same APT repositories as Debian, testing package installation on both Minideb and Debian is redundant.