### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.5.1_amd64.deb
-  sha256: 69f291f8fd983e4bf838c22bf0bcd67803195abd33689d51d01403f3b810b929
-  timestamp: 2024-04-19 00:21:29+00:00
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.6.0_amd64.deb
   sha256: b06396b056533bd5500e40aa86c3a45b9698fac8747cb1fb90f3defdb0331af8
   timestamp: 2024-04-25 15:06:04+00:00
@@ -148,3 +145,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.47.0_amd64.deb
   sha256: a29913cb4575b56ae2ad89e5099302f29466ac32f82da508a4d0147a44ca6ead
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.48.0_amd64.deb
+  sha256: d7ca49ef681153954edc17defbde1066cf51af0c07a9e04d98def3ced768c624
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -1,7 +1,6 @@
 name: signal-desktop
 matrix:
   versions:
-    - 7.5.1
     - 7.6.0
     - 7.7.0
     - 7.8.0
@@ -51,12 +50,14 @@ matrix:
     - 7.46.0
     - 7.46.1
     - 7.47.0
+    - 7.48.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-
   Links with Signal on Android or iOS and lets you message from your Windows,
   macOS, and Linux computers.
-fetch: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_{{version}}_amd64.deb
+fetch: 
+  https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_{{version}}_amd64.deb
 install:
   - data:/
 script:

--- a/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
@@ -112,3 +112,6 @@
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.13.1/teams-for-linux_1.13.1_amd64.deb
   sha256: 0dd58015d1973ca6bc99fe6828b318108d12db76cbe3ad7108ec984446c8483d
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.14.2/teams-for-linux_1.14.2_amd64.deb
+  sha256: 7716b55ae2e70c42136af76ca1cb009b6d8edff9f3436dd426ea0054fedc86e1
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/desktop/teams-for-linux/ops2deb.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.yml
@@ -39,12 +39,14 @@ matrix:
     - 1.12.7
     - 1.13.0
     - 1.13.1
+    - 1.14.2
 homepage: https://github.com/IsmaelMartinez/teams-for-linux/
 summary: unofficial Microsoft Teams for Linux client
 description: |-
   Unofficial Microsoft Teams client for Linux using Electron. It uses the Web App
   and wraps it as a standalone application using Electron.
-fetch: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v{{version}}/teams-for-linux_{{version}}_amd64.deb
+fetch: 
+  https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v{{version}}/teams-for-linux_{{version}}_amd64.deb
 install:
   - data:/
 script:

--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -247,3 +247,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.54.0/downloads/glab_1.54.0_linux_arm64.deb
   sha256: 0c1fdb4f57d1e3b2e5e1676b6e2ab99a1a4bb3c01ea58af2e51d5d4845f7b5ed
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.55.0/downloads/glab_1.55.0_linux_amd64.deb
+  sha256: ae3feac2aa1034a585e4a24787970dacd30f07906cdc75af8911c32d158b44e8
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.55.0/downloads/glab_1.55.0_linux_arm64.deb
+  sha256: 36c7368617111148dd34e5cd86ffa11665f76101e4ba396db943f8d17ceaa989
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -44,7 +44,8 @@
     issues, merge requests, look at running pipelines directly from your CLI, among
     other features.
   fetch:
-    url: https://gitlab.com/gitlab-org/cli/-/releases/v{{version}}/downloads/glab_{{version}}_Linux_{{target}}.deb
+    url: 
+      https://gitlab.com/gitlab-org/cli/-/releases/v{{version}}/downloads/glab_{{version}}_Linux_{{target}}.deb
     targets:
       amd64: x86_64
   install:
@@ -64,6 +65,7 @@
       - 1.52.0
       - 1.53.0
       - 1.54.0
+      - 1.55.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-
@@ -71,6 +73,7 @@
     git and your code without switching between browser windows or tabs. Work with
     issues, merge requests, look at running pipelines directly from your CLI, among
     other features.
-  fetch: https://gitlab.com/gitlab-org/cli/-/releases/v{{version}}/downloads/glab_{{version}}_linux_{{arch}}.deb
+  fetch: 
+    https://gitlab.com/gitlab-org/cli/-/releases/v{{version}}/downloads/glab_{{version}}_linux_{{arch}}.deb
   install:
     - data/usr/bin/glab:/usr/bin/

--- a/blueprints/dev/k6/ops2deb.lock.yml
+++ b/blueprints/dev/k6/ops2deb.lock.yml
@@ -40,3 +40,9 @@
 - url: https://github.com/grafana/k6/releases/download/v0.57.0/k6-v0.57.0-linux-arm64.tar.gz
   sha256: 223525edaadf23f1483ec4b3f38b81c4431dce38df5a843a89b2b87950faf56d
   timestamp: 2025-02-13 15:06:54+00:00
+- url: https://github.com/grafana/k6/releases/download/v0.58.0/k6-v0.58.0-linux-amd64.tar.gz
+  sha256: e487d8775a306ed1f7232855a37dee4e42b7a53b5a991009a267305c06f56dab
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/grafana/k6/releases/download/v0.58.0/k6-v0.58.0-linux-arm64.tar.gz
+  sha256: 0598bbdd9f9e67a8eae49520494137b235c3be2cbf3b3721db626ecb395944ee
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/dev/k6/ops2deb.yml
+++ b/blueprints/dev/k6/ops2deb.yml
@@ -11,12 +11,14 @@ matrix:
     - 0.55.2
     - 0.56.0
     - 0.57.0
+    - 0.58.0
 homepage: https://k6.io
 summary: modern load testing tool, using Go and JavaScript
 description: |-
   k6 is a modern load-testing tool, built on our years of experience in the
   performance and testing industries. It's built to be powerful, extensible, and
   full-featured. The key design goal is to provide the best developer experience.
-fetch: https://github.com/grafana/k6/releases/download/v{{version}}/k6-v{{version}}-linux-{{target}}.tar.gz
+fetch: 
+  https://github.com/grafana/k6/releases/download/v{{version}}/k6-v{{version}}-linux-{{target}}.tar.gz
 install:
   - k6-v{{version}}-linux-{{target}}/k6:/usr/bin/k6

--- a/blueprints/dev/kubebuilder/ops2deb.lock.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.lock.yml
@@ -184,3 +184,9 @@
 - url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.1/kubebuilder_linux_arm64
   sha256: de94401324b3c080e1f14290f68ddd06453baf20460ed0f444e86b9370a11608
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.2/kubebuilder_linux_amd64
+  sha256: 7a691c7c286b4c1a3f57b2ca9c85e3856662f850a4fa4cc6feb1aaae9273cf1c
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.2/kubebuilder_linux_arm64
+  sha256: 77ae785ea75d76ad191caa6bf69001faade8019ed771a19a0f174def3baf29ed
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/dev/kubebuilder/ops2deb.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.yml
@@ -35,6 +35,7 @@ matrix:
     - 4.4.0
     - 4.5.0
     - 4.5.1
+    - 4.5.2
 homepage: https://book.kubebuilder.io
 summary: SDK for building Kubernetes APIs using CRDs
 description: |-
@@ -51,6 +52,7 @@ description: |-
   powerful libraries and tools to simplify building and publishing Kubernetes
   APIs from scratch. It provides a plugin architecture allowing users to take
   advantage of optional helpers and features.
-fetch: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v{{version}}/kubebuilder_linux_{{arch}}
+fetch: 
+  https://github.com/kubernetes-sigs/kubebuilder/releases/download/v{{version}}/kubebuilder_linux_{{arch}}
 install:
   - kubebuilder_linux_{{arch}}:/usr/bin/kubebuilder

--- a/blueprints/dev/pdm/ops2deb.lock.yml
+++ b/blueprints/dev/pdm/ops2deb.lock.yml
@@ -127,3 +127,6 @@
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.22.4.tar.gz
   sha256: 01f372650b41897f6cc4bccdc7c22bcd51c732fcedc6bb33e47f93e30ab600d1
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.23.0.tar.gz
+  sha256: e67f6463e836eed9e85dfc55068c178c8ad7a6a8cea512622b437fd5f52c7ce0
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/dev/pdm/ops2deb.yml
+++ b/blueprints/dev/pdm/ops2deb.yml
@@ -44,6 +44,7 @@ matrix:
     - 2.22.2
     - 2.22.3
     - 2.22.4
+    - 2.23.0
 homepage: https://pdm.fming.dev/
 summary: modern Python package and dependency manager supporting the latest PEP standards
 description: |-

--- a/blueprints/dev/poetry/ops2deb.lock.yml
+++ b/blueprints/dev/poetry/ops2deb.lock.yml
@@ -58,9 +58,12 @@
 - url: https://github.com/python-poetry/poetry/archive/refs/tags/2.0.0.tar.gz
   sha256: ba4a93bd8e9c3668fab4e42215ddd85cbcddb9c02bdd9baf6291feef983dd32c
   timestamp: 2025-01-05 12:09:23+00:00
