### PR TITLE
feat(secops): add kubescape package

### DIFF
--- a/blueprints/secops/kubescape/ops2deb.lock.yml
+++ b/blueprints/secops/kubescape/ops2deb.lock.yml
@@ -1,0 +1,30 @@
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.10/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: e867543c53a4a47ae332391ed486aac8ec3f3e8a6eb37b8138f2feaeeff84c18
+  timestamp: 2024-07-15 22:04:28+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.11/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: de395f8b26056840ef83bb331bd486c7e634a89c99ebc17db4f9e1343ca34973
+  timestamp: 2024-07-15 22:04:28+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.12/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: 45beedfe9f9914ed2c4ce11b372b86ee912d9175a0bfd457306672aec029b9f3
+  timestamp: 2024-07-15 22:04:28+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.13/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: 36c70c005e6786d7feaa442e3482db0b5c3273ffc793eb97f3dce560d4acc6ea
+  timestamp: 2024-07-15 22:04:28+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.14/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: c3920c7ccf2183e17e9d5f6f8c9f33dbe59e49ee715ec472990e1ea014e3b5f6
+  timestamp: 2024-07-15 22:04:28+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.10/kubescape-ubuntu-latest.tar.gz
+  sha256: a37c4d0c3126ed081b2350136a72ba867e998c545d79d152d651b88df41d3ced
+  timestamp: 2024-07-15 22:15:02+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.11/kubescape-ubuntu-latest.tar.gz
+  sha256: af654301164a69fbb6ad5d89a1bf79659532e01864e799988e0a25987289b66c
+  timestamp: 2024-07-15 22:15:02+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.12/kubescape-ubuntu-latest.tar.gz
+  sha256: 3d474317ef373b0126a213499e88e2aff63631768a44e5bb4052aff0d2a695b1
+  timestamp: 2024-07-15 22:15:02+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.13/kubescape-ubuntu-latest.tar.gz
+  sha256: 71b8a290605a2431efd5cd67047b5e5fd4341b87755944738c37364a10ceb76c
+  timestamp: 2024-07-15 22:15:02+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.14/kubescape-ubuntu-latest.tar.gz
+  sha256: fb766abebf463921a7647b5dd7cb56f178e234c9e664f47e17bf9c1ff57430c4
+  timestamp: 2024-07-15 22:15:02+00:00

--- a/blueprints/secops/kubescape/ops2deb.yml
+++ b/blueprints/secops/kubescape/ops2deb.yml
@@ -1,0 +1,29 @@
+name: kubescape
+matrix:
+  architectures:
+    - amd64
+  versions:
+    - 3.0.10
+    - 3.0.11
+    - 3.0.12
+    - 3.0.13
+    - 3.0.14
+homepage: https://kubescape.io
+summary: kubernetes security platform for your IDE, CI/CD pipelines, and clusters
+description: |-
+  Kubescape is an open-source Kubernetes security platform. It includes risk
+  analysis, security compliance, and misconfiguration scanning. Targeted at the
+  DevSecOps practitioner or platform engineer, it offers an easy-to-use CLI
+  interface, flexible output formats, and automated scanning capabilities. It
+  saves Kubernetes users and admins precious time, effort, and resources.
+
+  Kubescape scans clusters, YAML files, and Helm charts. It detects
+  misconfigurations according to multiple frameworks (including NSA-CISA, MITRE
+  ATT&CK® and the CIS Benchmark).
+fetch:
+  url: https://github.com/kubescape/kubescape/releases/download/v{{version}}/kubescape-{{target}}-latest.tar.gz
+  targets:
+    amd64: ubuntu
+    arm64: arm64-ubuntu
+install:
+  - kubescape-{{target}}-latest:/usr/bin/kubescape


### PR DESCRIPTION
Add [kubescape](https://kubescape.io/) package.

Unfortunately [release assets](https://github.com/kubescape/kubescape/releases/tag/v3.0.14) in Github are named `kubescape-ubuntu-latest.tar.gz` and `kubescape-arm64-ubuntu-latest.tar.gz` which returns an error if I insert the `{{arch}}` template, I ended up declaring 2 packages (one for each arch) in the same file, I don't know if there is a better practice for this use case @fyhertz?