### PR TITLE
feat(devops): add argo package

### DIFF
--- a/blueprints/devops/argo/ops2deb.lock.yml
+++ b/blueprints/devops/argo/ops2deb.lock.yml
@@ -1,0 +1,48 @@
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.0/argo-linux-amd64.gz
+  sha256: 52557f2066d265a81362a808d6a76c1fc445a1f73e1a3c9509842427d447823c
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.0/argo-linux-arm64.gz
+  sha256: 224739385282142249195408cce6f6990b7f838be8554f70e2d37b0bd7967fc4
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.1/argo-linux-amd64.gz
+  sha256: 23108a150f9a88a183e3b80b49b5e81d9a4953f519a784224ba08714b36707db
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.1/argo-linux-arm64.gz
+  sha256: ffb062d9d274a6de4edbc28ca4022503a3ee036686415f7b0386e23a34fc9e8e
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.2/argo-linux-amd64.gz
+  sha256: bac1a01efe11ea11d9f8f7218ace48daf5de8fbc014c5a2c9756cb1f7760b737
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.2/argo-linux-arm64.gz
+  sha256: dd6651c47a7b3339ccbbf02f04c0a437078cc2988dc728f7b42bac4f6e95b57c
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.3/argo-linux-amd64.gz
+  sha256: ed20bfba190e9a4ccde2ab6039d9997b75271e4bd8e8f8adc326dc935feb4e7f
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.3/argo-linux-arm64.gz
+  sha256: b1b8d69089bc4d563e7c1c7d6048901523527a5d5257d77f528aa75ef94d59fe
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.4/argo-linux-amd64.gz
+  sha256: b534a14744cbf867f3c6bfdb69690d25271dc13d343b202057b7f15b131512fc
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.4/argo-linux-arm64.gz
+  sha256: a66f09db7fd9a5f7567ada01e985820c149e3c7a77127af62215bae265abc2b9
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.5/argo-linux-amd64.gz
+  sha256: b8d520f73b06357ed118e507b25e2a375a4013f315e43c23d6c1a09b1daf3686
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.5/argo-linux-arm64.gz
+  sha256: b928025a41e39ae46a9aefde8c28f6f3fdd1bbe8f98d24959fc024663fbf545c
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.6/argo-linux-amd64.gz
+  sha256: 6691b0aa1414b8b1cb8340f50eb7ab352517519f4f982ac682798f369a965c32
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.6/argo-linux-arm64.gz
+  sha256: 0a245bb062d88c7a6a7cdb9e2f26141184897ea0966eedd91b6a0e06ab15b702
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.7/argo-linux-amd64.gz
+  sha256: 9ae18d9831e05fbf2b1072dbdb00333daebf97848cc1e72aa76ddfa4cefcef3d
+  timestamp: 2024-05-31 02:15:27+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.5.7/argo-linux-arm64.gz
+  sha256: acebb498ebcc7318526cc8034101b1575d68db184e3001d565d1beb4b418d3c6
+  timestamp: 2024-05-31 02:15:27+00:00

--- a/blueprints/devops/argo/ops2deb.yml
+++ b/blueprints/devops/argo/ops2deb.yml
@@ -1,0 +1,23 @@
+name: argo
+matrix:
+  architectures:
+    - amd64
+    - arm64
+  versions:
+    - 3.5.0
+    - 3.5.1
+    - 3.5.2
+    - 3.5.3
+    - 3.5.4
+    - 3.5.5
+    - 3.5.6
+    - 3.5.7
+homepage: https://argo-workflows.readthedocs.io
+summary: Workflow Engine for Kubernetes
+description: |-
+  Argo Workflows is an open source container-native workflow engine for
+  orchestrating parallel jobs on Kubernetes. Argo Workflows is implemented as a
+  Kubernetes CRD (Custom Resource Definition).
+fetch: https://github.com/argoproj/argo-workflows/releases/download/v{{version}}/argo-linux-{{arch}}.gz
+install:
+  - argo-linux-{{arch}}:/usr/bin/argo


### PR DESCRIPTION
Adds the [argo](https://github.com/argoproj/argo-workflows) package, which is used to manage argo workflows (not the same purpose as argo-cd).