-- url: https://github.com/python-poetry/poetry/archive/refs/tags/2.0.1.tar.gz
-  sha256: 9e9f7a7b868338e40134f2e705bc5162fc0779043083b926e434963cf39e806a
-  timestamp: 2025-02-17 20:01:56+00:00
 - url: https://github.com/python-poetry/poetry/archive/refs/tags/2.1.1.tar.gz
   sha256: 1e33bc9c202d08ebde998bcb151f5f18ef56e70be0b10d126e831b78e337c046
   timestamp: 2025-02-17 19:08:06+00:00
+- url: https://github.com/python-poetry/poetry/archive/refs/tags/2.0.1.tar.gz
+  sha256: 9e9f7a7b868338e40134f2e705bc5162fc0779043083b926e434963cf39e806a
+  timestamp: 2025-02-17 20:01:56+00:00
+- url: https://github.com/python-poetry/poetry/archive/refs/tags/2.1.2.tar.gz
+  sha256: e674047e4730f0898789c8a1274e99f346edea130f4bd4ecf8189e40786723df
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/dev/poetry/ops2deb.yml
+++ b/blueprints/dev/poetry/ops2deb.yml
@@ -11,7 +11,8 @@
   description: |-
     Poetry helps you declare, manage and install dependencies of Python projects,
     ensuring you have the right stack everywhere.
-  fetch: https://github.com/python-poetry/poetry/releases/download/{{version}}/poetry-{{version}}-linux.tar.gz
+  fetch: 
+    https://github.com/python-poetry/poetry/releases/download/{{version}}/poetry-{{version}}-linux.tar.gz
   install:
     - content: |-
         #!/usr/bin/env python3
@@ -114,6 +115,7 @@
     versions:
       - 2.0.1
       - 2.1.1
+      - 2.1.2
   homepage: https://python-poetry.org
   summary: tool for dependency management and packaging in Python
   description: |-

--- a/blueprints/dev/typos-cli/ops2deb.lock.yml
+++ b/blueprints/dev/typos-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/crate-ci/typos/releases/download/v1.20.5/typos-v1.20.5-x86_64-unknown-linux-musl.tar.gz
-  sha256: dd638fcde5e955bb801b9be28e912977dba6c857603ca14c212c71fc6cd871b0
-  timestamp: 2024-04-09 03:06:35+00:00
 - url: https://github.com/crate-ci/typos/releases/download/v1.20.6/typos-v1.20.6-x86_64-unknown-linux-musl.tar.gz
   sha256: bceb5e6a9bde42e8147809bb894835aad65563fc90ac8f0c512ec750b5fb0ed7
   timestamp: 2024-04-09 18:06:15+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/crate-ci/typos/releases/download/v1.30.2/typos-v1.30.2-x86_64-unknown-linux-musl.tar.gz
   sha256: 0bb41546e8a91cb6c4a5cf80d640f7be8885717d96ba9463445a1fe258758523
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/crate-ci/typos/releases/download/v1.31.1/typos-v1.31.1-x86_64-unknown-linux-musl.tar.gz
+  sha256: f683c2abeaff70379df7176110100e18150ecd17a4b9785c32908aca11929993
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/dev/typos-cli/ops2deb.yml
+++ b/blueprints/dev/typos-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: typos-cli
 matrix:
   versions:
-    - 1.20.5
     - 1.20.6
     - 1.20.7
     - 1.20.8
@@ -51,6 +50,7 @@ matrix:
     - 1.29.7
     - 1.29.9
     - 1.30.2
+    - 1.31.1
 homepage: https://github.com/crate-ci/typos/
 summary: source code spell checker
 description: |-
@@ -58,6 +58,7 @@ description: |-
 
   - Fast enough to run on monorepos
   - Low false positives so you can run on PRs
-fetch: https://github.com/crate-ci/typos/releases/download/v{{version}}/typos-v{{version}}-x86_64-unknown-linux-musl.tar.gz
+fetch: 
+  https://github.com/crate-ci/typos/releases/download/v{{version}}/typos-v{{version}}-x86_64-unknown-linux-musl.tar.gz
 install:
   - typos:{{src}}/usr/bin/

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -466,3 +466,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.6.9/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 001b87a0c2ea642a3c75a98c6af3e8528aa473d560e653cf213efcc9aaa4a028
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.11/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: de20c247ef6a6bc0948e611ace3f3f321c098d7bf75b737f169c1db06b4f4d69
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.11/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: 5abacc141dabb6071fcc3a19a301874083c6cc4a36d6eb6b0654a276efbfd33b
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.11/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: c19b3be7ac26f8b211f7a5f07f01a77fd4d2b6205ff257790770a585f7f5bda4
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -73,7 +73,8 @@
     installs, Git dependencies, direct URL dependencies, local dependencies,
     constraints, source distributions, HTML and JSON indexes, and more.
   fetch:
-    url: https://github.com/astral-sh/uv/releases/download/{{version}}/uv-{{target|rust_target}}.tar.gz
+    url: 
+      https://github.com/astral-sh/uv/releases/download/{{version}}/uv-{{target|rust_target}}.tar.gz
     targets:
       armhf: armv7-unknown-linux-gnueabihf
       arm64: aarch64-unknown-linux-musl
@@ -89,6 +90,7 @@
     versions:
       - 0.6.8
       - 0.6.9
+      - 0.6.11
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-
@@ -107,7 +109,8 @@
     installs, Git dependencies, direct URL dependencies, local dependencies,
     constraints, source distributions, HTML and JSON indexes, and more.
   fetch:
-    url: https://github.com/astral-sh/uv/releases/download/{{version}}/uv-{{target|rust_target}}.tar.gz
+    url: 
+      https://github.com/astral-sh/uv/releases/download/{{version}}/uv-{{target|rust_target}}.tar.gz
     targets:
       armhf: armv7-unknown-linux-gnueabihf
       arm64: aarch64-unknown-linux-musl

--- a/blueprints/devops/act/ops2deb.lock.yml
+++ b/blueprints/devops/act/ops2deb.lock.yml
@@ -286,3 +286,12 @@
 - url: https://github.com/nektos/act/releases/download/v0.2.75/act_Linux_x86_64.tar.gz
   sha256: 4856dd522006d702acc8c72c3265752b1ab2be2dbd5580184aba19cec91f2651
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/nektos/act/releases/download/v0.2.76/act_Linux_arm64.tar.gz
+  sha256: a715da5585d7625dd4bab08a7076373bd83363c66e2c1d0c226c9ab63c6a95b5
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/nektos/act/releases/download/v0.2.76/act_Linux_armv7.tar.gz
+  sha256: 15adf3c7c1353fbd4bf11f7b66f133160557e9875a85fe33238609be43f48d9c
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/nektos/act/releases/download/v0.2.76/act_Linux_x86_64.tar.gz
+  sha256: d4720e05e73ce634239fc0e7fa6b552f9ac79b4e6c878a8756bbfacce3c56720
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/act/ops2deb.yml
+++ b/blueprints/devops/act/ops2deb.yml
@@ -19,7 +19,8 @@
     - Local Task Runner: With act, you can use the GitHub Actions defined in your
     .github/workflows/ to replace your Makefile!
   fetch:
-    url: https://github.com/nektos/act/releases/download/v{{version}}/act_Linux_{{target}}.tar.gz
+    url: 
+      https://github.com/nektos/act/releases/download/v{{version}}/act_Linux_{{target}}.tar.gz
     targets:
       amd64: x86_64
       armhf: armv7
@@ -64,6 +65,7 @@
       - 0.2.73
       - 0.2.74
       - 0.2.75
+      - 0.2.76
   homepage: https://github.com/nektos/act/
   summary: run your GitHub Actions locally
   description: |-
@@ -77,7 +79,8 @@
     - Local Task Runner: With act, you can use the GitHub Actions defined in your
     .github/workflows/ to replace your Makefile!
   fetch:
-    url: https://github.com/nektos/act/releases/download/v{{version}}/act_Linux_{{target}}.tar.gz
+    url: 
+      https://github.com/nektos/act/releases/download/v{{version}}/act_Linux_{{target}}.tar.gz
     targets:
       amd64: x86_64
       armhf: armv7

