### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/balena-etcher/ops2deb.lock.yml
+++ b/blueprints/desktop/balena-etcher/ops2deb.lock.yml
@@ -13,3 +13,6 @@
 - url: https://github.com/balena-io/etcher/releases/download/v2.0.0/balena-etcher_2.0.0_amd64.deb
   sha256: dfea54c2711a8cbfcadcf7eadf59e79a3e268fef813cc5bd64b8b5c59094f2fe
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/balena-io/etcher/releases/download/v2.1.0/balena-etcher_2.1.0_amd64.deb
+  sha256: e4cf558cbf0234e4030756f422ac04bde26b4c34fc295f7c01e71d171ffdd78a
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/desktop/balena-etcher/ops2deb.yml
+++ b/blueprints/desktop/balena-etcher/ops2deb.yml
@@ -6,6 +6,7 @@ matrix:
     - 1.19.21
     - 1.19.25
     - 2.0.0
+    - 2.1.0
 homepage: https://github.com/balena-io/etcher
 summary: flash OS images to SD cards and USB drives, safely and easily
 description: |-

--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.5.0_amd64.deb
-  sha256: c0b66cdea93d4af07df939cdbdb8b393696a34e0cf84098a69c14ba59621eee1
-  timestamp: 2024-04-18 10:04:46+00:00
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.5.1_amd64.deb
   sha256: 69f291f8fd983e4bf838c22bf0bcd67803195abd33689d51d01403f3b810b929
   timestamp: 2024-04-19 00:21:29+00:00
@@ -148,3 +145,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.46.1_amd64.deb
   sha256: f09a51bc37ccb69ce00a23f41921556fdc9d96ebc4056b2165e0644786692edd
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.47.0_amd64.deb
+  sha256: a29913cb4575b56ae2ad89e5099302f29466ac32f82da508a4d0147a44ca6ead
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -1,7 +1,6 @@
 name: signal-desktop
 matrix:
   versions:
-    - 7.5.0
     - 7.5.1
     - 7.6.0
     - 7.7.0
@@ -51,6 +50,7 @@ matrix:
     - 7.43.0
     - 7.46.0
     - 7.46.1
+    - 7.47.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
@@ -109,3 +109,6 @@
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.13.0/teams-for-linux_1.13.0_amd64.deb
   sha256: d093aa0bf6a7c592ce266634cad726a0cb52461c89b19fca393fec07b17d95e8
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.13.1/teams-for-linux_1.13.1_amd64.deb
+  sha256: 0dd58015d1973ca6bc99fe6828b318108d12db76cbe3ad7108ec984446c8483d
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/desktop/teams-for-linux/ops2deb.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.yml
@@ -38,6 +38,7 @@ matrix:
     - 1.12.6
     - 1.12.7
     - 1.13.0
+    - 1.13.1
 homepage: https://github.com/IsmaelMartinez/teams-for-linux/
 summary: unofficial Microsoft Teams for Linux client
 description: |-

--- a/blueprints/dev/github-cli/ops2deb.lock.yml
+++ b/blueprints/dev/github-cli/ops2deb.lock.yml
@@ -10,15 +10,6 @@
 - url: https://github.com/cli/cli/releases/download/v2.5.0/gh_2.5.0_linux_armv6.tar.gz
   sha256: 44e44829a5361957217bfd7c2c8c6dc88fc5f56a72f2e4df772e0ea551a493bd
   timestamp: 2022-02-02 23:13:50+00:00
-- url: https://github.com/cli/cli/releases/download/v2.31.0/gh_2.31.0_linux_amd64.tar.gz
-  sha256: eec349e43803759d3d7a138d214ae983a3bebebd8e6dd0ec0ff1eea7bdd823e7
-  timestamp: 2023-06-21 01:37:57+00:00
-- url: https://github.com/cli/cli/releases/download/v2.31.0/gh_2.31.0_linux_arm64.tar.gz
-  sha256: 8e704310972ecd4a51a7f92641501d8422923a4dfc07c76719ca42611dd36a23
-  timestamp: 2023-06-21 01:37:57+00:00
-- url: https://github.com/cli/cli/releases/download/v2.31.0/gh_2.31.0_linux_armv6.tar.gz
-  sha256: 8ca0f926fa7c7090199f0e87c3d22e8167f4f2892c1b77dcf041ce50fd6423a0
-  timestamp: 2023-06-21 01:37:57+00:00
 - url: https://github.com/cli/cli/releases/download/v2.32.0/gh_2.32.0_linux_amd64.tar.gz
   sha256: 2e306f118a46764bc1763bacc52e7b18eeca5aa6fd59d2b5fd260f0ef3cd87ae
   timestamp: 2023-07-11 21:16:23+00:00
