### PR TITLE
ci: build multiarch docker images

### DIFF
--- a/.github/workflows/build_and_publish_docker_images.yml
+++ b/.github/workflows/build_and_publish_docker_images.yml
@@ -66,6 +66,10 @@ jobs:
             tag: buster
 
     steps:
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU (for multi platform build)
+        uses: docker/setup-qemu-action@v3
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -83,3 +87,4 @@ jobs:
           build-args: |
             IMAGE=${{ matrix.image }}
             TAG=${{ matrix.tag }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Build multiarch (`amd64` and `arm64`) images based on [setup-buildx-action](https://github.com/docker/setup-buildx-action) and [setup-qemu-action](https://github.com/docker/setup-qemu-action).

*See: https://docs.docker.com/build/ci/github-actions/multi-platform*

All base images are compatible with the `arm64` target architecture: 
- https://hub.docker.com/_/ubuntu/tags
- https://hub.docker.com/_/debian/tags
- https://hub.docker.com/r/bitnami/minideb/tags