--- a/blueprints/devops/argocd/ops2deb.lock.yml
+++ b/blueprints/devops/argocd/ops2deb.lock.yml
@@ -178,3 +178,9 @@
 - url: https://github.com/argoproj/argo-cd/releases/download/v2.14.7/argocd-linux-arm64
   sha256: 3cfcc4be72b9fc3e975861cd6442c31a7b8181719aea1d331954dc2d95f5c013
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v2.14.8/argocd-linux-amd64
+  sha256: 76b3c1afe1138d362942961fab5b2a1dc005c8dd4c5b6cd39d45a8c33059be1f
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v2.14.8/argocd-linux-arm64
+  sha256: 2283367f712f7a0ce06d5a337c878e2074820f2729c6cd56cc2ed2308411c97c
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/argocd/ops2deb.yml
+++ b/blueprints/devops/argocd/ops2deb.yml
@@ -34,9 +34,11 @@ matrix:
     - 2.14.2
     - 2.14.5
     - 2.14.7
+    - 2.14.8
 homepage: https://github.com/argoproj/argo-cd
 summary: continuous delivery tool for Kubernetes
 description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
-fetch: https://github.com/argoproj/argo-cd/releases/download/v{{version}}/argocd-linux-{{arch}}
+fetch: 
+  https://github.com/argoproj/argo-cd/releases/download/v{{version}}/argocd-linux-{{arch}}
 install:
   - argocd-linux-{{arch}}:/usr/bin/argocd

--- a/blueprints/devops/carvel-ytt/ops2deb.lock.yml
+++ b/blueprints/devops/carvel-ytt/ops2deb.lock.yml
@@ -160,3 +160,9 @@
 - url: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.51.1/ytt-linux-arm64
   sha256: 55849cab41cf7780b0d26da416395cf77576a434a4bcf883b0e2a29944325e7c
   timestamp: 2024-12-11 12:11:16+00:00
+- url: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.51.2/ytt-linux-amd64
+  sha256: 61ad01f1df9cc8344c786e93acb1f5707ded9e4b52e4ec55a0f6637f2af53bae
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.51.2/ytt-linux-arm64
+  sha256: ae0bdc3aca64e71276f59679ea9253be5f88fc6880937ae1de3dd42a00492a8c
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/carvel-ytt/ops2deb.yml
+++ b/blueprints/devops/carvel-ytt/ops2deb.yml
@@ -31,6 +31,7 @@ matrix:
     - 0.50.0
     - 0.51.0
     - 0.51.1
+    - 0.51.2
 homepage: https://carvel.dev/ytt/
 summary: YAML templating tool that works on YAML structure instead of text
 description: |-
@@ -38,6 +39,7 @@ description: |-
   Template and patch as needed to easily make your configuration reusable and
   extensible.
   Works with your own and third-party YAML configuration.
-fetch: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v{{version}}/ytt-linux-{{goarch}}
+fetch: 
+  https://github.com/vmware-tanzu/carvel-ytt/releases/download/v{{version}}/ytt-linux-{{goarch}}
 install:
   - ytt-linux-{{goarch}}:/usr/bin/ytt

--- a/blueprints/devops/goreleaser/ops2deb.lock.yml
+++ b/blueprints/devops/goreleaser/ops2deb.lock.yml
@@ -118,3 +118,9 @@
 - url: https://github.com/goreleaser/goreleaser/releases/download/v2.8.1/goreleaser_Linux_x86_64.tar.gz
   sha256: 76a456f7e9b3d8644638d804d0fcda2f8557858af9b116d1a30b1aaa1d6a1ebc
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/goreleaser/goreleaser/releases/download/v2.8.2/goreleaser_Linux_arm64.tar.gz
+  sha256: ebf55249a59a4073b89379316953b3ce2e7505e5980f9c22e23399aa4679be69
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/goreleaser/goreleaser/releases/download/v2.8.2/goreleaser_Linux_x86_64.tar.gz
+  sha256: 847e2105d50da9133e567cf5450cd437ae29181cabf13ad42683151ba0f5b587
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/goreleaser/ops2deb.yml
+++ b/blueprints/devops/goreleaser/ops2deb.yml
@@ -24,6 +24,7 @@ matrix:
     - 2.7.0
     - 2.8.0
     - 2.8.1
+    - 2.8.2
 homepage: https://goreleaser.com
 summary: release Go projects as fast and easily as possible
 description: |-
@@ -31,7 +32,8 @@ description: |-
   Go projects to multiple platforms, ensuring a consistent and reliable
   deployment experience.
 fetch:
-  url: https://github.com/goreleaser/goreleaser/releases/download/v{{version}}/goreleaser_Linux_{{target}}.tar.gz
+  url: 
+    https://github.com/goreleaser/goreleaser/releases/download/v{{version}}/goreleaser_Linux_{{target}}.tar.gz
   targets:
     amd64: x86_64
     arm64: arm64

--- a/blueprints/devops/hubble/ops2deb.lock.yml
+++ b/blueprints/devops/hubble/ops2deb.lock.yml
@@ -25,3 +25,6 @@
 - url: https://github.com/cilium/hubble/releases/download/v1.17.1/hubble-linux-amd64.tar.gz
   sha256: 1fa643076206df77be36fab8eaf900bd8bf9cf2dd479e13bdb2a5af98335e530
   timestamp: 2025-02-12 18:08:26+00:00
+- url: https://github.com/cilium/hubble/releases/download/v1.17.2/hubble-linux-amd64.tar.gz
+  sha256: b048e73ee39ce1a46730460362afb14e08cf9edf2c541ab9dd8f2aadcb350ddc
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/hubble/ops2deb.yml
+++ b/blueprints/devops/hubble/ops2deb.yml
@@ -12,11 +12,13 @@ matrix:
     - 1.16.6
     - 1.17.0
     - 1.17.1
+    - 1.17.2
 homepage: https://github.com/cilium/hubble
 summary: Network, Service & Security Observability for Kubernetes using eBPF
 description: |-
   Fully distributed networking and security observability platform for cloud
   native workloads. It is built on top of Cilium and eBPF.
-fetch: https://github.com/cilium/hubble/releases/download/v{{version}}/hubble-linux-{{goarch}}.tar.gz
+fetch: 
+  https://github.com/cilium/hubble/releases/download/v{{version}}/hubble-linux-{{goarch}}.tar.gz
 install:
   - hubble:/usr/bin/hubble

--- a/blueprints/devops/iamlive/ops2deb.lock.yml
+++ b/blueprints/devops/iamlive/ops2deb.lock.yml
@@ -190,3 +190,9 @@
 - url: https://github.com/iann0036/iamlive/releases/download/v1.1.22/iamlive-v1.1.22-linux-arm64.tar.gz
   sha256: 7a14c6e594b2819e8f9b7ac0a7e14caeecd45252da227aa1e88fddde48dbf987
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/iann0036/iamlive/releases/download/v1.1.23/iamlive-v1.1.23-linux-amd64.tar.gz
+  sha256: bb0ed560705a8f5377e696dede9d6a0cbbbbbb62b8ff27a56ca1481fa48324f6
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/iann0036/iamlive/releases/download/v1.1.23/iamlive-v1.1.23-linux-arm64.tar.gz
+  sha256: 0acb20f770c4c7c4dc2c30d910e161c1d7a0c1e7501b9c295ad54f5ce84bc161
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/iamlive/ops2deb.yml
+++ b/blueprints/devops/iamlive/ops2deb.yml
@@ -36,11 +36,13 @@ matrix:
     - 1.1.18
     - 1.1.19
     - 1.1.22
+    - 1.1.23
 homepage: https://github.com/iann0036/iamlive
 summary: generate policies from AWS calls
 description: |-
   Generate an IAM policy from AWS calls using client-side monitoring (CSM) or
   embedded proxy policy.
-fetch: https://github.com/iann0036/iamlive/releases/download/v{{version}}/iamlive-v{{version}}-linux-{{goarch}}.tar.gz
+fetch: 
+  https://github.com/iann0036/iamlive/releases/download/v{{version}}/iamlive-v{{version}}-linux-{{goarch}}.tar.gz
 install:
   - iamlive:/usr/bin/iamlive

--- a/blueprints/devops/istioctl/ops2deb.lock.yml
+++ b/blueprints/devops/istioctl/ops2deb.lock.yml
@@ -439,3 +439,12 @@
 - url: https://github.com/istio/istio/releases/download/1.25.0/istio-1.25.0-linux-armv7.tar.gz
   sha256: ab75b292f7d846a37a9b7ecb01e2f2eb378d6c39c43250f535ccd4b40aabadc3
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/istio/istio/releases/download/1.25.1/istio-1.25.1-linux-amd64.tar.gz
+  sha256: dcdd18d94e398b49221c33d723a2d0bf2d022e795655dd7ce22b8b98a8982a8c
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/istio/istio/releases/download/1.25.1/istio-1.25.1-linux-arm64.tar.gz
+  sha256: aec291d524239822779abc1ec53f141740d693b5a125599e8d6a92c0d443559f
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/istio/istio/releases/download/1.25.1/istio-1.25.1-linux-armv7.tar.gz
+  sha256: a2b066150c4442314ea05541cc4407c77b4b33d218cf6043cdb6a716796bfa8e
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/istioctl/ops2deb.yml
+++ b/blueprints/devops/istioctl/ops2deb.yml
@@ -11,7 +11,8 @@
   summary: command-line interface for Istio
   description: Istio is an open platform to connect, manage, and secure microservices.
   fetch:
-    url: https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-{{target}}.tar.gz
+    url: 
+      https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-{{target}}.tar.gz
     targets:
       armhf: armv7
   script:
@@ -24,7 +25,8 @@
   homepage: https://istio.io
   summary: command-line interface for Istio
   description: Istio is an open platform to connect, manage, and secure microservices.
-  fetch: https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-amd64.tar.gz
+  fetch: 
+    https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-amd64.tar.gz
   script:
     - install -d {{src}}/opt/istio
     - mv * {{src}}/opt/istio/
@@ -44,7 +46,8 @@
   summary: command-line interface for Istio
   description: Istio is an open platform to connect, manage, and secure microservices.
   fetch:
-    url: https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-{{target}}.tar.gz
+    url: 
+      https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-{{target}}.tar.gz
     targets:
       armhf: armv7
   script:
@@ -64,7 +67,8 @@
   summary: command-line interface for Istio
   description: Istio is an open platform to connect, manage, and secure microservices.
   fetch:
-    url: https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-{{target}}.tar.gz
+    url: 
+      https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-{{target}}.tar.gz
     targets:
       armhf: armv7
   install:
@@ -122,11 +126,13 @@
       - 1.24.2
       - 1.24.3
       - 1.25.0
+      - 1.25.1
   homepage: https://istio.io
   summary: command-line interface for Istio
   description: Istio is an open platform to connect, manage, and secure microservices.
   fetch:
-    url: https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-{{target}}.tar.gz
+    url: 
+      https://github.com/istio/istio/releases/download/{{version}}/istio-{{version}}-linux-{{target}}.tar.gz
     targets:
       armhf: armv7
   install:

--- a/blueprints/devops/kubeseal/ops2deb.lock.yml
+++ b/blueprints/devops/kubeseal/ops2deb.lock.yml
@@ -361,3 +361,12 @@
 - url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.28.0/kubeseal-0.28.0-linux-arm64.tar.gz
   sha256: 9278624a6f3d2094eb2e0a6ec06b89318afe0f9bbea52dc0fe614243e225cd6c
   timestamp: 2025-01-28 09:07:22+00:00
+- url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.29.0/kubeseal-0.29.0-linux-amd64.tar.gz
+  sha256: d7f146ac7003787023ae81324b9b980e2182b7f217ddb7f2dd591683fb322bd3
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.29.0/kubeseal-0.29.0-linux-arm.tar.gz
+  sha256: 678b573dda5d34b39292016e8f8c1dd5dc588064a31f1145ccb7d8db6066dfaa
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.29.0/kubeseal-0.29.0-linux-arm64.tar.gz
+  sha256: 7a89f4f79d173c64a305f3f634f4cb2e863541c2a19bf0e19f048d7a1f4a33ae
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/kubeseal/ops2deb.yml
+++ b/blueprints/devops/kubeseal/ops2deb.yml
@@ -6,7 +6,8 @@
   description: |-
     Encrypt your Secret into a SealedSecret, which is safe to store - even to a
     public repository.
-  fetch: https://github.com/bitnami-labs/sealed-secrets/releases/download/v{{version}}/kubeseal-linux-amd64
+  fetch: 
+    https://github.com/bitnami-labs/sealed-secrets/releases/download/v{{version}}/kubeseal-linux-amd64
   script:
     - mv kubeseal-linux-amd64 {{src}}/usr/bin/kubeseal
 
@@ -24,7 +25,8 @@
   description: |-
     Encrypt your Secret into a SealedSecret, which is safe to store - even to a
     public repository.
-  fetch: https://github.com/bitnami-labs/sealed-secrets/releases/download/v{{version}}/kubeseal-{{version}}-linux-{{goarch}}.tar.gz
+  fetch: 
+    https://github.com/bitnami-labs/sealed-secrets/releases/download/v{{version}}/kubeseal-{{version}}-linux-{{goarch}}.tar.gz
   script:
     - mv kubeseal {{src}}/usr/bin/kubeseal
 
@@ -73,11 +75,13 @@
       - 0.27.2
       - 0.27.3
       - 0.28.0
+      - 0.29.0
   homepage: https://github.com/bitnami-labs/sealed-secrets
   summary: secret management solution for Kubernetes
   description: |-
     Encrypt your Secret into a SealedSecret, which is safe to store - even to a
     public repository.
-  fetch: https://github.com/bitnami-labs/sealed-secrets/releases/download/v{{version}}/kubeseal-{{version}}-linux-{{goarch}}.tar.gz
+  fetch: 
+    https://github.com/bitnami-labs/sealed-secrets/releases/download/v{{version}}/kubeseal-{{version}}-linux-{{goarch}}.tar.gz
   install:
     - kubeseal:/usr/bin/

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.104.0/mirrord_linux_aarch64.zip
-  sha256: 423f4851c4be9972cb1a6f912b4c55c73991505172f66ee7ed84013a871d311a
-  timestamp: 2024-06-06 18:06:37+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.104.0/mirrord_linux_x86_64.zip
-  sha256: fef27456edbdd27055bc5b2e972f5ece8324d905d99e2a567c224a7651985e11
-  timestamp: 2024-06-06 18:06:37+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.105.0/mirrord_linux_aarch64.zip
   sha256: 0feedf37d917edcdd009b7842477e79def36473f37d8afeba89cda4666019f68
   timestamp: 2024-06-12 12:08:57+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.136.0/mirrord_linux_x86_64.zip
   sha256: 962ee068b761907b68cb9ecd75a8e05b791576cad9467b61e2bdb7622edb5ab3
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.137.0/mirrord_linux_aarch64.zip
+  sha256: adc37436f7e7050cb50f3c2e468af7212a235883a5aab242e620d1300fa350ba
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.137.0/mirrord_linux_x86_64.zip
+  sha256: c8d4c92dd69d99941425d9250b1f6ecc35823ba4a445ab030237c301b23f022e
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.104.0
     - 3.105.0
     - 3.106.0
     - 3.107.0
@@ -54,6 +53,7 @@ matrix:
     - 3.133.1
     - 3.134.2
     - 3.136.0
+    - 3.137.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-
@@ -61,7 +61,8 @@ description: |-
   access to other microservices, databases, queues, and managed services, all
   without leaving the local setup you know and love.
 fetch:
-  url: https://github.com/metalbear-co/mirrord/releases/download/{{version}}/mirrord_linux_{{target}}.zip
+  url: 
+    https://github.com/metalbear-co/mirrord/releases/download/{{version}}/mirrord_linux_{{target}}.zip
   targets:
     amd64: x86_64
     arm64: aarch64

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -106,3 +106,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.6/openshift-client-linux.tar.gz
   sha256: 3c47ee67b4fc3c423cc15ca5699d61fd1619dbafc92f564492ddb860b24c541c
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.7/openshift-client-linux-arm64.tar.gz
+  sha256: 4fe7ed3e73c9a27e8d37799befdfdb896bccaea78f87cf9def1d68f9573084ff
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.7/openshift-client-linux.tar.gz
+  sha256: 49e539258eb402b2b739876dbf64c8b60729d9a06df5396e8355df0fffda7257
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -21,6 +21,7 @@ matrix:
     - 4.18.4
     - 4.18.5
     - 4.18.6
+    - 4.18.7
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-
@@ -30,7 +31,8 @@ description: |-
   Container Platform operations or managing projects while restricted by
   bandwidth resources and the web console is unavailable.
 fetch:
-  url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{version}}/openshift-client-{{target}}.tar.gz
+  url: 
+    https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{version}}/openshift-client-{{target}}.tar.gz
   targets:
     amd64: linux
     arm64: linux-arm64

--- a/blueprints/devops/rancher/ops2deb.lock.yml
+++ b/blueprints/devops/rancher/ops2deb.lock.yml
@@ -82,3 +82,9 @@
 - url: https://github.com/rancher/cli/releases/download/v2.10.1/rancher-linux-arm-v2.10.1.tar.gz
   sha256: 5c63ae5e26dbe326f3c889109aaa07713d13f2b312cd97a669cc37b724223f41
   timestamp: 2025-02-12 00:27:11+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.11.0/rancher-linux-amd64-v2.11.0.tar.gz