@@ -460,3 +451,12 @@
 - url: https://github.com/cli/cli/releases/download/v2.68.1/gh_2.68.1_linux_armv6.tar.gz
   sha256: ac7de4f2b8d692580a44cef00d44a37429c9b75e2c6f34fe7ce5e92a1c539ee7
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/cli/cli/releases/download/v2.69.0/gh_2.69.0_linux_amd64.tar.gz
+  sha256: 6e3079e1220920eb61b9e8b68093f6e84b6fb0676ac7da3716689421134c7cff
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/cli/cli/releases/download/v2.69.0/gh_2.69.0_linux_arm64.tar.gz
+  sha256: b910b612ad001c2bce19f1cfab6c97af5afb9038abb815bbc667920901281216
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/cli/cli/releases/download/v2.69.0/gh_2.69.0_linux_armv6.tar.gz
+  sha256: c53aece556064d765cff051960b2d31413ae55717db36a2d094452ddcfb41f09
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/dev/github-cli/ops2deb.yml
+++ b/blueprints/dev/github-cli/ops2deb.yml
@@ -38,7 +38,6 @@
       - arm64
       - armhf
     versions:
-      - 2.31.0
       - 2.32.0
       - 2.32.1
       - 2.33.0
@@ -88,6 +87,7 @@
       - 2.66.1
       - 2.67.0
       - 2.68.1
+      - 2.69.0
   homepage: https://github.com/cli/cli
   summary: GitHub on the command line
   description: |-

--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -241,3 +241,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.53.0/downloads/glab_1.53.0_linux_arm64.deb
   sha256: c159dec458ec3610d20dea93939eb8a95b29c6fd52c50de5bbaa8f6af2bba5b1
   timestamp: 2025-02-14 15:06:26+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.54.0/downloads/glab_1.54.0_linux_amd64.deb
+  sha256: 90b622082b90cc98251dfb72d0441f49642b540649df4820149f0021390646ad
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.54.0/downloads/glab_1.54.0_linux_arm64.deb
+  sha256: 0c1fdb4f57d1e3b2e5e1676b6e2ab99a1a4bb3c01ea58af2e51d5d4845f7b5ed
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -63,6 +63,7 @@
       - 1.51.0
       - 1.52.0
       - 1.53.0
+      - 1.54.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-

--- a/blueprints/dev/oasdiff/ops2deb.lock.yml
+++ b/blueprints/dev/oasdiff/ops2deb.lock.yml
@@ -262,3 +262,9 @@
 - url: https://github.com/Tufin/oasdiff/releases/download/v2.0.0/oasdiff_2.0.0_linux_arm64.tar.gz
   sha256: 3c9dd9bdb75ab8f59d61fc0fc9efde735583d4befd94b6e0cac2465a2b20b680
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/Tufin/oasdiff/releases/download/v2.1.2/oasdiff_2.1.2_linux_amd64.tar.gz
+  sha256: a54d38c914f7272d3f62cecda216686df757fb42ee2f5adbf8706fc886e584d0
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/Tufin/oasdiff/releases/download/v2.1.2/oasdiff_2.1.2_linux_arm64.tar.gz
+  sha256: 9352c7dc31c413029d496a3722907cf144c9b3c7a38ab3daeb5c703596bcf9d6
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/dev/oasdiff/ops2deb.yml
+++ b/blueprints/dev/oasdiff/ops2deb.yml
@@ -48,6 +48,7 @@ matrix:
     - 1.10.28
     - 1.11.1
     - 2.0.0
+    - 2.1.2
 homepage: https://github.com/tufin/oasdiff
 summary: compare and detect breaking changes in OpenAPI specs
 description: |-

--- a/blueprints/dev/pre-commit/ops2deb.lock.yml
+++ b/blueprints/dev/pre-commit/ops2deb.lock.yml
@@ -76,3 +76,6 @@
 - url: https://github.com/pre-commit/pre-commit/releases/download/v4.1.0/pre-commit-4.1.0.pyz
   sha256: df3ac88cb2d7825af90e887e1eafbdb85481b800541d86e4d437b37f8abf8a39
   timestamp: 2025-01-28 09:07:23+00:00
+- url: https://github.com/pre-commit/pre-commit/releases/download/v4.2.0/pre-commit-4.2.0.pyz
+  sha256: 0d4d80fd598dd1f7c268569de49e7c7a692a3de6f7a97cf14ad4e6cce993bbdf
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/dev/pre-commit/ops2deb.yml
+++ b/blueprints/dev/pre-commit/ops2deb.yml
@@ -27,6 +27,7 @@ matrix:
     - 4.0.0
     - 4.0.1
     - 4.1.0
+    - 4.2.0
 revision: "2"
 architecture: all
 homepage: https://pre-commit.com/

