### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/openlens/ops2deb.yml
+++ b/blueprints/desktop/openlens/ops2deb.yml
@@ -6,6 +6,7 @@ matrix:
   versions:
     - 6.4.15
     - 6.5.2-366
+    - 6.5.2
 homepage: https://github.com/MuhammedKalkan/OpenLens
 summary: powerful IDE for kubernetes
 description: |-

--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.5.1_amd64.deb
-  sha256: 69f291f8fd983e4bf838c22bf0bcd67803195abd33689d51d01403f3b810b929
-  timestamp: 2024-04-19 00:21:29+00:00
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.6.0_amd64.deb
   sha256: b06396b056533bd5500e40aa86c3a45b9698fac8747cb1fb90f3defdb0331af8
   timestamp: 2024-04-25 15:06:04+00:00
@@ -148,3 +145,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.47.0_amd64.deb
   sha256: a29913cb4575b56ae2ad89e5099302f29466ac32f82da508a4d0147a44ca6ead
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.49.0_amd64.deb
+  sha256: 7a35008a28db70af282b3cb7f8e8e3a471022568d21a99fa7ae9b483e311eba1
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -1,7 +1,6 @@
 name: signal-desktop
 matrix:
   versions:
-    - 7.5.1
     - 7.6.0
     - 7.7.0
     - 7.8.0
@@ -51,6 +50,7 @@ matrix:
     - 7.46.0
     - 7.46.1
     - 7.47.0
+    - 7.49.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
@@ -112,3 +112,6 @@
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.13.1/teams-for-linux_1.13.1_amd64.deb
   sha256: 0dd58015d1973ca6bc99fe6828b318108d12db76cbe3ad7108ec984446c8483d
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.14.0/teams-for-linux_1.14.0_amd64.deb
+  sha256: 30001b25441e1213f18fb98f3d0cc5572b4a468358fb46e70ac4cc6e303a080e
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/desktop/teams-for-linux/ops2deb.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.yml
@@ -39,6 +39,7 @@ matrix:
     - 1.12.7
     - 1.13.0
     - 1.13.1
+    - 1.14.0
 homepage: https://github.com/IsmaelMartinez/teams-for-linux/
 summary: unofficial Microsoft Teams for Linux client
 description: |-

--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -247,3 +247,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.54.0/downloads/glab_1.54.0_linux_arm64.deb
   sha256: 0c1fdb4f57d1e3b2e5e1676b6e2ab99a1a4bb3c01ea58af2e51d5d4845f7b5ed
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.55.0/downloads/glab_1.55.0_linux_amd64.deb
+  sha256: ae3feac2aa1034a585e4a24787970dacd30f07906cdc75af8911c32d158b44e8
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.55.0/downloads/glab_1.55.0_linux_arm64.deb
+  sha256: 36c7368617111148dd34e5cd86ffa11665f76101e4ba396db943f8d17ceaa989
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -64,6 +64,7 @@
       - 1.52.0
       - 1.53.0
       - 1.54.0
+      - 1.55.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-

--- a/blueprints/dev/k6/ops2deb.lock.yml
+++ b/blueprints/dev/k6/ops2deb.lock.yml
@@ -40,3 +40,9 @@
 - url: https://github.com/grafana/k6/releases/download/v0.57.0/k6-v0.57.0-linux-arm64.tar.gz
   sha256: 223525edaadf23f1483ec4b3f38b81c4431dce38df5a843a89b2b87950faf56d
   timestamp: 2025-02-13 15:06:54+00:00
+- url: https://github.com/grafana/k6/releases/download/v0.58.0/k6-v0.58.0-linux-amd64.tar.gz
+  sha256: e487d8775a306ed1f7232855a37dee4e42b7a53b5a991009a267305c06f56dab
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/grafana/k6/releases/download/v0.58.0/k6-v0.58.0-linux-arm64.tar.gz
+  sha256: 0598bbdd9f9e67a8eae49520494137b235c3be2cbf3b3721db626ecb395944ee
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/dev/k6/ops2deb.yml
+++ b/blueprints/dev/k6/ops2deb.yml
@@ -11,6 +11,7 @@ matrix:
     - 0.55.2
     - 0.56.0
     - 0.57.0