+  sha256: 10079d832ce1b9be93840363ef92b6ca45fd2bead485e4479fdaa6a5200901ef
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.11.0/rancher-linux-arm-v2.11.0.tar.gz
+  sha256: 5c595e5018ed9c70c11e085d0dfffc280c69c0e251018e621213b3aa0bd28fcd
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/rancher/ops2deb.yml
+++ b/blueprints/devops/rancher/ops2deb.yml
@@ -5,7 +5,8 @@
   description: |-
     The Rancher Command Line Interface (CLI) is a unified tool for interacting with
     your Rancher Server.
-  fetch: https://github.com/rancher/cli/releases/download/v{{version}}/rancher-linux-amd64-v{{version}}.tar.gz
+  fetch: 
+    https://github.com/rancher/cli/releases/download/v{{version}}/rancher-linux-amd64-v{{version}}.tar.gz
   script:
     - mv rancher-v{{version}}/rancher {{src}}/usr/bin/rancher
 
@@ -22,7 +23,8 @@
   description: |-
     The Rancher Command Line Interface (CLI) is a unified tool for interacting with
     your Rancher Server.
-  fetch: https://github.com/rancher/cli/releases/download/v{{version}}/rancher-linux-{{goarch}}-v{{version}}.tar.gz
+  fetch: 
+    https://github.com/rancher/cli/releases/download/v{{version}}/rancher-linux-{{goarch}}-v{{version}}.tar.gz
   script:
     - mv rancher-v{{version}}/rancher {{src}}/usr/bin/rancher
 
@@ -44,11 +46,13 @@
       - 2.9.2
       - 2.10.0
       - 2.10.1
+      - 2.11.0
   homepage: https://github.com/rancher/cli
   summary: command-line interface for rancher
   description: |-
     The Rancher Command Line Interface (CLI) is a unified tool for interacting with
     your Rancher Server.
-  fetch: https://github.com/rancher/cli/releases/download/v{{version}}/rancher-linux-{{goarch}}-v{{version}}.tar.gz
+  fetch: 
+    https://github.com/rancher/cli/releases/download/v{{version}}/rancher-linux-{{goarch}}-v{{version}}.tar.gz
   install:
     - rancher-v{{version}}/rancher:/usr/bin/

--- a/blueprints/devops/restic/ops2deb.lock.yml
+++ b/blueprints/devops/restic/ops2deb.lock.yml
@@ -88,3 +88,12 @@
 - url: https://github.com/restic/restic/releases/download/v0.17.3/restic_0.17.3_linux_arm64.bz2
   sha256: db27b803534d301cef30577468cf61cb2e242165b8cd6d8cd6efd7001be2e557
   timestamp: 2024-11-08 21:06:10+00:00
+- url: https://github.com/restic/restic/releases/download/v0.18.0/restic_0.18.0_linux_amd64.bz2
+  sha256: 98f6dd8bf5b59058d04bfd8dab58e196cc2a680666ccee90275a3b722374438e
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/restic/restic/releases/download/v0.18.0/restic_0.18.0_linux_arm.bz2
+  sha256: a202b58cb23c7b40e2562d9b0804492f77278bd0d0bf043f5e02951f89c83eb5
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/restic/restic/releases/download/v0.18.0/restic_0.18.0_linux_arm64.bz2
+  sha256: ce18179c25dc5f2e33e3c233ba1e580f9de1a4566d2977e8d9600210363ec209
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/restic/ops2deb.yml
+++ b/blueprints/devops/restic/ops2deb.yml
@@ -15,6 +15,7 @@ matrix:
     - 0.17.1
     - 0.17.2
     - 0.17.3
+    - 0.18.0
 homepage: https://restic.net/
 summary: fast, secure, efficient backup program
 description: |-
@@ -29,6 +30,7 @@ description: |-
   - Verifiably, enabling you to make sure that your files can be restored when
   needed
   - Freely - restic is entirely free to use and completely open source
-fetch: https://github.com/restic/restic/releases/download/v{{version}}/restic_{{version}}_linux_{{goarch}}.bz2
+fetch: 
+  https://github.com/restic/restic/releases/download/v{{version}}/restic_{{version}}_linux_{{goarch}}.bz2
 install:
   - restic_{{version}}_linux_{{goarch}}:/usr/bin/restic

--- a/blueprints/devops/rpk/ops2deb.lock.yml
+++ b/blueprints/devops/rpk/ops2deb.lock.yml
@@ -286,3 +286,9 @@
 - url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.8/rpk-linux-arm64.zip
   sha256: 33f2324236e6be4ff125821aec4999cd107d335e6eee3cce8664ec510eac7f3f
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.9/rpk-linux-amd64.zip
+  sha256: c7e3b159512c0892767d2a9dee47f425e11eef5dbf137d617c6c53974b45572e
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.9/rpk-linux-arm64.zip
+  sha256: 2c9262d0204e219c0d225e1614aebc7286ee32113987edc835ab24dca2a4fa54
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/rpk/ops2deb.yml
+++ b/blueprints/devops/rpk/ops2deb.yml
@@ -52,11 +52,13 @@ matrix:
     - 24.3.6
     - 24.3.7
     - 24.3.8
+    - 24.3.9
 homepage: https://redpanda.com/
 summary: interact with your Redpanda clusters
 description: |-
   Redpanda is a streaming data platform for developers. Kafka API compatible. 10x
   faster. No ZooKeeper. No JVM!
-fetch: https://github.com/redpanda-data/redpanda/releases/download/v{{version}}/rpk-linux-{{arch}}.zip
+fetch: 
+  https://github.com/redpanda-data/redpanda/releases/download/v{{version}}/rpk-linux-{{arch}}.zip
 install:
   - rpk:/usr/bin/rpk

--- a/blueprints/devops/scw/ops2deb.lock.yml
+++ b/blueprints/devops/scw/ops2deb.lock.yml
@@ -226,3 +226,9 @@
 - url: https://github.com/scaleway/scaleway-cli/releases/download/v2.37.0/scaleway-cli_2.37.0_linux_arm64
   sha256: 1361f6063fbfdbdc0cf9a0b54b6c31e99f168025676f12ceb2800ff806a8a25b
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/scaleway/scaleway-cli/releases/download/v2.38.0/scaleway-cli_2.38.0_linux_amd64
+  sha256: 4cc0152b24927e52623a8c0d40610e667f1cbca92fc3ff9131dafaa55197018f
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/scaleway/scaleway-cli/releases/download/v2.38.0/scaleway-cli_2.38.0_linux_arm64
+  sha256: 2b4760f0ce16acaec467ee19d9e417e899ed87eb8a2ae4f69bc2fc4aa5f85fa4
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/scw/ops2deb.yml
+++ b/blueprints/devops/scw/ops2deb.yml
@@ -5,7 +5,8 @@
   description: |-
     Scaleway CLI is a tool to help you pilot your Scaleway infrastructure
     directly from your terminal.
-  fetch: https://github.com/scaleway/scaleway-cli/releases/download/v{{version}}/scw-{{version}}-linux-x86_64
+  fetch: 
+    https://github.com/scaleway/scaleway-cli/releases/download/v{{version}}/scw-{{version}}-linux-x86_64
   script:
     - install -m 755 scw-{{version}}-linux-x86_64 {{src}}/usr/bin/scw
 
@@ -17,7 +18,8 @@
   description: |-
     Scaleway CLI is a tool to help you pilot your Scaleway infrastructure
     directly from your terminal.
-  fetch: https://github.com/scaleway/scaleway-cli/releases/download/v{{version}}/scw-{{version}}-linux-x86_64
+  fetch: 
+    https://github.com/scaleway/scaleway-cli/releases/download/v{{version}}/scw-{{version}}-linux-x86_64
   script:
     - mv scw-{{version}}-linux-x86_64 {{src}}/usr/bin/scw
 
@@ -64,11 +66,13 @@
       - 2.35.0
       - 2.36.0
       - 2.37.0
+      - 2.38.0
   homepage: https://github.com/scaleway/scaleway-cli
   summary: command-line interface for Scaleway
   description: |-
     Scaleway CLI is a tool to help you pilot your Scaleway infrastructure
     directly from your terminal.
-  fetch: https://github.com/scaleway/scaleway-cli/releases/download/v{{version}}/scaleway-cli_{{version}}_linux_{{goarch}}
+  fetch: 
+    https://github.com/scaleway/scaleway-cli/releases/download/v{{version}}/scaleway-cli_{{version}}_linux_{{goarch}}
   install:
     - scaleway-cli_{{version}}_linux_{{goarch}}:/usr/bin/scw

--- a/blueprints/devops/terraform/ops2deb.lock.yml
+++ b/blueprints/devops/terraform/ops2deb.lock.yml
@@ -28,15 +28,6 @@
 - url: https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_arm64.zip
   sha256: 2f72982008c52d2d57294ea50794d7c6ae45d2948e08598bfec3e492bce8d96e
   timestamp: 2022-03-02 22:16:55+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.0/terraform_1.4.0_linux_amd64.zip