--- a/blueprints/dev/scala-cli/ops2deb.lock.yml
+++ b/blueprints/dev/scala-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/VirtusLab/scala-cli/releases/download/v0.1.2/scala-cli-x86_64-pc-linux.deb
-  sha256: 40058131f8784f5b7fdd200a31823d5a021f051b831ea4de712a769040466819
-  timestamp: 2022-03-20 23:23:06+00:00
 - url: https://github.com/VirtusLab/scala-cli/releases/download/v0.1.3/scala-cli-x86_64-pc-linux.deb
   sha256: 08369461e8475b2e50a2523edb8876aedd2eac2eab6eb948701cd4dd1e1a0bb1
   timestamp: 2022-04-04 20:26:56+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/VirtusLab/scala-cli/releases/download/v1.7.0/scala-cli-x86_64-pc-linux.deb
   sha256: 49b2a7a464e363b3b45b0b4d608405fae167b413c9898058b854649c939fbd6a
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/VirtusLab/scala-cli/releases/download/v1.7.1/scala-cli-x86_64-pc-linux.deb
+  sha256: b03a960d6f83a2d30fa771db5775677a2ccddb6555a140780c02a69588fda1a7
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/dev/scala-cli/ops2deb.yml
+++ b/blueprints/dev/scala-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: scala-cli
 matrix:
   versions:
-    - 0.1.2
     - 0.1.3
     - 0.1.4
     - 0.1.5
@@ -51,6 +50,7 @@ matrix:
     - 1.6.1
     - 1.6.2
     - 1.7.0
+    - 1.7.1
 homepage: https://scala-cli.virtuslab.org/
 summary: command-line tool to interact with the Scala language
 description: |-

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -457,3 +457,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.6.8/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 2378ea0122bd56a11ee7ae2ad6116c1f22f4657c03b9efb78ac150236bf7974c
   timestamp: 2025-03-23 17:24:02+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.9/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: 4de15999c38a0e57a3708eccb1fe3295b3d1c0c69410029b16e5e42452d232a9
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.9/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: a9a307d6b3e6a3500aa0102ff7b03cccebe2a9af40130df97382688574afc637
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.9/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 001b87a0c2ea642a3c75a98c6af3e8528aa473d560e653cf213efcc9aaa4a028
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -88,6 +88,7 @@
       - armhf
     versions:
       - 0.6.8
+      - 0.6.9
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/devops/argocd/ops2deb.lock.yml
+++ b/blueprints/devops/argocd/ops2deb.lock.yml
@@ -172,3 +172,9 @@
 - url: https://github.com/argoproj/argo-cd/releases/download/v2.14.5/argocd-linux-arm64
   sha256: 3d6a8b1c46e2289c572894b4d8c85b99c59fbddba2d93459c793d630b01f5d7d
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v2.14.7/argocd-linux-amd64
+  sha256: ada78388f915ec4cdc68a0c7de0df1763cee3ca2f295759659cfd9bb94cd68a1
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v2.14.7/argocd-linux-arm64
+  sha256: 3cfcc4be72b9fc3e975861cd6442c31a7b8181719aea1d331954dc2d95f5c013
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/argocd/ops2deb.yml
+++ b/blueprints/devops/argocd/ops2deb.yml
@@ -33,6 +33,7 @@ matrix:
     - 2.14.1
     - 2.14.2
     - 2.14.5
+    - 2.14.7
 homepage: https://github.com/argoproj/argo-cd
 summary: continuous delivery tool for Kubernetes
 description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.

--- a/blueprints/devops/carvel-kapp/ops2deb.lock.yml
+++ b/blueprints/devops/carvel-kapp/ops2deb.lock.yml
@@ -172,3 +172,9 @@
 - url: https://github.com/vmware-tanzu/carvel-kapp/releases/download/v0.64.0/kapp-linux-arm64
   sha256: fc7617107fa87480e6326c1cdf2c62708f455c9d96f8e9550fb5e848c296cc80
   timestamp: 2024-12-11 12:11:16+00:00
+- url: https://github.com/vmware-tanzu/carvel-kapp/releases/download/v0.64.1/kapp-linux-amd64
+  sha256: 8b7cf929c1498a4ae91b880e77c8ba8b545afc14ee564cd50d749c9f611223ed
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/vmware-tanzu/carvel-kapp/releases/download/v0.64.1/kapp-linux-arm64
+  sha256: a74f11266571fab611d6d371f8ebc275fd16d7545ec00a8d178f2ac33e72d17c
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/carvel-kapp/ops2deb.yml
+++ b/blueprints/devops/carvel-kapp/ops2deb.yml
@@ -33,6 +33,7 @@ matrix:
     - 0.63.2
     - 0.63.3
     - 0.64.0
+    - 0.64.1
 homepage: https://carvel.dev/kapp/
 summary: simple deployment tool focused on the concept of "Kubernetes application"
 description: |-

--- a/blueprints/devops/clusterctl/ops2deb.lock.yml
+++ b/blueprints/devops/clusterctl/ops2deb.lock.yml
@@ -82,3 +82,9 @@
 - url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.5/clusterctl-linux-arm64
   sha256: e7d8de987372221891772d526846149bdf42e871700ebf7f8e6f65cfc24d027a
   timestamp: 2025-02-20 16:11:59+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/clusterctl-linux-amd64
+  sha256: e6a8843b3464eea3c5f98432128a914c5d8e44c2be1f308cf40a72aa98155d8c
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/clusterctl-linux-arm64
+  sha256: 49e80b6d6ac8ec4cf916ad434b12e703cd87b3edd3ee853b80da2510e6839d34
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/clusterctl/ops2deb.yml
+++ b/blueprints/devops/clusterctl/ops2deb.yml
@@ -18,6 +18,7 @@ matrix:
     - 1.9.3
     - 1.9.4
     - 1.9.5