+    - 0.58.0
 homepage: https://k6.io
 summary: modern load testing tool, using Go and JavaScript
 description: |-

--- a/blueprints/dev/kubebuilder/ops2deb.lock.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.lock.yml
@@ -184,3 +184,9 @@
 - url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.1/kubebuilder_linux_arm64
   sha256: de94401324b3c080e1f14290f68ddd06453baf20460ed0f444e86b9370a11608
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.2/kubebuilder_linux_amd64
+  sha256: 7a691c7c286b4c1a3f57b2ca9c85e3856662f850a4fa4cc6feb1aaae9273cf1c
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.2/kubebuilder_linux_arm64
+  sha256: 77ae785ea75d76ad191caa6bf69001faade8019ed771a19a0f174def3baf29ed
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/dev/kubebuilder/ops2deb.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.yml
@@ -35,6 +35,7 @@ matrix:
     - 4.4.0
     - 4.5.0
     - 4.5.1
+    - 4.5.2
 homepage: https://book.kubebuilder.io
 summary: SDK for building Kubernetes APIs using CRDs
 description: |-

--- a/blueprints/dev/pdm/ops2deb.lock.yml
+++ b/blueprints/dev/pdm/ops2deb.lock.yml
@@ -127,3 +127,6 @@
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.22.4.tar.gz
   sha256: 01f372650b41897f6cc4bccdc7c22bcd51c732fcedc6bb33e47f93e30ab600d1
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.23.0.tar.gz
+  sha256: e67f6463e836eed9e85dfc55068c178c8ad7a6a8cea512622b437fd5f52c7ce0
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/dev/pdm/ops2deb.yml
+++ b/blueprints/dev/pdm/ops2deb.yml
@@ -44,6 +44,7 @@ matrix:
     - 2.22.2
     - 2.22.3
     - 2.22.4
+    - 2.23.0
 homepage: https://pdm.fming.dev/
 summary: modern Python package and dependency manager supporting the latest PEP standards
 description: |-

--- a/blueprints/dev/poetry/ops2deb.lock.yml
+++ b/blueprints/dev/poetry/ops2deb.lock.yml
@@ -58,9 +58,12 @@
 - url: https://github.com/python-poetry/poetry/archive/refs/tags/2.0.0.tar.gz
   sha256: ba4a93bd8e9c3668fab4e42215ddd85cbcddb9c02bdd9baf6291feef983dd32c
   timestamp: 2025-01-05 12:09:23+00:00
-- url: https://github.com/python-poetry/poetry/archive/refs/tags/2.0.1.tar.gz
-  sha256: 9e9f7a7b868338e40134f2e705bc5162fc0779043083b926e434963cf39e806a
-  timestamp: 2025-02-17 20:01:56+00:00
 - url: https://github.com/python-poetry/poetry/archive/refs/tags/2.1.1.tar.gz
   sha256: 1e33bc9c202d08ebde998bcb151f5f18ef56e70be0b10d126e831b78e337c046
   timestamp: 2025-02-17 19:08:06+00:00
+- url: https://github.com/python-poetry/poetry/archive/refs/tags/2.0.1.tar.gz
+  sha256: 9e9f7a7b868338e40134f2e705bc5162fc0779043083b926e434963cf39e806a
+  timestamp: 2025-02-17 20:01:56+00:00
+- url: https://github.com/python-poetry/poetry/archive/refs/tags/2.1.2.tar.gz
+  sha256: e674047e4730f0898789c8a1274e99f346edea130f4bd4ecf8189e40786723df
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/dev/poetry/ops2deb.yml
+++ b/blueprints/dev/poetry/ops2deb.yml
@@ -114,6 +114,7 @@
     versions:
       - 2.0.1
       - 2.1.1
+      - 2.1.2
   homepage: https://python-poetry.org
   summary: tool for dependency management and packaging in Python
   description: |-