-  sha256: 5da60da508d6d1941ffa8b9216147456a16bbff6db7622ae9ad01d314cbdd188
-  timestamp: 2023-03-08 18:25:12+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.0/terraform_1.4.0_linux_arm.zip
-  sha256: e414df694001031fe530e05f19ec0fd0b8f115a3898149ee30226bb367da2f35
-  timestamp: 2023-03-08 18:25:12+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.0/terraform_1.4.0_linux_arm64.zip
-  sha256: 33e0f4f0b75f507fc19012111de008308df343153cd6a3992507f4566c0bb723
-  timestamp: 2023-03-08 18:25:12+00:00
 - url: https://releases.hashicorp.com/terraform/1.4.1/terraform_1.4.1_linux_amd64.zip
   sha256: 9e9f3e6752168dea8ecb3643ea9c18c65d5a52acc06c22453ebc4e3fc2d34421
   timestamp: 2023-03-15 15:20:47+00:00
@@ -478,3 +469,12 @@
 - url: https://releases.hashicorp.com/terraform/1.11.2/terraform_1.11.2_linux_arm64.zip
   sha256: 1f162f947e346f75ac3f6ccfdf5e6910924839f688f0773de9a79bc2e0b4ca94
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://releases.hashicorp.com/terraform/1.11.3/terraform_1.11.3_linux_amd64.zip
+  sha256: 377c8c18e2beab24f721994859236e98383350bf767921436511370d1f7c472b
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://releases.hashicorp.com/terraform/1.11.3/terraform_1.11.3_linux_arm.zip
+  sha256: 9bf99463a9353a4242a5650fedc20833537db26c0aa7063ab673a179a5a7ba26
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://releases.hashicorp.com/terraform/1.11.3/terraform_1.11.3_linux_arm64.zip
+  sha256: d685953bec501c0acda13319f34dddaadf33a8f553c85533531d3c7d5f84604a
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/terraform/ops2deb.yml
+++ b/blueprints/devops/terraform/ops2deb.yml
@@ -8,7 +8,8 @@
     a consistent CLI workflow to manage hundreds of cloud services. Terraform
     codifies cloud APIs into declarative configuration files. Terraform can manage
     existing and popular service providers as well as custom in-house solutions.
-  fetch: https://releases.hashicorp.com/terraform/{{version}}/terraform_{{version}}_linux_amd64.zip
+  fetch: 
+    https://releases.hashicorp.com/terraform/{{version}}/terraform_{{version}}_linux_amd64.zip
   script:
     - install -m 755 terraform {{src}}/usr/bin/terraform
 
@@ -29,7 +30,8 @@
     a consistent CLI workflow to manage hundreds of cloud services. Terraform
     codifies cloud APIs into declarative configuration files. Terraform can manage
     existing and popular service providers as well as custom in-house solutions.
-  fetch: https://releases.hashicorp.com/terraform/{{version}}/terraform_{{version}}_linux_{{goarch}}.zip
+  fetch: 
+    https://releases.hashicorp.com/terraform/{{version}}/terraform_{{version}}_linux_{{goarch}}.zip
   script:
     - mv terraform {{src}}/usr/bin/terraform
 
@@ -40,7 +42,6 @@
       - arm64
       - armhf
     versions:
-      - 1.4.0
       - 1.4.1
       - 1.4.2
       - 1.4.3
@@ -90,6 +91,7 @@
       - 1.10.4
       - 1.10.5
       - 1.11.2
+      - 1.11.3
   homepage: https://www.terraform.io
   summary: tool for building, changing, and versioning infrastructure safely
   description: |-
@@ -97,6 +99,7 @@
     a consistent CLI workflow to manage hundreds of cloud services. Terraform
     codifies cloud APIs into declarative configuration files. Terraform can manage
     existing and popular service providers as well as custom in-house solutions.
-  fetch: https://releases.hashicorp.com/terraform/{{version}}/terraform_{{version}}_linux_{{goarch}}.zip
+  fetch: 
+    https://releases.hashicorp.com/terraform/{{version}}/terraform_{{version}}_linux_{{goarch}}.zip
   install:
     - terraform:/usr/bin/

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.3/terragrunt_linux_amd64
-  sha256: 7968df7745fded0654c36cd8f8d41c73ca28eab8b84fb1a7add78fd3002c804b
-  timestamp: 2024-10-16 18:08:00+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.3/terragrunt_linux_arm64
-  sha256: 2cdcb7b4199b078e0e466fa13a4ad2fdb621d4a5f520b12b04fcf9663b1eb01c
-  timestamp: 2024-10-16 18:08:00+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.4/terragrunt_linux_amd64
   sha256: 5cb2e660005fbe3936274364c38b38e243d2017db92b329030543ced06300376
   timestamp: 2024-10-17 15:06:16+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.76.6/terragrunt_linux_arm64
   sha256: 13a34df57b68863f08a9eb8cd0e20b100d8eb6d29c4cba1b99457eb2151ddb01
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.77.6/terragrunt_linux_amd64
+  sha256: 23807f1ef5dfd12d2fe27caa424ace2d3aaf314046e649085667191aef9bdf4b
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.77.6/terragrunt_linux_arm64
+  sha256: a75fa41c18aca9a3fd04cf2e143278bdc34807b11befba0e888e810ddb1e13f2
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -15,7 +15,8 @@
     Terragrunt is a thin wrapper for Terraform that provides extra tools for
     keeping your Terraform configurations DRY, working with multiple Terraform
     modules, and managing remote state.
-  fetch: https://github.com/gruntwork-io/terragrunt/releases/download/v{{version}}/terragrunt_linux_{{goarch}}
+  fetch: 
+    https://github.com/gruntwork-io/terragrunt/releases/download/v{{version}}/terragrunt_linux_{{goarch}}
   script:
     - mv terragrunt_linux_{{goarch}} {{src}}/usr/bin/terragrunt
 
@@ -25,7 +26,6 @@
       - amd64
       - arm64
     versions:
-      - 0.68.3
       - 0.68.4
       - 0.68.5
       - 0.68.6
@@ -75,12 +75,14 @@
       - 0.75.6
       - 0.76.1
       - 0.76.6
+      - 0.77.6
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-
     Terragrunt is a thin wrapper for Terraform that provides extra tools for
     keeping your Terraform configurations DRY, working with multiple Terraform
     modules, and managing remote state.
-  fetch: https://github.com/gruntwork-io/terragrunt/releases/download/v{{version}}/terragrunt_linux_{{goarch}}
+  fetch: 
+    https://github.com/gruntwork-io/terragrunt/releases/download/v{{version}}/terragrunt_linux_{{goarch}}
   install:
     - terragrunt_linux_{{goarch}}:/usr/bin/terragrunt

--- a/blueprints/devops/tflint/ops2deb.lock.yml
+++ b/blueprints/devops/tflint/ops2deb.lock.yml
@@ -172,3 +172,9 @@
 - url: https://github.com/terraform-linters/tflint/releases/download/v0.55.1/tflint_linux_arm64.zip
   sha256: 3d5d6e1e749ae1d46c153dd6fac358cdfa76df475de8f2660a91ff531021f93b
   timestamp: 2025-02-01 18:06:57+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.56.0/tflint_linux_amd64.zip
+  sha256: e0d74c557815ee51c6ecfe826ed62fd411ee6c10e1eab5532a0b0cc684c5db8a
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.56.0/tflint_linux_arm64.zip
+  sha256: 95116e947c03127be4be6eaa9cc05c689e58b82679efba8d4e41b6c20d5f7555
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/devops/tflint/ops2deb.yml
+++ b/blueprints/devops/tflint/ops2deb.yml
@@ -33,6 +33,7 @@ matrix:
     - 0.54.0
     - 0.55.0
     - 0.55.1
+    - 0.56.0
 homepage: https://github.com/terraform-linters/tflint
 summary: pluggable Terraform linter
 description: |-
@@ -43,6 +44,7 @@ description: |-
   (AWS/Azure/GCP).
   - Warn about deprecated syntax, unused declarations.
   - Enforce best practices, naming conventions.
-fetch: https://github.com/terraform-linters/tflint/releases/download/v{{version}}/tflint_linux_{{target}}.zip
+fetch: 
+  https://github.com/terraform-linters/tflint/releases/download/v{{version}}/tflint_linux_{{target}}.zip
 install:
   - tflint:/usr/bin/tflint