+    - 1.9.6
 homepage: https://cluster-api.sigs.k8s.io/
 summary: Kubernetes project offering declarative APIs for managing multiple clusters
 description: |-

--- a/blueprints/devops/gitlab-release-cli/ops2deb.lock.yml
+++ b/blueprints/devops/gitlab-release-cli/ops2deb.lock.yml
@@ -106,3 +106,12 @@
 - url: https://gitlab.com/gitlab-org/release-cli/-/releases/v0.22.0/downloads/bin/release-cli-linux-arm64
   sha256: 4e299473d7f1cc651e8f2f247030aff8e62e7ebd3f6dd824e866eea320fead02
   timestamp: 2025-02-20 16:02:07+00:00
+- url: https://gitlab.com/gitlab-org/release-cli/-/releases/v0.23.0/downloads/bin/release-cli-linux-amd64
+  sha256: 9a998897932235b6c891c88e2c5f96463e1bbe13c5f048becc8a3b1f5650c8e1
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://gitlab.com/gitlab-org/release-cli/-/releases/v0.23.0/downloads/bin/release-cli-linux-arm
+  sha256: dcdc315eb721ec072a4e8b41285e0544b6be31cd4d4097f1e0f44caf0c461970
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://gitlab.com/gitlab-org/release-cli/-/releases/v0.23.0/downloads/bin/release-cli-linux-arm64
+  sha256: 52c971be359017d8acf11472b6602e4199435bf43f353fd3893a10a0f80bf9da
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/gitlab-release-cli/ops2deb.yml
+++ b/blueprints/devops/gitlab-release-cli/ops2deb.yml
@@ -17,6 +17,7 @@ matrix:
     - 0.20.0
     - 0.21.0
     - 0.22.0
+    - 0.23.0
 homepage: https://gitlab.com/gitlab-org/release-cli/
 summary: command-line interface for GitLab Release
 description: |-

--- a/blueprints/devops/jfrog-cli/ops2deb.lock.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.lock.yml
@@ -208,3 +208,9 @@
 - url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.74.0/jfrog-cli-linux-arm64/jf
   sha256: b9abf44f29b6cf3899d9af97ce08e4276b326968de1ccebc04c5eb85b7860db8
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.74.1/jfrog-cli-linux-amd64/jf
+  sha256: 9d01e42bfdbb4408abc99e56f68ae388c6eff84b5d84045a916acd2956da5409
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.74.1/jfrog-cli-linux-arm64/jf
+  sha256: 14e77c1d3c55f3ac9b81633950d7312469e5b616d6b69da5c3397868ac199947
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/jfrog-cli/ops2deb.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.yml
@@ -39,6 +39,7 @@ matrix:
     - 2.73.2
     - 2.73.3
     - 2.74.0
+    - 2.74.1
 homepage: https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli
 summary: client that provides a simple interface that automates access to the JFrog
   products

--- a/blueprints/devops/krew/ops2deb.lock.yml
+++ b/blueprints/devops/krew/ops2deb.lock.yml
@@ -16,3 +16,12 @@
 - url: https://github.com/kubernetes-sigs/krew/releases/download/v0.4.4/krew-linux_arm64.tar.gz
   sha256: f8f0cdbf698ed3e8cb46e7bd213754701341a10e11ccb69c90d4863e0cf5a16a
   timestamp: 2023-07-14 01:54:57+00:00
+- url: https://github.com/kubernetes-sigs/krew/releases/download/v0.4.5/krew-linux_amd64.tar.gz
+  sha256: bacc06800bda14ec063cd0b6f377a961fdf4661c00366bf9834723cd28bfabc7
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/kubernetes-sigs/krew/releases/download/v0.4.5/krew-linux_arm.tar.gz
+  sha256: 856f212fc83c22082cba1bedc5eac3d601f9d19a0f442a7e18db054b5cef35e9
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/kubernetes-sigs/krew/releases/download/v0.4.5/krew-linux_arm64.tar.gz
+  sha256: e02bdb8fe67cd6641b9ed6b45c6d084f7aa5b161fe49191caf5b1d5e83b0c0f9
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/krew/ops2deb.yml
+++ b/blueprints/devops/krew/ops2deb.yml
@@ -7,6 +7,7 @@ matrix:
   versions:
     - 0.4.3
     - 0.4.4
+    - 0.4.5
 homepage: https://krew.sigs.k8s.io
 summary: find and install kubectl plugins
 description: Krew is the package manager for kubectl plugins.

--- a/blueprints/devops/kubectl-oidc-login/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl-oidc-login/ops2deb.lock.yml
@@ -34,3 +34,9 @@
 - url: https://github.com/int128/kubelogin/releases/download/v1.32.2/kubelogin_linux_arm64.zip
   sha256: 996b6336bcda807493b13f3b4823981ca4f3444835825bf99eb4c0c749794366
   timestamp: 2025-01-31 15:06:21+00:00