--- a/blueprints/dev/typos-cli/ops2deb.lock.yml
+++ b/blueprints/dev/typos-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/crate-ci/typos/releases/download/v1.20.5/typos-v1.20.5-x86_64-unknown-linux-musl.tar.gz
-  sha256: dd638fcde5e955bb801b9be28e912977dba6c857603ca14c212c71fc6cd871b0
-  timestamp: 2024-04-09 03:06:35+00:00
 - url: https://github.com/crate-ci/typos/releases/download/v1.20.6/typos-v1.20.6-x86_64-unknown-linux-musl.tar.gz
   sha256: bceb5e6a9bde42e8147809bb894835aad65563fc90ac8f0c512ec750b5fb0ed7
   timestamp: 2024-04-09 18:06:15+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/crate-ci/typos/releases/download/v1.30.2/typos-v1.30.2-x86_64-unknown-linux-musl.tar.gz
   sha256: 0bb41546e8a91cb6c4a5cf80d640f7be8885717d96ba9463445a1fe258758523
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/crate-ci/typos/releases/download/v1.31.1/typos-v1.31.1-x86_64-unknown-linux-musl.tar.gz
+  sha256: f683c2abeaff70379df7176110100e18150ecd17a4b9785c32908aca11929993
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/dev/typos-cli/ops2deb.yml
+++ b/blueprints/dev/typos-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: typos-cli
 matrix:
   versions:
-    - 1.20.5
     - 1.20.6
     - 1.20.7
     - 1.20.8
@@ -51,6 +50,7 @@ matrix:
     - 1.29.7
     - 1.29.9
     - 1.30.2
+    - 1.31.1
 homepage: https://github.com/crate-ci/typos/
 summary: source code spell checker
 description: |-

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -466,3 +466,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.6.9/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 001b87a0c2ea642a3c75a98c6af3e8528aa473d560e653cf213efcc9aaa4a028
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.12/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: e999ae0679bfabe8a1e6343b8b204a531a6c851e315caff9b326f34182884af6
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.12/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: b5dedaca5fbb46f412c5426102eec7c9f10003a67dd41b943232e4a2b6a5cc16
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.12/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: eec3ccf53616e00905279a302bc043451bd96ca71a159a2ac3199452ac914c26
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -89,6 +89,7 @@
     versions:
       - 0.6.8
       - 0.6.9
+      - 0.6.12
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/secops/dive/ops2deb.lock.yml
+++ b/blueprints/secops/dive/ops2deb.lock.yml
@@ -19,3 +19,9 @@
 - url: https://github.com/wagoodman/dive/releases/download/v0.13.0/dive_0.13.0_linux_arm64.tar.gz
   sha256: 2fd82611e7b3064769b02fc8b9d38e896b98b93c95bec6a80b5d306fd1469e51
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/wagoodman/dive/releases/download/v0.13.1/dive_0.13.1_linux_amd64.tar.gz
+  sha256: 0970549eb4a306f8825a84145a2534153badb4d7dcf3febd1967c706367c3d0e
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/wagoodman/dive/releases/download/v0.13.1/dive_0.13.1_linux_arm64.tar.gz
+  sha256: 2fcd2cf20f634ccdb41efac44048b204bfc867c115641f37a7420693ed480a18
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/secops/dive/ops2deb.yml
+++ b/blueprints/secops/dive/ops2deb.yml
@@ -7,13 +7,14 @@ matrix:
     - 0.11.0
     - 0.12.0
     - 0.13.0
+    - 0.13.1
 homepage: https://github.com/wagoodman/dive
 summary: tool for exploring each layer in a docker image
 description: |-
   Dive is a tool used for exploring a docker image, layer contents, and
   discovering ways to shrink the size of your Docker/OCI image. It shows Docker
   image contents broken down by layer, indicates what's changed in each layer,
-  estimates "image efficiency", quick build/analysis cycles ans is ready to use
+  estimates "image efficiency", quick build/analysis cycles and is ready to use
   with CI integration.
 fetch: https://github.com/wagoodman/dive/releases/download/v{{version}}/dive_{{version}}_linux_{{arch}}.tar.gz
 install:

--- a/blueprints/secops/kubescape/ops2deb.lock.yml
+++ b/blueprints/secops/kubescape/ops2deb.lock.yml
@@ -118,3 +118,9 @@
 - url: https://github.com/kubescape/kubescape/releases/download/v3.0.32/kubescape-ubuntu-latest.tar.gz
   sha256: 761a4a7010ae336242f569b9986df6dc3dedf141a766e5fbbe941c6208826c69
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.34/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: 113f3df2c8dbe0923481978806afcafc1c6d68154763f19e0334496cd05df9e0
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.34/kubescape-ubuntu-latest.tar.gz
+  sha256: 598f6ac9d5e0fd5a38f4248b49f59ee549302da62957a89955760a9ac060a373
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/secops/kubescape/ops2deb.yml
+++ b/blueprints/secops/kubescape/ops2deb.yml
@@ -24,6 +24,7 @@ matrix:
     - 3.0.28
     - 3.0.31
     - 3.0.32
