### PR TITLE
Feat/add cheat package

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Debian packages are generated from [ops2deb](https://github.com/upciti/ops2deb) 
 * Run `make lock` to update the lock files.
 * Create a new pull request using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
+> [!TIP]
+> If you are running on Apple `arm64` based system you can use this command to format and generate lock files:
+> ```sh
+> docker run --platform linux/amd64 --workdir /home/ops2deb --volume ./:/home/ops2deb --rm \
+>   docker.io/wakemeops/debian /bin/bash -c "apt update && apt install -y make ops2deb && make format && make lock"
+> ```
+
 ## :notebook_with_decorative_cover: Documentation
 
 Please refer to our documentation at https://docs.wakemeops.com for more information.

--- a/blueprints/terminal/cheat/ops2deb.lock.yml
+++ b/blueprints/terminal/cheat/ops2deb.lock.yml
@@ -1,0 +1,18 @@
+- url: https://github.com/cheat/cheat/releases/download/4.4.0/cheat-linux-amd64.gz
+  sha256: f975e6df9b1226a4405e727b3222a0d6a58f2237cc449e12588d8df5eb713a59
+  timestamp: 2024-05-18 16:53:53+00:00
+- url: https://github.com/cheat/cheat/releases/download/4.4.0/cheat-linux-arm64.gz
+  sha256: b16845434c75519728747d19c566c6dd47778a04694fb245d3ed78da04f9a157
+  timestamp: 2024-05-18 16:53:53+00:00
+- url: https://github.com/cheat/cheat/releases/download/4.4.1/cheat-linux-amd64.gz
+  sha256: 0d3f3060f1353c177eb0bc688b21d4ca7695d270a6bc75fbcd8981517edd2fd2
+  timestamp: 2024-05-18 16:53:53+00:00
+- url: https://github.com/cheat/cheat/releases/download/4.4.1/cheat-linux-arm64.gz
+  sha256: 77b0daa8e4608679e110b44c317393cd8307fed6f04e15aad9a2f8444784c4ed
+  timestamp: 2024-05-18 16:53:53+00:00
+- url: https://github.com/cheat/cheat/releases/download/4.4.2/cheat-linux-amd64.gz
+  sha256: b81f5ba21f134087c0294d809f89e5442d641d7be297bb128807cbce00849e9b
+  timestamp: 2024-05-18 16:53:53+00:00
+- url: https://github.com/cheat/cheat/releases/download/4.4.2/cheat-linux-arm64.gz
+  sha256: 08e1741e4d7e0ad9fc5055d70ab1985e53ed0ed8070930b5d93569c8239d0d83
+  timestamp: 2024-05-18 16:53:53+00:00

--- a/blueprints/terminal/cheat/ops2deb.yml
+++ b/blueprints/terminal/cheat/ops2deb.yml
@@ -1,0 +1,18 @@
+name: cheat
+matrix:
+  architectures:
+    - amd64
+    - arm64
+  versions:
+    - 4.4.0
+    - 4.4.1
+    - 4.4.2
+homepage: https://github.com/cheat/cheat
+summary: Create and view interactive cheat sheets
+description: |-
+  Cheat allows you to create and view interactive cheatsheets on the command-
+  line. It was designed to help remind *nix system administrators of options for
+  commands that they use frequently, but not frequently enough to remember.
+fetch: https://github.com/cheat/cheat/releases/download/{{version}}/cheat-linux-{{arch}}.gz
+install:
+  - cheat-linux-{{arch}}:/usr/bin/cheat


### PR DESCRIPTION
- Add [cheat](https://github.com/cheat/cheat) package
- Add documentation to format and generate lockfiles on `OSX - arm64` based systems