+- url: https://github.com/int128/kubelogin/releases/download/v1.32.3/kubelogin_linux_amd64.zip
+  sha256: c065f95401f96e548a835838aaf0834dba9d347a0e5af2f38664272a66e2d948
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/int128/kubelogin/releases/download/v1.32.3/kubelogin_linux_arm64.zip
+  sha256: 4de7356c5eda64e5dc8e3a373f5bb99e1736d8edf4383e2d978839c4f6417938
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/kubectl-oidc-login/ops2deb.yml
+++ b/blueprints/devops/kubectl-oidc-login/ops2deb.yml
@@ -10,6 +10,7 @@ matrix:
     - 1.31.1
     - 1.32.1
     - 1.32.2
+    - 1.32.3
 homepage: https://github.com/int128/kubelogin
 summary: Kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)
 description: |-

--- a/blueprints/devops/kubelogin/ops2deb.lock.yml
+++ b/blueprints/devops/kubelogin/ops2deb.lock.yml
@@ -100,3 +100,9 @@
 - url: https://github.com/Azure/kubelogin/releases/download/v0.2.2/kubelogin-linux-arm64.zip
   sha256: 65af6187676368515a0af3e21545b23c8285553cba07ce4d7f0380d56e613ef4
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.7/kubelogin-linux-amd64.zip
+  sha256: 5053984edc5ccb9dafccf41bcf8d1814f9a4704f2da529c4b9100ecca3ca7857
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.7/kubelogin-linux-arm64.zip
+  sha256: 417ad3e7a3ed5595431a13b4a72f2b29c3a3ce4445e88516680a5dbdd4962b53
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/kubelogin/ops2deb.yml
+++ b/blueprints/devops/kubelogin/ops2deb.yml
@@ -21,6 +21,7 @@ matrix:
     - 0.1.6
     - 0.1.7
     - 0.2.2
+    - 0.2.7
 homepage: https://github.com/Azure/kubelogin
 summary: Kubernetes credential (exec) plugin implementing azure authentication
 description: |-

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.103.0/mirrord_linux_aarch64.zip
-  sha256: 94c752484d4f72b7ed9f8cc43e83fbbd0b983eaf7a89a2b7ce05cdb69b75449c
-  timestamp: 2024-06-02 18:07:29+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.103.0/mirrord_linux_x86_64.zip
-  sha256: 9c6a16788b1145f5a9482668786a3e1e12f2e87d4081c2dffb58c2caebe576f1
-  timestamp: 2024-06-02 18:07:29+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.104.0/mirrord_linux_aarch64.zip
   sha256: 423f4851c4be9972cb1a6f912b4c55c73991505172f66ee7ed84013a871d311a
   timestamp: 2024-06-06 18:06:37+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.134.2/mirrord_linux_x86_64.zip
   sha256: 065e157e477dad18dbfc1a4b10136f2668ef3cc49fb6bc2c1550e24ec44f9e55
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.136.0/mirrord_linux_aarch64.zip
+  sha256: a7eb66e5ca972e11082107d2a124d375ac45201d1bfb4ee40f3d1d35a96d0045
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.136.0/mirrord_linux_x86_64.zip
+  sha256: 962ee068b761907b68cb9ecd75a8e05b791576cad9467b61e2bdb7622edb5ab3
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.103.0
     - 3.104.0
     - 3.105.0
     - 3.106.0
@@ -54,6 +53,7 @@ matrix:
     - 3.132.1
     - 3.133.1
     - 3.134.2
+    - 3.136.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-

--- a/blueprints/devops/natscli/ops2deb.lock.yml
+++ b/blueprints/devops/natscli/ops2deb.lock.yml
@@ -85,3 +85,12 @@
 - url: https://github.com/nats-io/natscli/releases/download/v0.1.6/nats-0.1.6-linux-arm7.zip
   sha256: b720920e0f517782bf889f6291ca3889ddad25c287f347a4e985c28a03dd883c
   timestamp: 2024-12-23 12:10:45+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.0/nats-0.2.0-linux-amd64.zip
+  sha256: d603c2ab08c8a7bdfdffa07acaf07f076bc08a5966a8df3495d01cd4fd031126
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.0/nats-0.2.0-linux-arm64.zip
+  sha256: c9f31feff0aac100bac383761cebd4b3a30f4960a769de7aa3ff26e71ba96c4a
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.0/nats-0.2.0-linux-arm7.zip
+  sha256: ce72aadf626476900fd0e34d98ee01de8b029e059750454b5610041dc5859afc
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/natscli/ops2deb.yml
+++ b/blueprints/devops/natscli/ops2deb.yml
@@ -41,6 +41,7 @@
       - 0.1.4
       - 0.1.5
       - 0.1.6
