### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/balena-etcher/ops2deb.lock.yml
+++ b/blueprints/desktop/balena-etcher/ops2deb.lock.yml
@@ -10,3 +10,6 @@
 - url: https://github.com/balena-io/etcher/releases/download/v1.19.25/balena-etcher_1.19.25_amd64.deb
   sha256: 00e7334b88bfdb492277f3c0db03b83f53593573aae6bbe0102a0ecd1dcc1b3e
   timestamp: 2024-10-10 12:10:38+00:00
+- url: https://github.com/balena-io/etcher/releases/download/v2.0.0/balena-etcher_2.0.0_amd64.deb
+  sha256: dfea54c2711a8cbfcadcf7eadf59e79a3e268fef813cc5bd64b8b5c59094f2fe
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/desktop/balena-etcher/ops2deb.yml
+++ b/blueprints/desktop/balena-etcher/ops2deb.yml
@@ -5,6 +5,7 @@ matrix:
     - 1.18.11
     - 1.19.21
     - 1.19.25
+    - 2.0.0
 homepage: https://github.com/balena-io/etcher
 summary: flash OS images to SD cards and USB drives, safely and easily
 description: |-

--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -145,3 +145,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.46.0_amd64.deb
   sha256: 6eeb00618771ad785ecefaa6f69e656de206e4e31051683844abb6a7b304d03e
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.46.1_amd64.deb
+  sha256: f09a51bc37ccb69ce00a23f41921556fdc9d96ebc4056b2165e0644786692edd
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -50,6 +50,7 @@ matrix:
     - 7.42.0
     - 7.43.0
     - 7.46.0
+    - 7.46.1
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/dev/oasdiff/ops2deb.lock.yml
+++ b/blueprints/dev/oasdiff/ops2deb.lock.yml
@@ -256,3 +256,9 @@
 - url: https://github.com/Tufin/oasdiff/releases/download/v1.11.1/oasdiff_1.11.1_linux_arm64.tar.gz
   sha256: d91fedfa961df96c4a9fb838133f72b8ad8f23a40bf5b09828d480eb014e74bf
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/Tufin/oasdiff/releases/download/v2.0.0/oasdiff_2.0.0_linux_amd64.tar.gz
+  sha256: 02ca60c0e6cf843ad6c6d8a395abaa9c71fdd3b6fe329450d7e9c81afd734f4c
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/Tufin/oasdiff/releases/download/v2.0.0/oasdiff_2.0.0_linux_arm64.tar.gz
+  sha256: 3c9dd9bdb75ab8f59d61fc0fc9efde735583d4befd94b6e0cac2465a2b20b680
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/dev/oasdiff/ops2deb.yml
+++ b/blueprints/dev/oasdiff/ops2deb.yml
@@ -47,6 +47,7 @@ matrix:
     - 1.10.27
     - 1.10.28
     - 1.11.1
+    - 2.0.0
 homepage: https://github.com/tufin/oasdiff
 summary: compare and detect breaking changes in OpenAPI specs
 description: |-

--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.11.zip
-  sha256: dac365ef23c50bd7be15e689e0b0aad69ca4cc74a513d5222c309c02467a0798
-  timestamp: 2023-01-15 13:33:25+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.12.zip
   sha256: 85c04ac44231a1305ebe838e14faeca0b4e3751bd3d15d9aaee4acd38606ac62
   timestamp: 2023-01-30 10:19:06+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.5.3.zip
   sha256: 020c13e2e6e1a49f6804e6047f2cc5229c6325480ce520a0cce5a28dc87d44c1
   timestamp: 2025-02-13 09:07:20+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.5.4.zip
+  sha256: 26f5745a4c36ca79711b9d8321be4e81a27c84a54fb7feec4ce9ae4239c23937
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.3.11
       - 2.3.12
       - 2.3.13
       - 2.3.14
@@ -73,6 +72,7 @@
       - 2.5.1
       - 2.5.2
       - 2.5.3
