### PR TITLE
feat(kubelogin): Added new devops tool kubelogin for AAD login in AKS

### DIFF
--- a/blueprints/devops/kubelogin/ops2deb.lock.yml
+++ b/blueprints/devops/kubelogin/ops2deb.lock.yml
@@ -1,0 +1,6 @@
+- url: https://github.com/Azure/kubelogin/releases/download/v0.0.27/kubelogin-linux-amd64.zip
+  sha256: a8a0a34f330d1a8b19965dbf10dee4d76ce23ec5b5623f9534a88326b8475e03
+  timestamp: 2023-03-13 13:21:17+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.0.27/kubelogin-linux-arm64.zip
+  sha256: 3b3991d39f1c918ddb2467b68ff5cc0fe80627ff27d04c8e0207b2b2d314a948
+  timestamp: 2023-03-13 13:21:17+00:00

--- a/blueprints/devops/kubelogin/ops2deb.yml
+++ b/blueprints/devops/kubelogin/ops2deb.yml
@@ -1,0 +1,16 @@
+name: kubelogin
+matrix:
+  architectures:
+    - amd64
+    - arm64
+version: 0.0.27
+homepage: https://github.com/Azure/kubelogin
+summary: Kubernetes credential (exec) plugin implementing azure authentication
+description: |-
+  This plugin provides features that are not available in kubectl.
+  In Azure Kubernetes Service since k8s version 1.24, this plugin is necessary to
+  query the kubernetes api in clusters with Azure Active Directory
+  authentication.
+fetch: https://github.com/Azure/kubelogin/releases/download/v{{version}}/kubelogin-linux-{{goarch}}.zip
+script:
+  - install -m 755 bin/linux_{{goarch}}/kubelogin {{src}}/usr/bin/kubelogin


### PR DESCRIPTION
This plugin is required from Kubernetes version 1.24 in the Azure Kubernetes Service with Azure Active Directory in order to be able to authenticate against the Kubernetes API.