+      - 0.2.0
   homepage: https://github.com/nats-io/natscli
   summary: command-line interface for NATS
   description: |-

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -100,3 +100,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.5/openshift-client-linux.tar.gz
   sha256: 3cd9d759596230f8ebfaa2813067eb532bfae399c3d99e3ffceaf5f02a9e00d1
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.6/openshift-client-linux-arm64.tar.gz
+  sha256: 8d12e306f69123aa1cfffc19df8ddb115b03ff3d562487ed01470937b10b259e
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.6/openshift-client-linux.tar.gz
+  sha256: 3c47ee67b4fc3c423cc15ca5699d61fd1619dbafc92f564492ddb860b24c541c
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -20,6 +20,7 @@ matrix:
     - 4.18.1
     - 4.18.4
     - 4.18.5
+    - 4.18.6
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/operator-sdk/ops2deb.lock.yml
+++ b/blueprints/devops/operator-sdk/ops2deb.lock.yml
@@ -208,3 +208,9 @@
 - url: https://github.com/operator-framework/operator-sdk/releases/download/v1.39.1/operator-sdk_linux_arm64
   sha256: d3db1772964f1fe620d49073fa4782470b8f3cc7e9a72a68298596cfb063fc73
   timestamp: 2025-01-14 18:08:03+00:00
+- url: https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2/operator-sdk_linux_amd64
+  sha256: 28fc8298a3202cb61fcae941e607f1cab705c9595ca9a7cf2d6d9f54a6b34641
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2/operator-sdk_linux_arm64
+  sha256: 7430ef8d03dde4882d8eaf6465e0d351f5c71a76cce8185b36f9da93b1a3c29b
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/operator-sdk/ops2deb.yml
+++ b/blueprints/devops/operator-sdk/ops2deb.yml
@@ -67,6 +67,7 @@
       - 1.38.0
       - 1.39.0
       - 1.39.1
+      - 1.39.2
   homepage: https://sdk.operatorframework.io
   summary: SDK for building Kubernetes applications
   description: |-

--- a/blueprints/devops/ops2deb/ops2deb.lock.yml
+++ b/blueprints/devops/ops2deb/ops2deb.lock.yml
@@ -118,3 +118,6 @@
 - url: https://github.com/upciti/ops2deb/releases/download/2.5.0/ops2deb_linux_amd64
   sha256: 7810e684d254a46bc27d7dcb77cad43380392c2c16dcb997f9854a40211676df
   timestamp: 2023-12-11 11:25:21+00:00
+- url: https://github.com/upciti/ops2deb/releases/download/2.6.0/ops2deb_linux_amd64
+  sha256: 5d0672602ccff096e27aeb1684ff343018b0020a17ace763940667da40af0763
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/ops2deb/ops2deb.yml
+++ b/blueprints/devops/ops2deb/ops2deb.yml
@@ -127,6 +127,7 @@
       - 2.4.0
       - 2.4.1
       - 2.5.0
+      - 2.6.0
   homepage: https://github.com/upciti/ops2deb
   summary: debian packaging tool for portable applications
   description: |-

--- a/blueprints/devops/rpk/ops2deb.lock.yml
+++ b/blueprints/devops/rpk/ops2deb.lock.yml
@@ -280,3 +280,9 @@
 - url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.7/rpk-linux-arm64.zip
   sha256: 8783f8122a253b4aedef4d42f989638de4b30cdf12799aab40df2e3fba1cf5cb
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.8/rpk-linux-amd64.zip
+  sha256: 658fa8851aaf0bc6a212a2459f6d513a206b3882a775e31228ba97bb60eabb22
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.8/rpk-linux-arm64.zip
+  sha256: 33f2324236e6be4ff125821aec4999cd107d335e6eee3cce8664ec510eac7f3f
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/rpk/ops2deb.yml
+++ b/blueprints/devops/rpk/ops2deb.yml
@@ -51,6 +51,7 @@ matrix:
     - 24.3.5
     - 24.3.6
     - 24.3.7
+    - 24.3.8
 homepage: https://redpanda.com/
 summary: interact with your Redpanda clusters
 description: |-

--- a/blueprints/devops/skaffold/ops2deb.lock.yml
+++ b/blueprints/devops/skaffold/ops2deb.lock.yml
@@ -244,3 +244,9 @@
 - url: https://github.com/GoogleContainerTools/skaffold/releases/download/v2.14.1/skaffold-linux-arm64
   sha256: ef92ae3015d5331cabaee384b24fdd950f5c84c6729beb2604f2b637f6f535d8
   timestamp: 2025-02-05 21:06:07+00:00
+- url: https://github.com/GoogleContainerTools/skaffold/releases/download/v2.14.2/skaffold-linux-amd64
+  sha256: 2209463bafd0e021907c1efe72063d6b9ca3244a72b437a51aff061b0b97087a
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/GoogleContainerTools/skaffold/releases/download/v2.14.2/skaffold-linux-arm64
+  sha256: 7e4a2756e010224b7ec12023269b71ee863e9fff9d136eb8179e556436774f34
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/skaffold/ops2deb.yml
+++ b/blueprints/devops/skaffold/ops2deb.yml
@@ -82,6 +82,7 @@
       - 2.13.2
       - 2.14.0
       - 2.14.1
+      - 2.14.2
   homepage: https://skaffold.dev/
   summary: easy and repeatable Kubernetes development
   description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.2/terragrunt_linux_amd64
