### PR TITLE
feat: add blueprints for neovim

### DIFF
--- a/blueprints/desktop/nvim/ops2deb.lock.yml
+++ b/blueprints/desktop/nvim/ops2deb.lock.yml
@@ -1,0 +1,3 @@
+- url: https://github.com/neovim/neovim/releases/download/v0.9.5/nvim.appimage
+  sha256: 0c82e5702af7a11fbb916a11b4a82e98928abf8266c74b2030ea740340437bf9
+  timestamp: 2024-02-21 19:27:28+00:00

--- a/blueprints/desktop/nvim/ops2deb.yml
+++ b/blueprints/desktop/nvim/ops2deb.yml
@@ -1,0 +1,16 @@
+name: neovim
+matrix:
+  architectures:
+    - amd64
+  versions:
+    - 0.9.5
+homepage: https://github.com/neovim/neovim
+summary: Neovim text editor
+description: |-
+  Neovim is a project that seeks to aggressively refactor the Vim text editor.
+  Visit https://github.com/neovim/neovim for more informations.
+fetch: https://github.com/neovim/neovim/releases/download/v{{version}}/nvim.appimage
+install:
+  - nvim.appimage:/usr/bin/nvim
+script:
+  - sed -i "s/dh_strip --no-ddebs/true/" {{debian}}/rules


### PR DESCRIPTION
neovim versions packaged in Ubuntu are really old (https://packages.ubuntu.com/search?keywords=neovim) so this might be useful to stay up-to-date