+      - 2.5.4
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/astral-sh/uv/releases/download/0.4.12/uv-aarch64-unknown-linux-musl.tar.gz
-  sha256: 7329992bee100397b3520f1e93512804aa47ea01404c05609aedd181311cdf3b
-  timestamp: 2024-09-18 15:06:18+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.4.12/uv-armv7-unknown-linux-gnueabihf.tar.gz
-  sha256: 7a0433a46595b40d9e50eb9a8aeb193b18eb5d545a677a646f86760b716f4b6e
-  timestamp: 2024-09-18 15:06:18+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.4.12/uv-x86_64-unknown-linux-gnu.tar.gz
-  sha256: db44453ec57d6e3a35b7af2bb7938b47bdc9e7ca397269e978c53dd3065b1195
-  timestamp: 2024-09-18 15:06:18+00:00
 - url: https://github.com/astral-sh/uv/releases/download/0.4.13/uv-aarch64-unknown-linux-musl.tar.gz
   sha256: c24306c2cfc3bcaeab57f866c2501f07e21098fa03db7c1e5961280d44404443
   timestamp: 2024-09-20 00:26:14+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.6.6/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 4c3426c4919d9f44633ab9884827fa1ad64ad8d993516d636eb955a3835c4a8c
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.7/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: df9e1b9530ad63085b66936e65cca107acc98197856e2ac22b896b1ab3936ac4
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.7/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: a877f7697375f6b19d3b537c5152cbb3d86430120b20d957cfa7c084e6b79d6c
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.7/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 601c2b1147117c4471a154b4cebbdb31c818105f796d5f8115fe42d2526689c8
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 0.4.12
     - 0.4.13
     - 0.4.14
     - 0.4.15
@@ -55,6 +54,7 @@ matrix:
     - 0.6.0
     - 0.6.2
     - 0.6.6
+    - 0.6.7
 homepage: https://github.com/astral-sh/uv
 summary: extremely fast Python package installer and resolver
 description: |-

--- a/blueprints/devops/docker-compose/ops2deb.lock.yml
+++ b/blueprints/devops/docker-compose/ops2deb.lock.yml
@@ -1,15 +1,6 @@
 - url: https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64
   sha256: f3f10cf3dbb8107e9ba2ea5f23c1d2159ff7321d16f0a23051d68d8e2547b323
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-linux-aarch64
-  sha256: 6d1784542f74806ef0ed4e798d31c91604453eb06b86448b4c60d7df5d5b7afb
-  timestamp: 2023-05-17 18:20:46+00:00
-- url: https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-linux-armv7
-  sha256: cced34fc17c3689b5e0760b115ef481014eb004370a7b9380fc25eeef55570bb
-  timestamp: 2023-05-17 18:20:46+00:00
-- url: https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-linux-x86_64
-  sha256: b4e6aff14c30f82ce26e94d37686b5598b3f870ce1e053927c853b4f4b128575
-  timestamp: 2023-05-17 18:20:46+00:00
 - url: https://github.com/docker/compose/releases/download/v2.19.0/docker-compose-linux-aarch64
   sha256: c963c6d913a57e0571104ecb8f8ba0502516eafd7b784b5abc4a0d96ebb54d04
   timestamp: 2023-06-21 12:34:20+00:00
@@ -451,3 +442,12 @@
 - url: https://github.com/docker/compose/releases/download/v2.33.1/docker-compose-linux-x86_64
   sha256: 3efda1ad6caed49dedd5644cadbf7e0c9cc3d74d8844ca5237b6a43ac1ef1a46
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/docker/compose/releases/download/v2.34.0/docker-compose-linux-aarch64
+  sha256: cd1ef5eda1119edb9314c0224bac97cee14a9c31909a0f7aa0ddfe266e08adaa
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/docker/compose/releases/download/v2.34.0/docker-compose-linux-armv7
+  sha256: 9080c489047880546b0269b74d0750d94ef604fe4a3c11b2e5dfad436b1e4fa6
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/docker/compose/releases/download/v2.34.0/docker-compose-linux-x86_64
+  sha256: 94a416c6f2836a0a1ba5eb3feb00f2e700a9d98311f062c4c61494ccbf3cd457
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/devops/docker-compose/ops2deb.yml
+++ b/blueprints/devops/docker-compose/ops2deb.yml
@@ -18,7 +18,6 @@
       - arm64
       - armhf
     versions:
-      - 2.18.1
       - 2.19.0
       - 2.19.1
       - 2.20.0
@@ -68,6 +67,7 @@
       - 2.32.4
       - 2.33.0
       - 2.33.1
+      - 2.34.0
   homepage: https://docs.docker.com/compose
   summary: lightweight development environments using Docker
   description: |-

--- a/blueprints/devops/goreleaser/ops2deb.lock.yml
+++ b/blueprints/devops/goreleaser/ops2deb.lock.yml
@@ -112,3 +112,9 @@
 - url: https://github.com/goreleaser/goreleaser/releases/download/v2.8.0/goreleaser_Linux_x86_64.tar.gz
   sha256: f1994d20e67a0b5108fe891123cb0e685d052a8d58a462fc8e0fdb572dc603f9
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/goreleaser/goreleaser/releases/download/v2.8.1/goreleaser_Linux_arm64.tar.gz
+  sha256: 9d4a8aa6b95a1390ece6b55f62f53bdf041440a7e6ef639e7375b0e95284c2ae
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/goreleaser/goreleaser/releases/download/v2.8.1/goreleaser_Linux_x86_64.tar.gz
+  sha256: 76a456f7e9b3d8644638d804d0fcda2f8557858af9b116d1a30b1aaa1d6a1ebc
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/devops/goreleaser/ops2deb.yml
+++ b/blueprints/devops/goreleaser/ops2deb.yml
@@ -23,6 +23,7 @@ matrix:
     - 2.6.1
     - 2.7.0
     - 2.8.0