--- a/blueprints/secops/dive/ops2deb.lock.yml
+++ b/blueprints/secops/dive/ops2deb.lock.yml
@@ -19,3 +19,9 @@
 - url: https://github.com/wagoodman/dive/releases/download/v0.13.0/dive_0.13.0_linux_arm64.tar.gz
   sha256: 2fd82611e7b3064769b02fc8b9d38e896b98b93c95bec6a80b5d306fd1469e51
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/wagoodman/dive/releases/download/v0.13.1/dive_0.13.1_linux_amd64.tar.gz
+  sha256: 0970549eb4a306f8825a84145a2534153badb4d7dcf3febd1967c706367c3d0e
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/wagoodman/dive/releases/download/v0.13.1/dive_0.13.1_linux_arm64.tar.gz
+  sha256: 2fcd2cf20f634ccdb41efac44048b204bfc867c115641f37a7420693ed480a18
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/secops/dive/ops2deb.yml
+++ b/blueprints/secops/dive/ops2deb.yml
@@ -7,6 +7,7 @@ matrix:
     - 0.11.0
     - 0.12.0
     - 0.13.0
+    - 0.13.1
 homepage: https://github.com/wagoodman/dive
 summary: tool for exploring each layer in a docker image
 description: |-
@@ -15,6 +16,7 @@ description: |-
   image contents broken down by layer, indicates what's changed in each layer,
   estimates "image efficiency", quick build/analysis cycles ans is ready to use
   with CI integration.
-fetch: https://github.com/wagoodman/dive/releases/download/v{{version}}/dive_{{version}}_linux_{{arch}}.tar.gz
+fetch: 
+  https://github.com/wagoodman/dive/releases/download/v{{version}}/dive_{{version}}_linux_{{arch}}.tar.gz
 install:
   - dive:/usr/bin/dive

--- a/blueprints/secops/kubescape/ops2deb.lock.yml
+++ b/blueprints/secops/kubescape/ops2deb.lock.yml
@@ -118,3 +118,9 @@
 - url: https://github.com/kubescape/kubescape/releases/download/v3.0.32/kubescape-ubuntu-latest.tar.gz
   sha256: 761a4a7010ae336242f569b9986df6dc3dedf141a766e5fbbe941c6208826c69
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.34/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: 113f3df2c8dbe0923481978806afcafc1c6d68154763f19e0334496cd05df9e0
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.34/kubescape-ubuntu-latest.tar.gz
+  sha256: 598f6ac9d5e0fd5a38f4248b49f59ee549302da62957a89955760a9ac060a373
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/secops/kubescape/ops2deb.yml
+++ b/blueprints/secops/kubescape/ops2deb.yml
@@ -24,6 +24,7 @@ matrix:
     - 3.0.28
     - 3.0.31
     - 3.0.32
+    - 3.0.34
 homepage: https://kubescape.io
 summary: kubernetes security platform for your IDE, CI/CD pipelines, and clusters
 description: |-
@@ -37,7 +38,8 @@ description: |-
   misconfigurations according to multiple frameworks (including NSA-CISA, MITRE
   ATT&CK® and the CIS Benchmark).
 fetch:
-  url: https://github.com/kubescape/kubescape/releases/download/v{{version}}/kubescape-{{target}}-latest.tar.gz
+  url: 
+    https://github.com/kubescape/kubescape/releases/download/v{{version}}/kubescape-{{target}}-latest.tar.gz
   targets:
     amd64: ubuntu
     arm64: arm64-ubuntu

--- a/blueprints/secops/sops/ops2deb.lock.yml
+++ b/blueprints/secops/sops/ops2deb.lock.yml
@@ -52,3 +52,9 @@
 - url: https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.arm64
   sha256: 16564c6b181d88505d9e0dfef62771894293d85cde5884d9b1a843859eee174b
   timestamp: 2025-01-28 09:07:23+00:00
+- url: https://github.com/getsops/sops/releases/download/v3.10.1/sops-v3.10.1.linux.amd64
+  sha256: 1bc9fbce48e3fcc7e684d604d50f7c56721b6cd2d27f96ec74b8b56b5a96c942
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/getsops/sops/releases/download/v3.10.1/sops-v3.10.1.linux.arm64
+  sha256: 1e82b1abc846b1e7763c9e4d817fb8f6bf740a44d9036935eff9423626a270cd
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/secops/sops/ops2deb.yml
+++ b/blueprints/secops/sops/ops2deb.yml
@@ -13,12 +13,14 @@ matrix:
     - 3.9.2
     - 3.9.3
     - 3.9.4
+    - 3.10.1
 homepage: https://age-encryption.org/
 summary: simple and flexible tool for managing secrets
 description: |-
   sops is an editor of encrypted files that supports YAML, JSON, ENV, INI and
   BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault, age, and
   PGP.
-fetch: https://github.com/getsops/sops/releases/download/v{{version}}/sops-v{{version}}.linux.{{goarch}}
+fetch: 
+  https://github.com/getsops/sops/releases/download/v{{version}}/sops-v{{version}}.linux.{{goarch}}
 install:
   - sops-v{{version}}.linux.{{goarch}}:/usr/bin/sops

--- a/blueprints/secops/trivy/ops2deb.lock.yml
+++ b/blueprints/secops/trivy/ops2deb.lock.yml
@@ -670,3 +670,9 @@
 - url: https://github.com/aquasecurity/trivy/releases/download/v0.60.0/trivy_0.60.0_Linux-ARM64.tar.gz
   sha256: df5094134134b79c928d3f3c8a611b992fd583134823924d30ca0afc0f86507d
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-64bit.tar.gz
+  sha256: 31af7049380abcdc422094638cc33364593f0ccc89c955dd69d27aca288ae79c
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-ARM64.tar.gz
+  sha256: e3ff876fd6fa95919de02c38258acdb26b8f71be1b89c5cb7831f6ec29719ca5
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/secops/trivy/ops2deb.yml
+++ b/blueprints/secops/trivy/ops2deb.yml
@@ -56,7 +56,8 @@
     Scanner for vulnerabilities in container images, file systems, and Git
     repositories, as well as for configuration issues
   fetch:
-    url: https://github.com/aquasecurity/trivy/releases/download/v{{version}}/trivy_{{version}}_Linux-{{target}}.tar.gz
+    url: 
+      https://github.com/aquasecurity/trivy/releases/download/v{{version}}/trivy_{{version}}_Linux-{{target}}.tar.gz
     targets:
       amd64: 64bit
       armhf: ARM
@@ -113,13 +114,15 @@
       - 0.59.0
       - 0.59.1
       - 0.60.0
+      - 0.61.0
   homepage: https://www.aquasec.com/products/trivy/
   summary: vulnerability and misconfiguration scanner
   description: |-
     Scanner for vulnerabilities in container images, file systems, and Git
     repositories, as well as for configuration issues
   fetch:
-    url: https://github.com/aquasecurity/trivy/releases/download/v{{version}}/trivy_{{version}}_Linux-{{target}}.tar.gz
+    url: 
+      https://github.com/aquasecurity/trivy/releases/download/v{{version}}/trivy_{{version}}_Linux-{{target}}.tar.gz
     targets:
       amd64: 64bit
       arm64: ARM64

--- a/blueprints/terminal/dust/ops2deb.lock.yml
+++ b/blueprints/terminal/dust/ops2deb.lock.yml
@@ -82,3 +82,9 @@
 - url: https://github.com/bootandy/dust/releases/download/v1.1.2/dust-v1.1.2-x86_64-unknown-linux-gnu.tar.gz
   sha256: 297b7ee84ab2f49bde54ffe47ce8656fd4937ce576eef7f627294bd1a0d70211
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/bootandy/dust/releases/download/v1.2.0/dust-v1.2.0-arm-unknown-linux-gnueabihf.tar.gz
+  sha256: 92f34bd92879f2bfdadcc0323fe4456e338e3ee10e7ebd9507b45c3fe0db4760
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/bootandy/dust/releases/download/v1.2.0/dust-v1.2.0-x86_64-unknown-linux-gnu.tar.gz
+  sha256: c4bac8dfe91311ba0794b393ea0ec4a0eaa838bf974c6dc353dac4cd1140dc9a
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/terminal/dust/ops2deb.yml
+++ b/blueprints/terminal/dust/ops2deb.yml
@@ -4,7 +4,8 @@
   homepage: https://github.com/bootandy/dust
   summary: human-friendly and fast alternative to 'du'
   description: du + rust = dust. Like du but more intuitive.
-  fetch: https://github.com/bootandy/dust/releases/download/v{{version}}/dust-v{{version}}-x86_64-unknown-linux-gnu.tar.gz
+  fetch: 
+    https://github.com/bootandy/dust/releases/download/v{{version}}/dust-v{{version}}-x86_64-unknown-linux-gnu.tar.gz
   script:
     - mv dust-v{{version}}-x86_64-unknown-linux-gnu/dust {{src}}/usr/bin/dust
 