-  sha256: 11953dc822f846b0508a62d4687fd173e5ceb6b04acce72aa13c0dfe0b9bcfbf
-  timestamp: 2024-10-16 00:27:00+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.2/terragrunt_linux_arm64
-  sha256: 005a735caa024ad6f4c0ee912397a259a7fade73a067db62e2034328e35c8e7e
-  timestamp: 2024-10-16 00:27:00+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.3/terragrunt_linux_amd64
   sha256: 7968df7745fded0654c36cd8f8d41c73ca28eab8b84fb1a7add78fd3002c804b
   timestamp: 2024-10-16 18:08:00+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.76.1/terragrunt_linux_arm64
   sha256: fdd3e57af39bca20ca76f1673c411f1aab9710f8fecc98ef95769a0159b90ee5
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.76.6/terragrunt_linux_amd64
+  sha256: 5bba39a3d6a2516f022ccbe501d2f1f9f7fb306dbb4ed5d1a48324864725d229
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.76.6/terragrunt_linux_arm64
+  sha256: 13a34df57b68863f08a9eb8cd0e20b100d8eb6d29c4cba1b99457eb2151ddb01
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.68.2
       - 0.68.3
       - 0.68.4
       - 0.68.5
@@ -75,6 +74,7 @@
       - 0.73.8
       - 0.75.6
       - 0.76.1
+      - 0.76.6
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/secops/dive/ops2deb.lock.yml
+++ b/blueprints/secops/dive/ops2deb.lock.yml
@@ -13,3 +13,9 @@
 - url: https://github.com/wagoodman/dive/releases/download/v0.12.0/dive_0.12.0_linux_arm64.tar.gz
   sha256: a2a1470302cdfa367a48f80b67bbf11c0cd8039af9211e39515bd2bbbda58fea
   timestamp: 2024-07-04 17:39:42+00:00
+- url: https://github.com/wagoodman/dive/releases/download/v0.13.0/dive_0.13.0_linux_amd64.tar.gz
+  sha256: 19ed7a1cfc567897a0a1e0e47ed4bdf803b053519b4d3bec50663182495db716
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/wagoodman/dive/releases/download/v0.13.0/dive_0.13.0_linux_arm64.tar.gz
+  sha256: 2fd82611e7b3064769b02fc8b9d38e896b98b93c95bec6a80b5d306fd1469e51
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/secops/dive/ops2deb.yml
+++ b/blueprints/secops/dive/ops2deb.yml
@@ -6,6 +6,7 @@ matrix:
   versions:
     - 0.11.0
     - 0.12.0
+    - 0.13.0
 homepage: https://github.com/wagoodman/dive
 summary: tool for exploring each layer in a docker image
 description: |-

--- a/blueprints/secops/kubescape/ops2deb.lock.yml
+++ b/blueprints/secops/kubescape/ops2deb.lock.yml
@@ -112,3 +112,9 @@
 - url: https://github.com/kubescape/kubescape/releases/download/v3.0.31/kubescape-ubuntu-latest.tar.gz
   sha256: 9cc99773ab9576fab5451d5abe4f39838ae8f4e06496cc33ec12107299aa542d
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.32/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: 7c1ffd518985304c790564e66bdd63337e1deb2fb26877aba3b03c7b72a3d345
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.32/kubescape-ubuntu-latest.tar.gz
+  sha256: 761a4a7010ae336242f569b9986df6dc3dedf141a766e5fbbe941c6208826c69
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/secops/kubescape/ops2deb.yml
+++ b/blueprints/secops/kubescape/ops2deb.yml
@@ -23,6 +23,7 @@ matrix:
     - 3.0.27
     - 3.0.28
     - 3.0.31
+    - 3.0.32
 homepage: https://kubescape.io
 summary: kubernetes security platform for your IDE, CI/CD pipelines, and clusters
 description: |-

--- a/blueprints/terminal/chezmoi/ops2deb.lock.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.35.1/chezmoi_2.35.1_linux_amd64.tar.gz
-  sha256: fabfd7e2c3d47765a9654c8af5f74e3aae0fa8986bc009d035ff56183c1100a8
-  timestamp: 2023-07-18 21:13:52+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.35.1/chezmoi_2.35.1_linux_arm.tar.gz
-  sha256: e5353cccc35cd4078b96d82eea8fa7704eb97f8c7ba4538188f5af7b937edc1c
-  timestamp: 2023-07-18 21:13:52+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.35.1/chezmoi_2.35.1_linux_arm64.tar.gz
-  sha256: eb92b85a2e5aa20858d5a8c6dc1295745f97d4de502da7332bc078fd4ab4e4f0
-  timestamp: 2023-07-18 21:13:52+00:00
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.35.2/chezmoi_2.35.2_linux_amd64.tar.gz
   sha256: ca8c500767dc0017caa04c530d2848321c86b2fe00e43b57d11a30fca9647316
   timestamp: 2023-07-19 12:34:22+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.60.1/chezmoi_2.60.1_linux_arm64.tar.gz
   sha256: ea71988b836f18397f8e5079b1890f1f470af4bb3a1a695e9126f0f82335fad6
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.61.0/chezmoi_2.61.0_linux_amd64.tar.gz
+  sha256: d6513141e656c10a00adc0debb3353f88502f508c53e3c37f815b42506baff28
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.61.0/chezmoi_2.61.0_linux_arm.tar.gz
+  sha256: 14f6ebfbe958bf37c2c14e70908093267bd1b619963726c4b8d8bbd47b53e834
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.61.0/chezmoi_2.61.0_linux_arm64.tar.gz
+  sha256: 4f49fd10159de7524189d16aa7f4bec0c1222f14d0465e3bc81b2d63e37b2b2e
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/terminal/chezmoi/ops2deb.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 2.35.1
     - 2.35.2
     - 2.36.0
     - 2.36.1