+    - 2.8.1
 homepage: https://goreleaser.com
 summary: release Go projects as fast and easily as possible
 description: |-

--- a/blueprints/devops/helm/ops2deb.lock.yml
+++ b/blueprints/devops/helm/ops2deb.lock.yml
@@ -268,3 +268,9 @@
 - url: https://get.helm.sh/helm-v3.17.1-linux-arm.tar.gz
   sha256: 1dc5ed54350f4f7ae87441e878be4f4fd9b727a86b11b1d20b1001358c83bed3
   timestamp: 2025-02-12 21:06:08+00:00
+- url: https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz
+  sha256: 90c28792a1eb5fb0b50028e39ebf826531ebfcf73f599050dbd79bab2f277241
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://get.helm.sh/helm-v3.17.2-linux-arm.tar.gz
+  sha256: 0b13ec8580dd5498b5a2d7cb34146e098049f59500a266db1bb98f59649eb90a
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/devops/helm/ops2deb.yml
+++ b/blueprints/devops/helm/ops2deb.yml
@@ -78,6 +78,7 @@
       - 3.16.4
       - 3.17.0
       - 3.17.1
+      - 3.17.2
   homepage: https://helm.sh
   summary: Kubernetes package manager
   description: |-

--- a/blueprints/devops/k9s/ops2deb.lock.yml
+++ b/blueprints/devops/k9s/ops2deb.lock.yml
@@ -385,3 +385,12 @@
 - url: https://github.com/derailed/k9s/releases/download/v0.40.8/k9s_Linux_armv7.tar.gz
   sha256: 1cbece343361530dfc9683ad5ffe42bd2bcb1aa24cae88906f74f5a5ea4657fb
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.40.10/k9s_Linux_amd64.tar.gz
+  sha256: 490bbfcb9314e59c0b1396e1d896786dc944fa9f83062296f454fef97aee0a54
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.40.10/k9s_Linux_arm64.tar.gz
+  sha256: b1f12af342fbd21d466463132fd57eb9175b40ab98b5c711d3b249d3f507fc91
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.40.10/k9s_Linux_armv7.tar.gz
+  sha256: 140f32372777a2b7b429c67cd902d928287e1c8230af0de4f6a9c9d5420c1b07
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/devops/k9s/ops2deb.yml
+++ b/blueprints/devops/k9s/ops2deb.yml
@@ -86,6 +86,7 @@
       - 0.32.7
       - 0.40.5
       - 0.40.8
+      - 0.40.10
   homepage: https://k9scli.io
   summary: manage your Kubernetes clusters with style
   description: |-

--- a/blueprints/devops/kubelogin/ops2deb.lock.yml
+++ b/blueprints/devops/kubelogin/ops2deb.lock.yml
@@ -94,3 +94,9 @@
 - url: https://github.com/Azure/kubelogin/releases/download/v0.1.7/kubelogin-linux-arm64.zip
   sha256: 6bc2cec95e2ce6dbf16f647a102d2f427f6d844729e682824be177ba3f788e5a
   timestamp: 2025-01-31 00:26:58+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.2/kubelogin-linux-amd64.zip
+  sha256: 93da76588d25ccc2a85b23f87e5f6e845f0c2b8c19ddb0dd2d96e90fb9db51ea
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.2/kubelogin-linux-arm64.zip
+  sha256: 65af6187676368515a0af3e21545b23c8285553cba07ce4d7f0380d56e613ef4
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/devops/kubelogin/ops2deb.yml
+++ b/blueprints/devops/kubelogin/ops2deb.yml
@@ -20,6 +20,7 @@ matrix:
     - 0.1.5
     - 0.1.6
     - 0.1.7
+    - 0.2.2
 homepage: https://github.com/Azure/kubelogin
 summary: Kubernetes credential (exec) plugin implementing azure authentication
 description: |-

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -94,3 +94,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.4/openshift-client-linux.tar.gz
   sha256: 74cdd6dca72f40f8cdd04f8d7ef1d1b8b5f3a904216d09a13fa2a03f3997d358
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.5/openshift-client-linux-arm64.tar.gz
+  sha256: 2f8e52c9df4b4c79524d67e64f372161a3700f9fe91776006196b5cb4505cb3a
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.5/openshift-client-linux.tar.gz
+  sha256: 3cd9d759596230f8ebfaa2813067eb532bfae399c3d99e3ffceaf5f02a9e00d1
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -19,6 +19,7 @@ matrix:
     - 4.17.18
     - 4.18.1
     - 4.18.4