+    - 3.0.34
 homepage: https://kubescape.io
 summary: kubernetes security platform for your IDE, CI/CD pipelines, and clusters
 description: |-

--- a/blueprints/secops/sops/ops2deb.lock.yml
+++ b/blueprints/secops/sops/ops2deb.lock.yml
@@ -52,3 +52,9 @@
 - url: https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.arm64
   sha256: 16564c6b181d88505d9e0dfef62771894293d85cde5884d9b1a843859eee174b
   timestamp: 2025-01-28 09:07:23+00:00
+- url: https://github.com/getsops/sops/releases/download/v3.10.1/sops-v3.10.1.linux.amd64
+  sha256: 1bc9fbce48e3fcc7e684d604d50f7c56721b6cd2d27f96ec74b8b56b5a96c942
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/getsops/sops/releases/download/v3.10.1/sops-v3.10.1.linux.arm64
+  sha256: 1e82b1abc846b1e7763c9e4d817fb8f6bf740a44d9036935eff9423626a270cd
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/secops/sops/ops2deb.yml
+++ b/blueprints/secops/sops/ops2deb.yml
@@ -13,6 +13,7 @@ matrix:
     - 3.9.2
     - 3.9.3
     - 3.9.4
+    - 3.10.1
 homepage: https://age-encryption.org/
 summary: simple and flexible tool for managing secrets
 description: |-

--- a/blueprints/secops/trivy/ops2deb.lock.yml
+++ b/blueprints/secops/trivy/ops2deb.lock.yml
@@ -670,3 +670,9 @@
 - url: https://github.com/aquasecurity/trivy/releases/download/v0.60.0/trivy_0.60.0_Linux-ARM64.tar.gz
   sha256: df5094134134b79c928d3f3c8a611b992fd583134823924d30ca0afc0f86507d
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-64bit.tar.gz
+  sha256: 31af7049380abcdc422094638cc33364593f0ccc89c955dd69d27aca288ae79c
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-ARM64.tar.gz
+  sha256: e3ff876fd6fa95919de02c38258acdb26b8f71be1b89c5cb7831f6ec29719ca5
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/secops/trivy/ops2deb.yml
+++ b/blueprints/secops/trivy/ops2deb.yml
@@ -113,6 +113,7 @@
       - 0.59.0
       - 0.59.1
       - 0.60.0
+      - 0.61.0
   homepage: https://www.aquasec.com/products/trivy/
   summary: vulnerability and misconfiguration scanner
   description: |-

--- a/blueprints/terminal/dust/ops2deb.lock.yml
+++ b/blueprints/terminal/dust/ops2deb.lock.yml
@@ -82,3 +82,9 @@
 - url: https://github.com/bootandy/dust/releases/download/v1.1.2/dust-v1.1.2-x86_64-unknown-linux-gnu.tar.gz
   sha256: 297b7ee84ab2f49bde54ffe47ce8656fd4937ce576eef7f627294bd1a0d70211
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/bootandy/dust/releases/download/v1.2.0/dust-v1.2.0-arm-unknown-linux-gnueabihf.tar.gz
+  sha256: 92f34bd92879f2bfdadcc0323fe4456e338e3ee10e7ebd9507b45c3fe0db4760
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/bootandy/dust/releases/download/v1.2.0/dust-v1.2.0-x86_64-unknown-linux-gnu.tar.gz
+  sha256: c4bac8dfe91311ba0794b393ea0ec4a0eaa838bf974c6dc353dac4cd1140dc9a
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/terminal/dust/ops2deb.yml
+++ b/blueprints/terminal/dust/ops2deb.yml
@@ -51,6 +51,7 @@
       - 1.1.0
       - 1.1.1
       - 1.1.2