@@ -15,7 +16,8 @@
   homepage: https://github.com/bootandy/dust
   summary: human-friendly and fast alternative to 'du'
   description: du + rust = dust. Like du but more intuitive.
-  fetch: https://github.com/bootandy/dust/releases/download/v{{version}}/dust-v{{version}}-{{rust_target}}.tar.gz
+  fetch: 
+    https://github.com/bootandy/dust/releases/download/v{{version}}/dust-v{{version}}-{{rust_target}}.tar.gz
   script:
     - mv dust-v{{version}}-*/dust {{src}}/usr/bin/dust
 
@@ -30,7 +32,8 @@
   homepage: https://github.com/bootandy/dust
   summary: human-friendly and fast alternative to 'du'
   description: du + rust = dust. Like du but more intuitive.
-  fetch: https://github.com/bootandy/dust/releases/download/v{{version}}/dust-v{{version}}-{{rust_target}}.tar.gz
+  fetch: 
+    https://github.com/bootandy/dust/releases/download/v{{version}}/dust-v{{version}}-{{rust_target}}.tar.gz
   script:
     - mv dust-v{{version}}-*/dust {{src}}/usr/bin/dust
 
@@ -51,9 +54,11 @@
       - 1.1.0
       - 1.1.1
       - 1.1.2
+      - 1.2.0
   homepage: https://github.com/bootandy/dust
   summary: human-friendly and fast alternative to 'du'
   description: du + rust = dust. Like du but more intuitive.
-  fetch: https://github.com/bootandy/dust/releases/download/v{{version}}/dust-v{{version}}-{{rust_target}}.tar.gz
+  fetch: 
+    https://github.com/bootandy/dust/releases/download/v{{version}}/dust-v{{version}}-{{rust_target}}.tar.gz
   install:
     - dust-v{{version}}-{{rust_target}}/dust:/usr/bin/

--- a/blueprints/terminal/fzf/ops2deb.lock.yml
+++ b/blueprints/terminal/fzf/ops2deb.lock.yml
@@ -28,3 +28,9 @@
 - url: https://github.com/junegunn/fzf/releases/download/v0.60.3/fzf-0.60.3-linux_arm64.tar.gz
   sha256: 13df4d556992938a4beb340ac3b17c51c77e46db978d3071429eb77a94c581c1
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.61.0/fzf-0.61.0-linux_amd64.tar.gz
+  sha256: 69767835a69f0eaef03d4ea4117b32197382ebb59cae358ea22f08b46c33fa50
+  timestamp: 2025-04-02 18:09:31+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.61.0/fzf-0.61.0-linux_arm64.tar.gz
+  sha256: 760f4f62c30af0f722430af099c40af191b3fe5a55b8f850926dac406f6bf9fe
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/terminal/fzf/ops2deb.yml
+++ b/blueprints/terminal/fzf/ops2deb.yml
@@ -9,6 +9,7 @@ matrix:
     - 0.59.0
     - 0.60.0
     - 0.60.3
+    - 0.61.0
 homepage: https://junegunn.github.io/fzf/
 summary: A command-line fuzzy finder in Go
 description: |-
@@ -17,6 +18,7 @@ description: |-
   history, processes, hostnames, bookmarks, git commits, etc.
   With its novel “fuzzy” matching algorithm, you can quickly type in patterns
   with omitted characters and still get the results you want.
-fetch: https://github.com/junegunn/fzf/releases/download/v{{version}}/fzf-{{version}}-linux_{{arch}}.tar.gz
+fetch: 
+  https://github.com/junegunn/fzf/releases/download/v{{version}}/fzf-{{version}}-linux_{{arch}}.tar.gz
 install:
   - fzf:/usr/bin/

--- a/blueprints/terminal/mdbook/ops2deb.lock.yml
+++ b/blueprints/terminal/mdbook/ops2deb.lock.yml
@@ -73,3 +73,6 @@
 - url: https://github.com/rust-lang/mdBook/releases/download/v0.4.47/mdbook-v0.4.47-x86_64-unknown-linux-gnu.tar.gz
   sha256: 3f66d94eb6e26cbcf64cb3a8bb7188d30818db3394668d8938868cc95f97c1e2
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/rust-lang/mdBook/releases/download/v0.4.48/mdbook-v0.4.48-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 8e13735f22491cce1dd94fdb54dc09b7eb09afadc0d39c57d73340236382d4d5
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/terminal/mdbook/ops2deb.yml
+++ b/blueprints/terminal/mdbook/ops2deb.yml
@@ -26,6 +26,7 @@ matrix:
     - 0.4.43
     - 0.4.44
     - 0.4.47
+    - 0.4.48
 homepage: https://rust-lang.github.io/mdBook/
 summary: create book from markdown files
 description: |-
@@ -38,6 +39,7 @@ description: |-
   * Theme files allow customizing the formatting of the output
   * Preprocessors that provide extensions for custom syntax and modifying content
   * Backends that can render the output to multiple formats
-fetch: https://github.com/rust-lang/mdBook/releases/download/v{{version}}/mdbook-v{{version}}-x86_64-unknown-linux-gnu.tar.gz
+fetch: 
+  https://github.com/rust-lang/mdBook/releases/download/v{{version}}/mdbook-v{{version}}-x86_64-unknown-linux-gnu.tar.gz
 install:
   - mdbook:/usr/bin/

--- a/blueprints/terminal/procs/ops2deb.lock.yml
+++ b/blueprints/terminal/procs/ops2deb.lock.yml
@@ -49,3 +49,6 @@
 - url: https://github.com/dalance/procs/releases/download/v0.14.9/procs-v0.14.9-x86_64-linux.zip
   sha256: b3d1baaf8beadf6e97d0f9fd9847447800f067601c95c64b5456bddac72aa558
   timestamp: 2025-01-28 09:07:23+00:00
+- url: https://github.com/dalance/procs/releases/download/v0.14.10/procs-v0.14.10-x86_64-linux.zip
+  sha256: ad84b948703e74379edc32d80fe9b862f6f1e95fc1e305ff0a8a3b4cb7b05ee4
+  timestamp: 2025-04-02 18:09:31+00:00

--- a/blueprints/terminal/procs/ops2deb.yml
+++ b/blueprints/terminal/procs/ops2deb.yml
@@ -9,7 +9,8 @@
     Procs has a colored and human-readable output, multi-column keyword search,
     additional information which are not supported by ps, a tree view, a watch mode
     and more...
-  fetch: https://github.com/dalance/procs/releases/download/v{{version}}/procs-v{{version}}-x86_64-lnx.zip
+  fetch: 
+    https://github.com/dalance/procs/releases/download/v{{version}}/procs-v{{version}}-x86_64-lnx.zip
   script:
     - mv procs {{src}}/usr/bin/procs
 
@@ -31,12 +32,14 @@
       - 0.14.7
       - 0.14.8
       - 0.14.9
+      - 0.14.10
   homepage: https://github.com/dalance/procs
   summary: alternative in rust to 'ps'
   description: |-
     Procs has a colored and human-readable output, multi-column keyword search,
     additional information which are not supported by ps, a tree view, a watch mode
     and more...
-  fetch: https://github.com/dalance/procs/releases/download/v{{version}}/procs-v{{version}}-x86_64-linux.zip
+  fetch: 
+    https://github.com/dalance/procs/releases/download/v{{version}}/procs-v{{version}}-x86_64-linux.zip
   install:
     - procs:/usr/bin/


### PR DESCRIPTION
Add fzf v0.61.0
Add dust v1.2.0
Add mdbook v0.4.48
Add procs v0.14.10
Add kubebuilder v4.5.2
Add glab v1.55.0
Add pdm v2.23.0
Add k6 v0.58.0
Add typos-cli v1.31.1
Remove typos-cli v1.20.5
Add uv v0.6.11
Add poetry v2.1.2
Add tflint v0.56.0
Add kubeseal v0.29.0
Add rpk v24.3.9
Add carvel-ytt v0.51.2
Add scw v2.38.0
Add istioctl v1.25.1
Add mirrord v3.137.0
Remove mirrord v3.104.0
Add terragrunt v0.77.6
Remove terragrunt v0.68.3
Add argocd v2.14.8
Add terraform v1.11.3
Remove terraform v1.4.0
Add hubble v1.17.2
Add oc v4.18.7
Add act v0.2.76
Add iamlive v1.1.23
Add goreleaser v2.8.2
Add rancher v2.11.0
Add restic v0.18.0
Add kubescape v3.0.34
Add trivy v0.61.0
Add dive v0.13.1
Add sops v3.10.1
Add signal-desktop v7.48.0
Remove signal-desktop v7.5.1
Add teams-for-linux v1.14.2