+    - 4.18.5
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/rpk/ops2deb.lock.yml
+++ b/blueprints/devops/rpk/ops2deb.lock.yml
@@ -274,3 +274,9 @@
 - url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.6/rpk-linux-arm64.zip
   sha256: 3ba22945d058d413b021f7d802cb7986ccddc17082421c1fa024625c669f0a5e
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.7/rpk-linux-amd64.zip
+  sha256: 47ea80152532d82baa77b3077e42e1e17f4f79be60ed5daf2f5f29d15389fb11
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.7/rpk-linux-arm64.zip
+  sha256: 8783f8122a253b4aedef4d42f989638de4b30cdf12799aab40df2e3fba1cf5cb
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/devops/rpk/ops2deb.yml
+++ b/blueprints/devops/rpk/ops2deb.yml
@@ -50,6 +50,7 @@ matrix:
     - 24.3.4
     - 24.3.5
     - 24.3.6
+    - 24.3.7
 homepage: https://redpanda.com/
 summary: interact with your Redpanda clusters
 description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.1/terragrunt_linux_amd64
-  sha256: 0872d38a4a3105a15bc678b9691fc4b401e3fc366942b06e5616d6f6096ee622
-  timestamp: 2024-10-10 15:06:14+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.1/terragrunt_linux_arm64
-  sha256: ae9a1172f32cf69a7db4762376acb2264a1dd4712e38c53fbc050854acc377b0
-  timestamp: 2024-10-10 15:06:14+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.2/terragrunt_linux_amd64
   sha256: 11953dc822f846b0508a62d4687fd173e5ceb6b04acce72aa13c0dfe0b9bcfbf
   timestamp: 2024-10-16 00:27:00+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.75.6/terragrunt_linux_arm64
   sha256: a1cf60505e61ff3108b2aaa7c42a766bda6b7f6fdb56355aade8d3b1eb5ef39a
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.76.1/terragrunt_linux_amd64
+  sha256: 31ee04da7f9c6cb1d178d3e395bb75d7fe085b1940a96b5b86d8433d9b8caa98
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.76.1/terragrunt_linux_arm64
+  sha256: fdd3e57af39bca20ca76f1673c411f1aab9710f8fecc98ef95769a0159b90ee5
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.68.1
       - 0.68.2
       - 0.68.3
       - 0.68.4
@@ -75,6 +74,7 @@
       - 0.73.5
       - 0.73.8
       - 0.75.6
+      - 0.76.1
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/terminal/zellij/ops2deb.lock.yml
+++ b/blueprints/terminal/zellij/ops2deb.lock.yml
@@ -106,3 +106,9 @@
 - url: https://github.com/zellij-org/zellij/releases/download/v0.41.2/zellij-x86_64-unknown-linux-musl.tar.gz
   sha256: b1c321a817d8a5baf55c2798f6ac7495bba925d686d9877e9604a50784bf6c78
   timestamp: 2024-11-19 15:06:44+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.42.0/zellij-aarch64-unknown-linux-musl.tar.gz
+  sha256: fbf836c93f71d0d1b671f5d3ebab145d027e6f8a69237c9de30648ac308c263b
+  timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.42.0/zellij-x86_64-unknown-linux-musl.tar.gz
+  sha256: eb0c21b1dd3134c267f9990b59e747ad10ee46800b97f9103a4d80de89482668
+  timestamp: 2025-03-18 03:17:18+00:00

--- a/blueprints/terminal/zellij/ops2deb.yml
+++ b/blueprints/terminal/zellij/ops2deb.yml
@@ -22,6 +22,7 @@ matrix:
     - 0.41.0
     - 0.41.1
     - 0.41.2
+    - 0.42.0
 homepage: https://zellij.dev
 summary: terminal workspace with batteries included
 description: |-


### PR DESCRIPTION
Add zellij v0.42.0
Add pyenv v2.5.4
Remove pyenv v2.3.11
Add oasdiff v2.0.0
Add uv v0.6.7
Remove uv v0.4.12
Add rpk v24.3.7
Add helm v3.17.2
Add k9s v0.40.10
Add terragrunt v0.76.1
Remove terragrunt v0.68.1
Add oc v4.18.5
Add kubelogin v0.2.2
Add goreleaser v2.8.1
Add docker-compose v2.34.0
Remove docker-compose v2.18.1
Add signal-desktop v7.46.1
Add balena-etcher v2.0.0