### PR TITLE
fix(secops): correctly manage arm64 package for kubescape

### DIFF
--- a/blueprints/secops/kubescape/ops2deb.lock.yml
+++ b/blueprints/secops/kubescape/ops2deb.lock.yml
@@ -31,3 +31,6 @@
 - url: https://github.com/kubescape/kubescape/releases/download/v3.0.15/kubescape-ubuntu-latest.tar.gz
   sha256: 33feac97f715a2f5eb0f12b449729b8f0a7c350f46a033d157e997b134ab7bb2
   timestamp: 2024-07-24 12:09:04+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.15/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: 860ea20ccd940ba2dd4e03d4a65d5b9645fa1d4b14adcd48fe4dab8f09e9ebf5
+  timestamp: 2024-07-25 21:55:53+00:00

--- a/blueprints/secops/kubescape/ops2deb.yml
+++ b/blueprints/secops/kubescape/ops2deb.yml
@@ -2,6 +2,7 @@ name: kubescape
 matrix:
   architectures:
     - amd64
+    - arm64
   versions:
     - 3.0.10
     - 3.0.11


### PR DESCRIPTION
Hey @fyhertz,

I realized that the `arm64` arch isn't provided for the kubescape package, either on the [documentation](https://docs.wakemeops.com/packages/kubescape) or when trying to download it : 

```sh
╭─tobi@pi.bastion ~  
╰─➤sudo apt install kubescape
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package kubescape
```

I also noticed that everything seems correct in the [ops2deb.lock.yml file](https://github.com/upciti/wakemeops/blob/main/blueprints/secops/kubescape/ops2deb.lock.yml), maybe the change I made would solve the problem ?