+      - 1.2.0
   homepage: https://github.com/bootandy/dust
   summary: human-friendly and fast alternative to 'du'
   description: du + rust = dust. Like du but more intuitive.

--- a/blueprints/terminal/fzf/ops2deb.lock.yml
+++ b/blueprints/terminal/fzf/ops2deb.lock.yml
@@ -28,3 +28,9 @@
 - url: https://github.com/junegunn/fzf/releases/download/v0.60.3/fzf-0.60.3-linux_arm64.tar.gz
   sha256: 13df4d556992938a4beb340ac3b17c51c77e46db978d3071429eb77a94c581c1
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.61.0/fzf-0.61.0-linux_amd64.tar.gz
+  sha256: 69767835a69f0eaef03d4ea4117b32197382ebb59cae358ea22f08b46c33fa50
+  timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.61.0/fzf-0.61.0-linux_arm64.tar.gz
+  sha256: 760f4f62c30af0f722430af099c40af191b3fe5a55b8f850926dac406f6bf9fe
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/terminal/fzf/ops2deb.yml
+++ b/blueprints/terminal/fzf/ops2deb.yml
@@ -9,6 +9,7 @@ matrix:
     - 0.59.0
     - 0.60.0
     - 0.60.3
+    - 0.61.0
 homepage: https://junegunn.github.io/fzf/
 summary: A command-line fuzzy finder in Go
 description: |-

--- a/blueprints/terminal/mdbook/ops2deb.lock.yml
+++ b/blueprints/terminal/mdbook/ops2deb.lock.yml
@@ -73,3 +73,6 @@
 - url: https://github.com/rust-lang/mdBook/releases/download/v0.4.47/mdbook-v0.4.47-x86_64-unknown-linux-gnu.tar.gz
   sha256: 3f66d94eb6e26cbcf64cb3a8bb7188d30818db3394668d8938868cc95f97c1e2
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/rust-lang/mdBook/releases/download/v0.4.48/mdbook-v0.4.48-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 8e13735f22491cce1dd94fdb54dc09b7eb09afadc0d39c57d73340236382d4d5
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/terminal/mdbook/ops2deb.yml
+++ b/blueprints/terminal/mdbook/ops2deb.yml
@@ -26,6 +26,7 @@ matrix:
     - 0.4.43
     - 0.4.44
     - 0.4.47
+    - 0.4.48
 homepage: https://rust-lang.github.io/mdBook/
 summary: create book from markdown files
 description: |-

--- a/blueprints/terminal/procs/ops2deb.lock.yml
+++ b/blueprints/terminal/procs/ops2deb.lock.yml
@@ -49,3 +49,6 @@
 - url: https://github.com/dalance/procs/releases/download/v0.14.9/procs-v0.14.9-x86_64-linux.zip
   sha256: b3d1baaf8beadf6e97d0f9fd9847447800f067601c95c64b5456bddac72aa558
   timestamp: 2025-01-28 09:07:23+00:00
+- url: https://github.com/dalance/procs/releases/download/v0.14.10/procs-v0.14.10-x86_64-linux.zip
+  sha256: ad84b948703e74379edc32d80fe9b862f6f1e95fc1e305ff0a8a3b4cb7b05ee4
+  timestamp: 2025-04-02 21:25:10+00:00

--- a/blueprints/terminal/procs/ops2deb.yml
+++ b/blueprints/terminal/procs/ops2deb.yml
@@ -31,6 +31,7 @@
       - 0.14.7
       - 0.14.8
       - 0.14.9
+      - 0.14.10
   homepage: https://github.com/dalance/procs
   summary: alternative in rust to 'ps'
   description: |-


### PR DESCRIPTION
Add fzf v0.61.0
Add dust v1.2.0
Add mdbook v0.4.48
Add procs v0.14.10
Add kubebuilder v4.5.2
Add glab v1.55.0
Add pdm v2.23.0
Add k6 v0.58.0
Add typos-cli v1.31.1
Remove typos-cli v1.20.5
Add uv v0.6.12
Add poetry v2.1.2
Add kubescape v3.0.34
Add trivy v0.61.0
Add dive v0.13.1
Add sops v3.10.1
Add signal-desktop v7.49.0
Remove signal-desktop v7.5.1
Add teams-for-linux v1.14.0
Add openlens v6.5.2