@@ -55,6 +54,7 @@ matrix:
     - 2.59.0
     - 2.59.1
     - 2.60.1
+    - 2.61.0
 homepage: https://github.com/twpayne/chezmoi
 summary: manage your dotfiles across multiple diverse machines
 description: |-

--- a/blueprints/terminal/nushell/ops2deb.lock.yml
+++ b/blueprints/terminal/nushell/ops2deb.lock.yml
@@ -286,3 +286,9 @@
 - url: https://github.com/nushell/nushell/releases/download/0.102.0/nu-0.102.0-x86_64-unknown-linux-gnu.tar.gz
   sha256: 8facc8575dc5cc1406d5f00625faf40556da986f8932e90c8f891241df7275a3
   timestamp: 2025-02-05 06:08:49+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.103.0/nu-0.103.0-aarch64-unknown-linux-gnu.tar.gz
+  sha256: a920256e12bd59d30f6b4ec58fbc394b02928d750eb07ca3c163be77084f3407
+  timestamp: 2025-03-23 18:08:34+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.103.0/nu-0.103.0-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 8d765a31611b3ae8fb63582a53b39111c11e2a3a6be3c76afb2c0a4bb38eebee
+  timestamp: 2025-03-23 18:08:34+00:00

--- a/blueprints/terminal/nushell/ops2deb.yml
+++ b/blueprints/terminal/nushell/ops2deb.yml
@@ -114,6 +114,7 @@
       - 0.100.0
       - 0.101.0
       - 0.102.0
+      - 0.103.0
   homepage: https://www.nushell.sh/
   summary: new type of shell written in rust
   description: |-

--- a/blueprints/terminal/zellij/ops2deb.lock.yml
+++ b/blueprints/terminal/zellij/ops2deb.lock.yml
@@ -112,3 +112,9 @@
 - url: https://github.com/zellij-org/zellij/releases/download/v0.42.0/zellij-x86_64-unknown-linux-musl.tar.gz
   sha256: eb0c21b1dd3134c267f9990b59e747ad10ee46800b97f9103a4d80de89482668
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.42.1/zellij-aarch64-unknown-linux-musl.tar.gz
+  sha256: 297d7cdf45485f52be39605f6ec154789a012e1fa52002f62d0b224f9b8d7878
+  timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.42.1/zellij-x86_64-unknown-linux-musl.tar.gz
+  sha256: 0ac71035d6ab6c68c709cfbd638dbe00ba9215dfde59ee97fe322beb47bd10ff
+  timestamp: 2025-03-23 18:08:35+00:00

--- a/blueprints/terminal/zellij/ops2deb.yml
+++ b/blueprints/terminal/zellij/ops2deb.yml
@@ -23,6 +23,7 @@ matrix:
     - 0.41.1
     - 0.41.2
     - 0.42.0
+    - 0.42.1
 homepage: https://zellij.dev
 summary: terminal workspace with batteries included
 description: |-


### PR DESCRIPTION
Add nushell v0.103.0
Add chezmoi v2.61.0
Remove chezmoi v2.35.1
Add zellij v0.42.1
Add scala-cli v1.7.1
Remove scala-cli v0.1.2
Add glab v1.54.0
Add pre-commit v4.2.0
Add github-cli v2.69.0
Remove github-cli v2.31.0
Add oasdiff v2.1.2
Add uv v0.6.9
Add rpk v24.3.8
Add skaffold v2.14.2
Add gitlab-release-cli v0.23.0
Add mirrord v3.136.0
Remove mirrord v3.103.0
Add krew v0.4.5
Add natscli v0.2.0
Add terragrunt v0.76.6
Remove terragrunt v0.68.2
Add jfrog-cli v2.74.1
Add argocd v2.14.7
Add clusterctl v1.9.6
Add oc v4.18.6
Add operator-sdk v1.39.2
Add ops2deb v2.6.0
Add kubelogin v0.2.7
Add kubectl-oidc-login v1.32.3
Add carvel-kapp v0.64.1
Add kubescape v3.0.32
Add dive v0.13.0
Add signal-desktop v7.47.0
Remove signal-desktop v7.5.0
Add balena-etcher v2.1.0
Add teams-for-linux v1.13.1