### PR TITLE
feat(devops): zot container registry and corresponding zli tool

### DIFF
--- a/blueprints/devops/zli/ops2deb.lock.yml
+++ b/blueprints/devops/zli/ops2deb.lock.yml
@@ -1,0 +1,6 @@
+- url: https://github.com/project-zot/zot/releases/download/v2.1.0/zli-linux-amd64
+  sha256: 224a879060a2eaf030e58a4efcd147661a6b1c77878a3701785277c984b08ab4
+  timestamp: 2024-11-30 19:02:56+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.0/zli-linux-arm64
+  sha256: 933886eba29f046d0565ff0294a34502ee338ebbf769422bed31d9cac36d8bc6
+  timestamp: 2024-11-30 19:04:04+00:00

--- a/blueprints/devops/zli/ops2deb.yml
+++ b/blueprints/devops/zli/ops2deb.yml
@@ -1,0 +1,15 @@
+name: zli
+matrix:
+  architectures:
+    - amd64
+    - arm64
+  versions:
+    - 2.1.0
+homepage: https://zotregistry.dev
+summary: tool for OCI-native container image registry, simplified
+description: |-
+  zli is a binary that implements a set of command line commands for interacting
+  with the zot registry server
+fetch: https://github.com/project-zot/zot/releases/download/v{{version}}/zli-linux-{{arch}}
+install:
+  - zli-linux-{{arch}}:/usr/bin/zli

--- a/blueprints/devops/zot/ops2deb.lock.yml
+++ b/blueprints/devops/zot/ops2deb.lock.yml
@@ -1,0 +1,12 @@
+- url: https://github.com/project-zot/zot/releases/download/v2.1.0/zot-linux-amd64
+  sha256: ca345a87d0f58e2ebe4fba0177bd1cabec7f6ea93d1527d3a449d49bc22ef8b5
+  timestamp: 2024-11-30 18:57:08+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.1/zot-linux-amd64
+  sha256: cb727862ec10c6b246a62999b5e590422f50bd8be20316a9e24e1f1a1d856d38
+  timestamp: 2024-11-30 19:00:35+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.0/zot-linux-arm64
+  sha256: 33c5549c9a099bb123e7ba53a521f36d0e231392e6af953e331ab4a9174d9d0e
+  timestamp: 2024-11-30 19:03:52+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.1/zot-linux-arm64
+  sha256: 607b6c0d77bc8bb8767baad598165660f8d4e5bd93835fe920bd6e847c5fc0d3
+  timestamp: 2024-11-30 19:03:52+00:00

--- a/blueprints/devops/zot/ops2deb.yml
+++ b/blueprints/devops/zot/ops2deb.yml
@@ -1,0 +1,15 @@
+name: zot
+matrix:
+  architectures:
+    - amd64
+    - arm64
+  versions:
+    - 2.1.1
+homepage: https://zotregistry.dev
+summary: OCI-native container image registry, simplified
+description: |-
+  zot is an OCI image registry that allows you to store, manage, and share
+  container images.
+fetch: https://github.com/project-zot/zot/releases/download/v{{version}}/zot-linux-{{arch}}
+install:
+  - zot-linux-{{arch}}:/usr/bin/zot


### PR DESCRIPTION
Zot is a simple one-binary registry which can be used as a proxy cache for container images on a developer’s notebook.