### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.6.0_amd64.deb
-  sha256: b06396b056533bd5500e40aa86c3a45b9698fac8747cb1fb90f3defdb0331af8
-  timestamp: 2024-04-25 15:06:04+00:00
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.7.0_amd64.deb
   sha256: 5044a96d8678a11861405f0662b6ca9cd92a99e7c27d31358df0822bb72d20a9
   timestamp: 2024-05-02 00:21:43+00:00
@@ -148,3 +145,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.49.0_amd64.deb
   sha256: 7a35008a28db70af282b3cb7f8e8e3a471022568d21a99fa7ae9b483e311eba1
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.50.0_amd64.deb
+  sha256: 5411ee0dea8a2cc97e28bffee7ae8071e84db928e11b0369e374f9133f6200ab
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -1,7 +1,6 @@
 name: signal-desktop
 matrix:
   versions:
-    - 7.6.0
     - 7.7.0
     - 7.8.0
     - 7.9.0
@@ -51,6 +50,7 @@ matrix:
     - 7.46.1
     - 7.47.0
     - 7.49.0
+    - 7.50.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
@@ -115,3 +115,6 @@
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.14.0/teams-for-linux_1.14.0_amd64.deb
   sha256: 30001b25441e1213f18fb98f3d0cc5572b4a468358fb46e70ac4cc6e303a080e
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.0.8/teams-for-linux_2.0.8_amd64.deb
+  sha256: a59ce79a3f3ef48590131e09b82a1dfe37330d908759c6f1d8ee1aa9476e8c42
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/desktop/teams-for-linux/ops2deb.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.yml
@@ -40,6 +40,7 @@ matrix:
     - 1.13.0
     - 1.13.1
     - 1.14.0
+    - 2.0.8
 homepage: https://github.com/IsmaelMartinez/teams-for-linux/
 summary: unofficial Microsoft Teams for Linux client
 description: |-

--- a/blueprints/dev/github-cli/ops2deb.lock.yml
+++ b/blueprints/dev/github-cli/ops2deb.lock.yml
@@ -10,15 +10,6 @@
 - url: https://github.com/cli/cli/releases/download/v2.5.0/gh_2.5.0_linux_armv6.tar.gz
   sha256: 44e44829a5361957217bfd7c2c8c6dc88fc5f56a72f2e4df772e0ea551a493bd
   timestamp: 2022-02-02 23:13:50+00:00
-- url: https://github.com/cli/cli/releases/download/v2.32.0/gh_2.32.0_linux_amd64.tar.gz
-  sha256: 2e306f118a46764bc1763bacc52e7b18eeca5aa6fd59d2b5fd260f0ef3cd87ae
-  timestamp: 2023-07-11 21:16:23+00:00
-- url: https://github.com/cli/cli/releases/download/v2.32.0/gh_2.32.0_linux_arm64.tar.gz
-  sha256: 9eff1eb5d13a3fa858859bd2995077f8987a89d352548a3c116af0536f49afc0
-  timestamp: 2023-07-11 21:16:23+00:00
-- url: https://github.com/cli/cli/releases/download/v2.32.0/gh_2.32.0_linux_armv6.tar.gz
-  sha256: 77fa90e418aae717b29f11ae591c89a6eafe8a4d7661133ba9e57a5bbebb843d
-  timestamp: 2023-07-11 21:16:23+00:00
 - url: https://github.com/cli/cli/releases/download/v2.32.1/gh_2.32.1_linux_amd64.tar.gz
   sha256: 5c9a70b6411cc9774f5f4e68f9227d5d55ca0bfbd00dfc6353081c9b705c8939
   timestamp: 2023-07-27 09:16:48+00:00
@@ -460,3 +451,12 @@
 - url: https://github.com/cli/cli/releases/download/v2.69.0/gh_2.69.0_linux_armv6.tar.gz
   sha256: c53aece556064d765cff051960b2d31413ae55717db36a2d094452ddcfb41f09
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/cli/cli/releases/download/v2.70.0/gh_2.70.0_linux_amd64.tar.gz
+  sha256: 664b70c80aaddf7b45c4df890324d3876762e630cffb429971791b8e2fb2e04b
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/cli/cli/releases/download/v2.70.0/gh_2.70.0_linux_arm64.tar.gz
+  sha256: 15518ce7455beb67e91928cc0b5d8431d491afeced45d173929d29f2647810ac
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/cli/cli/releases/download/v2.70.0/gh_2.70.0_linux_armv6.tar.gz
+  sha256: b5845b9e40a65bcc2bba8950f6be2cc312c4648c293a50881e42bd17e1553b74
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/dev/github-cli/ops2deb.yml
+++ b/blueprints/dev/github-cli/ops2deb.yml
@@ -38,7 +38,6 @@
       - arm64
       - armhf
     versions:
-      - 2.32.0
       - 2.32.1
       - 2.33.0
       - 2.34.0
@@ -88,6 +87,7 @@
       - 2.67.0
       - 2.68.1
       - 2.69.0
+      - 2.70.0
   homepage: https://github.com/cli/cli
   summary: GitHub on the command line
   description: |-

--- a/blueprints/dev/gitoxide/ops2deb.lock.yml
+++ b/blueprints/dev/gitoxide/ops2deb.lock.yml
@@ -25,3 +25,6 @@
 - url: https://github.com/Byron/gitoxide/releases/download/v0.41.0/gitoxide-max-pure-v0.41.0-x86_64-unknown-linux-musl.tar.gz
   sha256: e199a03db2d9a94fd0a28d3abe54294913ed62ab4e0b19f24b130e256df83a86
   timestamp: 2025-01-28 09:07:23+00:00
+- url: https://github.com/Byron/gitoxide/releases/download/v0.42.0/gitoxide-max-pure-v0.42.0-x86_64-unknown-linux-musl.tar.gz
+  sha256: 72bec56a1dcef03e97673679961184a18c24cefbfcddd5cf4e0d320d0d2c4e76
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/dev/gitoxide/ops2deb.yml
+++ b/blueprints/dev/gitoxide/ops2deb.yml
@@ -10,6 +10,7 @@ matrix:
     - 0.39.0
     - 0.40.0
     - 0.41.0
+    - 0.42.0
 homepage: https://github.com/Byron/gitoxide
 summary: idiomatic, lean, fast & safe pure Rust implementation of Git
 description: |-

--- a/blueprints/dev/hugo/ops2deb.lock.yml
+++ b/blueprints/dev/hugo/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-amd64.tar.gz
-  sha256: 55f5a5f6a4c923457b2ed4e2b00c251eabfe43d8d4afbe2ada92d9759c5e0410
-  timestamp: 2024-03-20 12:08:09+00:00
-- url: https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_linux-arm64.tar.gz
-  sha256: 5afde01bcff49d7a22b96844c329f6cbb175d8a30456e17ef47df0c3e6f60135
-  timestamp: 2024-03-20 12:08:09+00:00
 - url: https://github.com/gohugoio/hugo/releases/download/v0.125.0/hugo_extended_0.125.0_linux-amd64.tar.gz
   sha256: 73d9e96248fa59d285b179da02008c5f8dceda26445e8946289cf61e9bc20c39
   timestamp: 2024-04-16 18:06:25+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/gohugoio/hugo/releases/download/v0.145.0/hugo_extended_0.145.0_linux-arm64.tar.gz
   sha256: ec6543e43efc96dd40aacb578413bb3d0532a3e8898d49edff6528f06333866e
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.146.5/hugo_extended_0.146.5_linux-amd64.tar.gz
+  sha256: eb89d48b2eb4645b8fe1c80b01845504eaa8f074a38122fc8b860edfa71d15f1
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.146.5/hugo_extended_0.146.5_linux-arm64.tar.gz
+  sha256: 8318167ced2f2a40338a960372865f6f167f2d6d5a37abc68b804d0de78b4404
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/dev/hugo/ops2deb.yml
+++ b/blueprints/dev/hugo/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 0.124.1
     - 0.125.0
     - 0.125.1
     - 0.125.2
@@ -54,6 +53,7 @@ matrix:
     - 0.143.1
     - 0.144.2
     - 0.145.0
+    - 0.146.5
 revision: "2"
 homepage: https://gohugo.io/
 summary: fast and flexible Static Site Generator

--- a/blueprints/dev/lazygit/ops2deb.lock.yml
+++ b/blueprints/dev/lazygit/ops2deb.lock.yml
@@ -34,3 +34,9 @@
 - url: https://github.com/jesseduffield/lazygit/releases/download/v0.48.0/lazygit_0.48.0_Linux_x86_64.tar.gz
   sha256: 291722c643a10805de3bd7b58f51d5275878269aeadb046709708f8683f558d7
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/jesseduffield/lazygit/releases/download/v0.49.0/lazygit_0.49.0_Linux_arm64.tar.gz
+  sha256: 68574882593b23f79a32b52ce2bc40c9a08b0b8f9e1b2240243fe69388ed7f47
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/jesseduffield/lazygit/releases/download/v0.49.0/lazygit_0.49.0_Linux_x86_64.tar.gz
+  sha256: ae9c9a3fcea9cdaf6511a7ca0040210cc71ab481fc773e53737cbfe92da974ce
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/dev/lazygit/ops2deb.yml
+++ b/blueprints/dev/lazygit/ops2deb.yml
@@ -10,6 +10,7 @@ matrix:
     - 0.45.2
     - 0.46.0
     - 0.48.0
+    - 0.49.0
 homepage: https://github.com/jesseduffield/lazygit
 summary: a lazier way to manage everything git
 description: A simple terminal UI for git, written in Go with the gocui library.

--- a/blueprints/dev/pdm/ops2deb.lock.yml
+++ b/blueprints/dev/pdm/ops2deb.lock.yml
@@ -130,3 +130,6 @@
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.23.0.tar.gz
   sha256: e67f6463e836eed9e85dfc55068c178c8ad7a6a8cea512622b437fd5f52c7ce0
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.23.1.tar.gz
+  sha256: f58e57062fce7beae68d5fbba5e5ff56a0877866d1bc561ec871327c8dd52857
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/dev/pdm/ops2deb.yml
+++ b/blueprints/dev/pdm/ops2deb.yml
@@ -45,6 +45,7 @@ matrix:
     - 2.22.3
     - 2.22.4
     - 2.23.0
+    - 2.23.1
 homepage: https://pdm.fming.dev/
 summary: modern Python package and dependency manager supporting the latest PEP standards
 description: |-

--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.12.zip
-  sha256: 85c04ac44231a1305ebe838e14faeca0b4e3751bd3d15d9aaee4acd38606ac62
-  timestamp: 2023-01-30 10:19:06+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.13.zip
   sha256: 250208d8e6826ade84c9cf84c54d60fefcaf06dd679dd74f3250d5b7fdff71b4
   timestamp: 2023-02-15 07:25:57+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.5.4.zip
   sha256: 26f5745a4c36ca79711b9d8321be4e81a27c84a54fb7feec4ce9ae4239c23937
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.5.5.zip
+  sha256: a77a8cabc576f6693b120f4fbdc743259ee3822a7b2b1e4fa80faf1608ba3f60
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.3.12
       - 2.3.13
       - 2.3.14
       - 2.3.15
@@ -73,6 +72,7 @@
       - 2.5.2
       - 2.5.3
       - 2.5.4
+      - 2.5.5
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -475,3 +475,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.6.12/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: eec3ccf53616e00905279a302bc043451bd96ca71a159a2ac3199452ac914c26
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.14/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: 94e22c4be44d205def456427639ca5ca1c1a9e29acc31808a7b28fdd5dcf7f17
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.14/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: d73b09f23c7056b3b5318edf670ebc8d2eac5adfdd4f4ee46796723298f21e18
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.14/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 0aaf451c391d3913823bfb8ed354b446dcfd0553a32ed8266611e4181c61fd51
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -90,6 +90,7 @@
       - 0.6.8
       - 0.6.9
       - 0.6.12
+      - 0.6.14
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/devops/argocd/ops2deb.lock.yml
+++ b/blueprints/devops/argocd/ops2deb.lock.yml
@@ -184,3 +184,9 @@
 - url: https://github.com/argoproj/argo-cd/releases/download/v2.14.9/argocd-linux-arm64
   sha256: ff044f62c31b70f97e7ebffb75c7a8b0acc3301c375fabeeee11fbfb7946564f
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v2.14.10/argocd-linux-amd64
+  sha256: d1750274a336f0a090abf196a832cee14cb9f1c2fc3d20d80b0dbfeff83550fa
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v2.14.10/argocd-linux-arm64
+  sha256: d9406019f11f3df4d1287adc86b1e4218feb1fbee018c30f14210568eb7f9ce0
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/argocd/ops2deb.yml
+++ b/blueprints/devops/argocd/ops2deb.yml
@@ -35,6 +35,7 @@ matrix:
     - 2.14.5
     - 2.14.7
     - 2.14.9
+    - 2.14.10
 homepage: https://github.com/argoproj/argo-cd
 summary: continuous delivery tool for Kubernetes
 description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.

--- a/blueprints/devops/aws-iam-authenticator/ops2deb.lock.yml
+++ b/blueprints/devops/aws-iam-authenticator/ops2deb.lock.yml
@@ -106,3 +106,9 @@
 - url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.30/aws-iam-authenticator_0.6.30_linux_arm64
   sha256: f6621ca85dc5c257a53968a2b9fd67bb4e15ca88fcb05eaea96dbb73fd1d991d
   timestamp: 2025-02-06 03:09:32+00:00
+- url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.31/aws-iam-authenticator_0.6.31_linux_amd64
+  sha256: a0a828913d71305792eeca4ff71f2abce6d9fcff7b7612b765f760012aad4727
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.31/aws-iam-authenticator_0.6.31_linux_arm64
+  sha256: a38e26787110fecc1104d346a23f9864070f7c4a29aea09d41e3a280d2bde53c
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/aws-iam-authenticator/ops2deb.yml
+++ b/blueprints/devops/aws-iam-authenticator/ops2deb.yml
@@ -22,6 +22,7 @@ matrix:
     - 0.6.28
     - 0.6.29
     - 0.6.30
+    - 0.6.31
 homepage: https://github.com/kubernetes-sigs/aws-iam-authenticator
 summary: Kubernetes authentication using AWS IAM
 description: A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster.

--- a/blueprints/devops/cilium/ops2deb.lock.yml
+++ b/blueprints/devops/cilium/ops2deb.lock.yml
@@ -58,3 +58,9 @@
 - url: https://github.com/cilium/cilium-cli/releases/download/v0.18.2/cilium-linux-arm64.tar.gz
   sha256: db3fae09ba005d6d345858655777bb5c972c9c841f98dc3fad3455d3084dba61
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/cilium/cilium-cli/releases/download/v0.18.3/cilium-linux-amd64.tar.gz
+  sha256: 5fe565f3b98b5846b867319aa76bc057fca37894d80db56edc20e4e809d10b25
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/cilium/cilium-cli/releases/download/v0.18.3/cilium-linux-arm64.tar.gz
+  sha256: e0588268fc9ab6e0b7a363c4e15ecf69ed2a4cade956ab272745262e456f0e54
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/cilium/ops2deb.yml
+++ b/blueprints/devops/cilium/ops2deb.yml
@@ -14,6 +14,7 @@ matrix:
     - 0.16.24
     - 0.17.0
     - 0.18.2
+    - 0.18.3
 homepage: https://github.com/cilium/cilium-cli
 summary: CLI for interacting with the local Cilium Agent
 description: CLI to install, manage & troubleshoot Kubernetes clusters running Cilium.

--- a/blueprints/devops/dapr/ops2deb.lock.yml
+++ b/blueprints/devops/dapr/ops2deb.lock.yml
@@ -28,3 +28,9 @@
 - url: https://github.com/dapr/cli/releases/download/v1.15.0/dapr_linux_arm64.tar.gz
   sha256: e76783d13544480633c1c45f11ef5a15209193e3c34fb9cc556bd1c0a685c068
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/dapr/cli/releases/download/v1.15.1/dapr_linux_amd64.tar.gz
+  sha256: 4680ad905ebe2b709e2139b1bda4e8d7ab1beedd601a4240f92c9e8a4a4296ad
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/dapr/cli/releases/download/v1.15.1/dapr_linux_arm64.tar.gz
+  sha256: d40248c9183a73104bccf850902a7cae59ba81a27e01bce1490eda2958962bd2
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/dapr/ops2deb.yml
+++ b/blueprints/devops/dapr/ops2deb.yml
@@ -9,6 +9,7 @@ matrix:
     - 1.14.0
     - 1.14.1
     - 1.15.0
+    - 1.15.1
 homepage: https://dapr.io/
 summary: command-line tools for Dapr.
 description: |-

--- a/blueprints/devops/docker-compose/ops2deb.lock.yml
+++ b/blueprints/devops/docker-compose/ops2deb.lock.yml
@@ -1,15 +1,6 @@
 - url: https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64
   sha256: f3f10cf3dbb8107e9ba2ea5f23c1d2159ff7321d16f0a23051d68d8e2547b323
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/docker/compose/releases/download/v2.19.0/docker-compose-linux-aarch64
-  sha256: c963c6d913a57e0571104ecb8f8ba0502516eafd7b784b5abc4a0d96ebb54d04
-  timestamp: 2023-06-21 12:34:20+00:00
-- url: https://github.com/docker/compose/releases/download/v2.19.0/docker-compose-linux-armv7
-  sha256: 0c0e3af9ae2b833e09b303899ef3330d40c09ec13a4def861c22b3d0a7ec8540
-  timestamp: 2023-06-21 12:34:20+00:00
-- url: https://github.com/docker/compose/releases/download/v2.19.0/docker-compose-linux-x86_64
-  sha256: 34e3b754d13eab683222f67827e20f640dfe0630b3b786c49a9de3f7fc7400a6
-  timestamp: 2023-06-21 12:34:20+00:00
 - url: https://github.com/docker/compose/releases/download/v2.19.1/docker-compose-linux-aarch64
   sha256: 35db0e5207c66e002bfde3cab84e907aa7e552812803bebebf990487729eb2bf
   timestamp: 2023-06-30 01:47:38+00:00
@@ -451,3 +442,12 @@
 - url: https://github.com/docker/compose/releases/download/v2.34.0/docker-compose-linux-x86_64
   sha256: 94a416c6f2836a0a1ba5eb3feb00f2e700a9d98311f062c4c61494ccbf3cd457
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/docker/compose/releases/download/v2.35.0/docker-compose-linux-aarch64
+  sha256: a08457d837d5d4ed7c079f0721dc51ef3f21ce2d9654a6abd44944b74d975cd2
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/docker/compose/releases/download/v2.35.0/docker-compose-linux-armv7
+  sha256: 9f9831ef951fbb1eaff7dfd17e4ca2e3522a9e66670e81075b68a25fbbfc0ee2
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/docker/compose/releases/download/v2.35.0/docker-compose-linux-x86_64
+  sha256: dba1915cf2f282527f5df0cd7a94b9503047ed200317801853abe8f22c8cd493
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/docker-compose/ops2deb.yml
+++ b/blueprints/devops/docker-compose/ops2deb.yml
@@ -18,7 +18,6 @@
       - arm64
       - armhf
     versions:
-      - 2.19.0
       - 2.19.1
       - 2.20.0
       - 2.20.1
@@ -68,6 +67,7 @@
       - 2.33.0
       - 2.33.1
       - 2.34.0
+      - 2.35.0
   homepage: https://docs.docker.com/compose
   summary: lightweight development environments using Docker
   description: |-

--- a/blueprints/devops/helm/ops2deb.lock.yml
+++ b/blueprints/devops/helm/ops2deb.lock.yml
@@ -274,3 +274,9 @@
 - url: https://get.helm.sh/helm-v3.17.2-linux-arm.tar.gz
   sha256: 0b13ec8580dd5498b5a2d7cb34146e098049f59500a266db1bb98f59649eb90a
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://get.helm.sh/helm-v3.17.3-linux-amd64.tar.gz
+  sha256: ee88b3c851ae6466a3de507f7be73fe94d54cbf2987cbaa3d1a3832ea331f2cd
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://get.helm.sh/helm-v3.17.3-linux-arm.tar.gz
+  sha256: 60d76d1e12d3e058a9e9a8209eff748a6fab5948028a1f0860f48e141243d33d
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/helm/ops2deb.yml
+++ b/blueprints/devops/helm/ops2deb.yml
@@ -79,6 +79,7 @@
       - 3.17.0
       - 3.17.1
       - 3.17.2
+      - 3.17.3
   homepage: https://helm.sh
   summary: Kubernetes package manager
   description: |-

--- a/blueprints/devops/istioctl/ops2deb.lock.yml
+++ b/blueprints/devops/istioctl/ops2deb.lock.yml
@@ -448,3 +448,12 @@
 - url: https://github.com/istio/istio/releases/download/1.25.1/istio-1.25.1-linux-armv7.tar.gz
   sha256: a2b066150c4442314ea05541cc4407c77b4b33d218cf6043cdb6a716796bfa8e
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-amd64.tar.gz
+  sha256: 2a8bc831fe6ceeb02df31651734d06e0954006a8f4780f40d8b5ad60f34471fd
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-arm64.tar.gz
+  sha256: 595687b7d3337c6d61e432d1d08e1eee16da5db3932cadf4a2eaecf1317293e3
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-armv7.tar.gz
+  sha256: 3723ed9443cdf14dbd26aba85b7db8209b9ff24d64ef8c167a106497308e301b
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/istioctl/ops2deb.yml
+++ b/blueprints/devops/istioctl/ops2deb.yml
@@ -123,6 +123,7 @@
       - 1.24.3
       - 1.25.0
       - 1.25.1
+      - 1.25.2
   homepage: https://istio.io
   summary: command-line interface for Istio
   description: Istio is an open platform to connect, manage, and secure microservices.

--- a/blueprints/devops/jfrog-cli/ops2deb.lock.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.lock.yml
@@ -214,3 +214,9 @@
 - url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.74.1/jfrog-cli-linux-arm64/jf
   sha256: 14e77c1d3c55f3ac9b81633950d7312469e5b616d6b69da5c3397868ac199947
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.75.0/jfrog-cli-linux-amd64/jf
+  sha256: 06d44566775df66435f9b15125cebc6535778798f6ba4edc85bae7042dd871fa
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.75.0/jfrog-cli-linux-arm64/jf
+  sha256: f2f1e68f1e76ef74dddb7dbd855f5e2ab264e8035d91d9883c2ff39849ad5a49
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/jfrog-cli/ops2deb.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.yml
@@ -40,6 +40,7 @@ matrix:
     - 2.73.3
     - 2.74.0
     - 2.74.1
+    - 2.75.0
 homepage: https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli
 summary: client that provides a simple interface that automates access to the JFrog
   products

--- a/blueprints/devops/k9s/ops2deb.lock.yml
+++ b/blueprints/devops/k9s/ops2deb.lock.yml
@@ -394,3 +394,12 @@
 - url: https://github.com/derailed/k9s/releases/download/v0.40.10/k9s_Linux_armv7.tar.gz
   sha256: 140f32372777a2b7b429c67cd902d928287e1c8230af0de4f6a9c9d5420c1b07
   timestamp: 2025-03-18 03:17:18+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.3/k9s_Linux_amd64.tar.gz
+  sha256: dea642a914d31ab1e11e8027326587dcaa11e697c4d17713fbc8019f95415bbd
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.3/k9s_Linux_arm64.tar.gz
+  sha256: 6d8a272742257e6dae7a4903bb571a738fcdfddd207a047fec1c5c65ef8bd553
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.3/k9s_Linux_armv7.tar.gz
+  sha256: cdf5889aa61b303d3277329f80ce9b188e92cc44cffb05eda57363834c67853e
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/k9s/ops2deb.yml
+++ b/blueprints/devops/k9s/ops2deb.yml
@@ -87,6 +87,7 @@
       - 0.40.5
       - 0.40.8
       - 0.40.10
+      - 0.50.3
   homepage: https://k9scli.io
   summary: manage your Kubernetes clusters with style
   description: |-

--- a/blueprints/devops/linkerd/ops2deb.lock.yml
+++ b/blueprints/devops/linkerd/ops2deb.lock.yml
@@ -415,3 +415,12 @@
 - url: https://github.com/linkerd/linkerd2/releases/download/edge-25.4.1/linkerd2-cli-edge-25.4.1-linux-arm64
   sha256: ac78a241c151cf039d2dc4b8ac3f2ebbb5a4aac84975ffdf085e519bb24f902d
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.4.2/linkerd2-cli-edge-25.4.2-linux-amd64
+  sha256: 1b9bcc9ae3c9f184ee04801662df1113d089e3a0858058e0e991dafc5293283f
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.4.2/linkerd2-cli-edge-25.4.2-linux-arm
+  sha256: 7c53ea950ba8312dd88058bf7b41fb3d075578235511de64b5af3eb7b96ed454
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.4.2/linkerd2-cli-edge-25.4.2-linux-arm64
+  sha256: 9f7d0c889c8cc137e38c4b66c0b30742008f489f5e81d4c43c6f7f80a54a2241
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/linkerd/ops2deb.yml
+++ b/blueprints/devops/linkerd/ops2deb.yml
@@ -64,6 +64,7 @@
       - 23.12.3
       - 23.12.4
       - 25.4.1
+      - 25.4.2
   homepage: https://linkerd.io
   summary: ultralight service mesh for Kubernetes
   description: |-

--- a/blueprints/devops/logcli/ops2deb.lock.yml
+++ b/blueprints/devops/logcli/ops2deb.lock.yml
@@ -295,3 +295,12 @@
 - url: https://github.com/grafana/loki/releases/download/v3.4.2/logcli-linux-arm64.zip
   sha256: 1d47c93eece5d8cc6136c9388f5df03e0eaf3acb173ceae1df8d17fe6177e727
   timestamp: 2025-02-14 15:06:26+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.4.3/logcli-linux-amd64.zip
+  sha256: 1a23d9d91eacc5666f233397f248058d1389756ba91797af264f85b8d58feded
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.4.3/logcli-linux-arm.zip
+  sha256: 4fca5f2020d51f5a458a302f2fbcb2cd6f9fd10e19d947a40cd9983d4525f374
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.4.3/logcli-linux-arm64.zip
+  sha256: 7b03b828ed850afd698f1539331bf2c4d344005e1940b3579de9ca4c5e561091
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/logcli/ops2deb.yml
+++ b/blueprints/devops/logcli/ops2deb.yml
@@ -38,6 +38,7 @@ matrix:
     - 3.4.0
     - 3.4.1
     - 3.4.2
+    - 3.4.3
 homepage: https://github.com/grafana/loki
 summary: command-line interface for loki
 description: It facilitates running LogQL queries against a Loki instance.

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,15 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.104.0/mirrord_linux_aarch64.zip
-  sha256: 423f4851c4be9972cb1a6f912b4c55c73991505172f66ee7ed84013a871d311a
-  timestamp: 2024-06-06 18:06:37+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.104.0/mirrord_linux_x86_64.zip
-  sha256: fef27456edbdd27055bc5b2e972f5ece8324d905d99e2a567c224a7651985e11
-  timestamp: 2024-06-06 18:06:37+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.105.0/mirrord_linux_aarch64.zip
-  sha256: 0feedf37d917edcdd009b7842477e79def36473f37d8afeba89cda4666019f68
-  timestamp: 2024-06-12 12:08:57+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.105.0/mirrord_linux_x86_64.zip
-  sha256: c75df9a1f98b6b208fe5a648c74453908b271d1bf642d8203d9ca95e713ddc9f
-  timestamp: 2024-06-12 12:08:57+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.106.0/mirrord_linux_aarch64.zip
   sha256: 7132d9de773f74551bd0af33a0cdb68e6de758b5724457f25458247997a64730
   timestamp: 2024-06-18 15:05:55+00:00
@@ -304,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.137.0/mirrord_linux_x86_64.zip
   sha256: c8d4c92dd69d99941425d9250b1f6ecc35823ba4a445ab030237c301b23f022e
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.138.0/mirrord_linux_aarch64.zip
+  sha256: 184ba6b1c0b71a6be6d318ef0a6ee4c772fd1586a8ae0664b20bd28c8bdc0da6
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.138.0/mirrord_linux_x86_64.zip
+  sha256: 9999cdd57f824f09a0ec46e53ebe85ed7a95e578cde11a37a149bd2c57ef9542
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,8 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.104.0
-    - 3.105.0
     - 3.106.0
     - 3.107.0
     - 3.108.0
@@ -55,6 +53,7 @@ matrix:
     - 3.134.2
     - 3.136.0
     - 3.137.0
+    - 3.138.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-

--- a/blueprints/devops/natscli/ops2deb.lock.yml
+++ b/blueprints/devops/natscli/ops2deb.lock.yml
@@ -94,3 +94,12 @@
 - url: https://github.com/nats-io/natscli/releases/download/v0.2.0/nats-0.2.0-linux-arm7.zip
   sha256: ce72aadf626476900fd0e34d98ee01de8b029e059750454b5610041dc5859afc
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.2/nats-0.2.2-linux-amd64.zip
+  sha256: 6e14ce8f370ba93ee73182a323457bf6623ce94ed33c1529640f694c39dbc5dd
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.2/nats-0.2.2-linux-arm64.zip
+  sha256: 20a0cf38397581f4bab9be0cd3e262442fb749e08c1937f2fae776106ca071fc
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.2/nats-0.2.2-linux-arm7.zip
+  sha256: a7c0589889938982d5f5c33cade289558a74c01284f1f0f0c97e27a5f9a58870
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/natscli/ops2deb.yml
+++ b/blueprints/devops/natscli/ops2deb.yml
@@ -42,6 +42,7 @@
       - 0.1.5
       - 0.1.6
       - 0.2.0
+      - 0.2.2
   homepage: https://github.com/nats-io/natscli
   summary: command-line interface for NATS
   description: |-

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -112,3 +112,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.7/openshift-client-linux.tar.gz
   sha256: 49e539258eb402b2b739876dbf64c8b60729d9a06df5396e8355df0fffda7257
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.9/openshift-client-linux-arm64.tar.gz
+  sha256: dbd838412705374b3385a81d0c071bac066da1bd965e660f5fff43a169e5f046
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.9/openshift-client-linux.tar.gz
+  sha256: 1e2d73c870756e3940dcb6c1112c7aa7f702a89cfdb992d11079ac852b4ea05c
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -22,6 +22,7 @@ matrix:
     - 4.18.5
     - 4.18.6
     - 4.18.7
+    - 4.18.9
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/olivetin/ops2deb.lock.yml
+++ b/blueprints/devops/olivetin/ops2deb.lock.yml
@@ -241,3 +241,12 @@
 - url: https://github.com/OliveTin/OliveTin/releases/download/2025.3.28/OliveTin_linux_armv7.deb
   sha256: 39939459ca349b87e4e64f18991bdd466f4043f257fbe39a6113b3b4da1e5211
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/OliveTin/OliveTin/releases/download/2025.4.14/OliveTin_linux_amd64.deb
+  sha256: 846a2ba6fd478b94d3573ffc8ddeb3a5276628e498254019f95e0bdf80baaede
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/OliveTin/OliveTin/releases/download/2025.4.14/OliveTin_linux_arm64.deb
+  sha256: 8409829fbc0ee3a13ece9c8003b4ae1b6098e1dc066ca13fee7835191b0e61af
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/OliveTin/OliveTin/releases/download/2025.4.14/OliveTin_linux_armv7.deb
+  sha256: 941de7a28064531b27757d49df9386706b1e9d97389303f9fa0ec6bf58ac3da6
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/olivetin/ops2deb.yml
+++ b/blueprints/devops/olivetin/ops2deb.yml
@@ -32,6 +32,7 @@ matrix:
     - 2024.12.11
     - 2025.2.19
     - 2025.3.28
+    - 2025.4.14
 revision: "2"
 summary: safe and simple access to predefined shell commands from a web interface
 description: |-

--- a/blueprints/devops/resticprofile/ops2deb.lock.yml
+++ b/blueprints/devops/resticprofile/ops2deb.lock.yml
@@ -61,3 +61,12 @@
 - url: https://github.com/creativeprojects/resticprofile/releases/download/v0.29.1/resticprofile_0.29.1_linux_armv7.tar.gz
   sha256: 9c25e8d94c3880be10ce3a6b46d33c3cc476569173b470b9615c5bc099630621
   timestamp: 2025-02-06 18:08:14+00:00
+- url: https://github.com/creativeprojects/resticprofile/releases/download/v0.30.0/resticprofile_0.30.0_linux_amd64.tar.gz
+  sha256: 088c16d74bb2c5079ef14ccd0f48a03eb0c59be3f247813eff6bfb8e91978a3f
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/creativeprojects/resticprofile/releases/download/v0.30.0/resticprofile_0.30.0_linux_arm64.tar.gz
+  sha256: 46657d5400feeea0d16650114ed2397434c2813fa2ac9bc5cc1d097d8623ce10
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/creativeprojects/resticprofile/releases/download/v0.30.0/resticprofile_0.30.0_linux_armv7.tar.gz
+  sha256: eb27a3e984a2d25c0c7bd758e8e62ab833a7797a9816a0015107a41d771eb4ae
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/resticprofile/ops2deb.yml
+++ b/blueprints/devops/resticprofile/ops2deb.yml
@@ -12,6 +12,7 @@ matrix:
     - 0.28.1
     - 0.29.0
     - 0.29.1
+    - 0.30.0
 homepage: https://creativeprojects.github.io/resticprofile/
 summary: configuration profiles manager for restic backup
 description: |-

--- a/blueprints/devops/rpk/ops2deb.lock.yml
+++ b/blueprints/devops/rpk/ops2deb.lock.yml
@@ -292,3 +292,9 @@
 - url: https://github.com/redpanda-data/redpanda/releases/download/v24.3.9/rpk-linux-arm64.zip
   sha256: 2c9262d0204e219c0d225e1614aebc7286ee32113987edc835ab24dca2a4fa54
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.1/rpk-linux-amd64.zip
+  sha256: 1efb2799c9ed752f387daecc892a7c632a9c728aa70136fcee9cb64b124c81cb
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.1/rpk-linux-arm64.zip
+  sha256: 34bde67e5772746884fcc88e6ba41d561ccb1d088b3cc04a7d65394b47fcf1af
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/rpk/ops2deb.yml
+++ b/blueprints/devops/rpk/ops2deb.yml
@@ -53,6 +53,7 @@ matrix:
     - 24.3.7
     - 24.3.8
     - 24.3.9
+    - 25.1.1
 homepage: https://redpanda.com/
 summary: interact with your Redpanda clusters
 description: |-

--- a/blueprints/devops/scw/ops2deb.lock.yml
+++ b/blueprints/devops/scw/ops2deb.lock.yml
@@ -232,3 +232,9 @@
 - url: https://github.com/scaleway/scaleway-cli/releases/download/v2.38.0/scaleway-cli_2.38.0_linux_arm64
   sha256: 2b4760f0ce16acaec467ee19d9e417e899ed87eb8a2ae4f69bc2fc4aa5f85fa4
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/scaleway/scaleway-cli/releases/download/v2.39.0/scaleway-cli_2.39.0_linux_amd64
+  sha256: e2edbba6f92d542e0660ec0eac104c1fe0f16314288fd89d471994df966c9303
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/scaleway/scaleway-cli/releases/download/v2.39.0/scaleway-cli_2.39.0_linux_arm64
+  sha256: 3f850d57bc529476c5f4e2923a7843ce1e8de5eb38f34145b3795f631cd2a997
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/scw/ops2deb.yml
+++ b/blueprints/devops/scw/ops2deb.yml
@@ -65,6 +65,7 @@
       - 2.36.0
       - 2.37.0
       - 2.38.0
+      - 2.39.0
   homepage: https://github.com/scaleway/scaleway-cli
   summary: command-line interface for Scaleway
   description: |-

--- a/blueprints/devops/skaffold/ops2deb.lock.yml
+++ b/blueprints/devops/skaffold/ops2deb.lock.yml
@@ -250,3 +250,9 @@
 - url: https://github.com/GoogleContainerTools/skaffold/releases/download/v2.14.2/skaffold-linux-arm64
   sha256: 7e4a2756e010224b7ec12023269b71ee863e9fff9d136eb8179e556436774f34
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/GoogleContainerTools/skaffold/releases/download/v2.15.0/skaffold-linux-amd64
+  sha256: 089d45bca89437ef47739cf01f1d50c50855ccb483bf18b43a8303d12005c8c5
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/GoogleContainerTools/skaffold/releases/download/v2.15.0/skaffold-linux-arm64
+  sha256: f50dbef0386b0f8211cfaa94ee0f90538f852d21e578ee84f8d674006798af03
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/skaffold/ops2deb.yml
+++ b/blueprints/devops/skaffold/ops2deb.yml
@@ -83,6 +83,7 @@
       - 2.14.0
       - 2.14.1
       - 2.14.2
+      - 2.15.0
   homepage: https://skaffold.dev/
   summary: easy and repeatable Kubernetes development
   description: |-

--- a/blueprints/devops/terraform-docs/ops2deb.lock.yml
+++ b/blueprints/devops/terraform-docs/ops2deb.lock.yml
@@ -25,3 +25,9 @@
 - url: https://github.com/terraform-docs/terraform-docs/releases/download/v0.19.0/terraform-docs-v0.19.0-linux-arm64.tar.gz
   sha256: ebda7dda3a1f678e9e3ef2f091c97b43f34a5a1b52fb9b1d3f44a003f481e8b5
   timestamp: 2024-09-18 21:05:54+00:00
+- url: https://github.com/terraform-docs/terraform-docs/releases/download/v0.20.0/terraform-docs-v0.20.0-linux-arm.tar.gz
+  sha256: e7312d59357a83cb245ef73062189e0d4f89b7738cd62c51802592fbfae301c2
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/terraform-docs/terraform-docs/releases/download/v0.20.0/terraform-docs-v0.20.0-linux-arm64.tar.gz
+  sha256: 371b4ed983781d1efdd8f7de06264baac41b1d80927f7fd718c405a303d863a0
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/terraform-docs/ops2deb.yml
+++ b/blueprints/devops/terraform-docs/ops2deb.yml
@@ -19,6 +19,7 @@
       - 0.17.0
       - 0.18.0
       - 0.19.0
+      - 0.20.0
   homepage: https://terraform-docs.io
   summary: generate documentation from Terraform modules in various output formats
   description: |-

--- a/blueprints/devops/terraform/ops2deb.lock.yml
+++ b/blueprints/devops/terraform/ops2deb.lock.yml
@@ -28,24 +28,6 @@
 - url: https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_arm64.zip
   sha256: 2f72982008c52d2d57294ea50794d7c6ae45d2948e08598bfec3e492bce8d96e
   timestamp: 2022-03-02 22:16:55+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.0/terraform_1.4.0_linux_amd64.zip
-  sha256: 5da60da508d6d1941ffa8b9216147456a16bbff6db7622ae9ad01d314cbdd188
-  timestamp: 2023-03-08 18:25:12+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.0/terraform_1.4.0_linux_arm.zip
-  sha256: e414df694001031fe530e05f19ec0fd0b8f115a3898149ee30226bb367da2f35
-  timestamp: 2023-03-08 18:25:12+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.0/terraform_1.4.0_linux_arm64.zip
-  sha256: 33e0f4f0b75f507fc19012111de008308df343153cd6a3992507f4566c0bb723
-  timestamp: 2023-03-08 18:25:12+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.1/terraform_1.4.1_linux_amd64.zip
-  sha256: 9e9f3e6752168dea8ecb3643ea9c18c65d5a52acc06c22453ebc4e3fc2d34421
-  timestamp: 2023-03-15 15:20:47+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.1/terraform_1.4.1_linux_arm.zip
-  sha256: 04deec30914bc10fedb7f9e3aa430d6bd58c1449378b84925654af5122aac238
-  timestamp: 2023-03-15 15:20:47+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.1/terraform_1.4.1_linux_arm64.zip
-  sha256: 53322cc70b6e50ac1985bf26a78ffa2814789a4704880f071eaf3e67a463d6f6
-  timestamp: 2023-03-15 15:20:47+00:00
 - url: https://releases.hashicorp.com/terraform/1.4.2/terraform_1.4.2_linux_amd64.zip
   sha256: 9f3ca33d04f5335472829d1df7785115b60176d610ae6f1583343b0a2221a931
   timestamp: 2023-03-16 15:21:04+00:00
@@ -487,3 +469,12 @@
 - url: https://releases.hashicorp.com/terraform/1.11.3/terraform_1.11.3_linux_arm64.zip
   sha256: d685953bec501c0acda13319f34dddaadf33a8f553c85533531d3c7d5f84604a
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://releases.hashicorp.com/terraform/1.11.4/terraform_1.11.4_linux_amd64.zip
+  sha256: 1ce994251c00281d6845f0f268637ba50c0005657eb3cf096b92f753b42ef4dc
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://releases.hashicorp.com/terraform/1.11.4/terraform_1.11.4_linux_arm.zip
+  sha256: 3cf072a049ab0178e9cbec47a14712ba7f38cc8ef061f3a7c0ff57b83d320edd
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://releases.hashicorp.com/terraform/1.11.4/terraform_1.11.4_linux_arm64.zip
+  sha256: a43d1d0da9b9bab214a8305a39db0e40869572594ccf50c416a7756499143633
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/terraform/ops2deb.yml
+++ b/blueprints/devops/terraform/ops2deb.yml
@@ -40,8 +40,6 @@
       - arm64
       - armhf
     versions:
-      - 1.4.0
-      - 1.4.1
       - 1.4.2
       - 1.4.3
       - 1.4.4
@@ -91,6 +89,7 @@
       - 1.10.5
       - 1.11.2
       - 1.11.3
+      - 1.11.4
   homepage: https://www.terraform.io
   summary: tool for building, changing, and versioning infrastructure safely
   description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,18 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.3/terragrunt_linux_amd64
-  sha256: 7968df7745fded0654c36cd8f8d41c73ca28eab8b84fb1a7add78fd3002c804b
-  timestamp: 2024-10-16 18:08:00+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.3/terragrunt_linux_arm64
-  sha256: 2cdcb7b4199b078e0e466fa13a4ad2fdb621d4a5f520b12b04fcf9663b1eb01c
-  timestamp: 2024-10-16 18:08:00+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.4/terragrunt_linux_amd64
-  sha256: 5cb2e660005fbe3936274364c38b38e243d2017db92b329030543ced06300376
-  timestamp: 2024-10-17 15:06:16+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.4/terragrunt_linux_arm64
-  sha256: c64869a0de9b7227e117c9871a15ab111c11d00703e6b15afef75af958441b99
-  timestamp: 2024-10-17 15:06:16+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.5/terragrunt_linux_amd64
   sha256: 3372f4c5535d20c88f0b8b8b64705698f770534f8b9cbef524050dc4afb39eb5
   timestamp: 2024-10-28 15:06:57+00:00
@@ -334,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.77.6/terragrunt_linux_arm64
   sha256: a75fa41c18aca9a3fd04cf2e143278bdc34807b11befba0e888e810ddb1e13f2
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.77.17/terragrunt_linux_amd64
+  sha256: c6d9aa1eb5c8873d6986adc258cdf49abb1f9d9f0821ef4b7ff9e72809adb8cd
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.77.17/terragrunt_linux_arm64
+  sha256: 10df92b305dc282f55b2b5acea88d5cf8f87b2f30d2dca67f52ea1fa04d7685d
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,8 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.68.3
-      - 0.68.4
       - 0.68.5
       - 0.68.6
       - 0.68.7
@@ -76,6 +74,7 @@
       - 0.76.1
       - 0.76.6
       - 0.77.6
+      - 0.77.17
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/devops/velero/ops2deb.lock.yml
+++ b/blueprints/devops/velero/ops2deb.lock.yml
@@ -223,3 +223,12 @@
 - url: https://github.com/vmware-tanzu/velero/releases/download/v1.15.2/velero-v1.15.2-linux-arm64.tar.gz
   sha256: d3cf10a5f3e110efb31b003519c49a8d994abbdcc8c8ab3a2d4af23fc598c1c5
   timestamp: 2025-01-15 12:10:18+00:00
+- url: https://github.com/vmware-tanzu/velero/releases/download/v1.16.0/velero-v1.16.0-linux-amd64.tar.gz
+  sha256: b228154536d377cd6ddc271f5d6a622f1167d911ae555dd7382181d0840f6d05
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/vmware-tanzu/velero/releases/download/v1.16.0/velero-v1.16.0-linux-arm.tar.gz
+  sha256: 6ef0d42a5082f1fb6e16fb0131e8534aee87a0418fec06dda80a2392ff84a23c
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/vmware-tanzu/velero/releases/download/v1.16.0/velero-v1.16.0-linux-arm64.tar.gz
+  sha256: ac2ada82bbd08e33b951a085c4ee30e28b9343b83525c93aab468c4999e91a7e
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/devops/velero/ops2deb.yml
+++ b/blueprints/devops/velero/ops2deb.yml
@@ -73,6 +73,7 @@
       - 1.15.0
       - 1.15.1
       - 1.15.2
+      - 1.16.0
   homepage: https://velero.io
   summary: backup and migrate Kubernetes applications and their persistent volumes
   description: |-

--- a/blueprints/secops/bitwarden-cli/ops2deb.lock.yml
+++ b/blueprints/secops/bitwarden-cli/ops2deb.lock.yml
@@ -1,3 +1,6 @@
 - url: https://github.com/bitwarden/clients/releases/download/cli-v2025.2.0/bw-linux-2025.2.0.zip
   sha256: ddb69bb4266470a37e65b715ddba4d052fd20e3b191de1b25cc1fcae727f6129
   timestamp: 2025-04-03 07:04:17+00:00
+- url: https://github.com/bitwarden/clients/releases/download/cli-v2025.3.0/bw-linux-2025.3.0.zip
+  sha256: 36cbcae8212fdc91f0542035e70952e30d5e1a65bcac0820539cf5389a77e1c9
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/secops/bitwarden-cli/ops2deb.yml
+++ b/blueprints/secops/bitwarden-cli/ops2deb.yml
@@ -2,6 +2,7 @@ name: bitwarden-cli
 matrix:
   versions:
     - 2025.2.0
+    - 2025.3.0
 homepage: https://bitwarden.com/help/cli/
 summary: CLI to access and manage a bitwarden vault
 description: |-

--- a/blueprints/secops/cosign/ops2deb.lock.yml
+++ b/blueprints/secops/cosign/ops2deb.lock.yml
@@ -16,3 +16,9 @@
 - url: https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-linux-arm64
   sha256: bd0f9763bca54de88699c3656ade2f39c9a1c7a2916ff35601caf23a79be0629
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/sigstore/cosign/releases/download/v2.5.0/cosign-linux-amd64
+  sha256: 1f6c194dd0891eb345b436bb71ff9f996768355f5e0ce02dde88567029ac2188
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/sigstore/cosign/releases/download/v2.5.0/cosign-linux-arm64
+  sha256: 080a998f9878f22dafdb9ad54d5b2e2b8e7a38c53527250f9d89a6763a28d545
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/secops/cosign/ops2deb.yml
+++ b/blueprints/secops/cosign/ops2deb.yml
@@ -7,6 +7,7 @@ matrix:
     - 2.4.1
     - 2.4.2
     - 2.4.3
+    - 2.5.0
 homepage: https://www.sigstore.dev
 summary: code signing and transparency for containers and binaries
 description: |-

--- a/blueprints/secops/sops/ops2deb.lock.yml
+++ b/blueprints/secops/sops/ops2deb.lock.yml
@@ -58,3 +58,9 @@
 - url: https://github.com/getsops/sops/releases/download/v3.10.1/sops-v3.10.1.linux.arm64
   sha256: 1e82b1abc846b1e7763c9e4d817fb8f6bf740a44d9036935eff9423626a270cd
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/getsops/sops/releases/download/v3.10.2/sops-v3.10.2.linux.amd64
+  sha256: 79b0f844237bd4b0446e4dc884dbc1765fc7dedc3968f743d5949c6f2e701739
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/getsops/sops/releases/download/v3.10.2/sops-v3.10.2.linux.arm64
+  sha256: e91ddc04e6a78f5aed9e4fc347a279b539c43b74d99e6b8078e2f2f6f5b309f5
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/secops/sops/ops2deb.yml
+++ b/blueprints/secops/sops/ops2deb.yml
@@ -14,6 +14,7 @@ matrix:
     - 3.9.3
     - 3.9.4
     - 3.10.1
+    - 3.10.2
 homepage: https://age-encryption.org/
 summary: simple and flexible tool for managing secrets
 description: |-

--- a/blueprints/secops/vault/ops2deb.lock.yml
+++ b/blueprints/secops/vault/ops2deb.lock.yml
@@ -442,3 +442,12 @@
 - url: https://releases.hashicorp.com/vault/1.19.0/vault_1.19.0_linux_arm64.zip
   sha256: 252bf12d0ce1824860d6e06bd21b74b548eedd6a35225f12bf38482a4c78bef6
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://releases.hashicorp.com/vault/1.19.1/vault_1.19.1_linux_amd64.zip
+  sha256: a673933f5b02236b5e241e153c0d2fed15b47b48ad640ae886f8b3b567087a05
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://releases.hashicorp.com/vault/1.19.1/vault_1.19.1_linux_arm.zip
+  sha256: b0b56cb005916112493d5fa91cd453dfe23d873cc9dc737a0ced257c27efbcda
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://releases.hashicorp.com/vault/1.19.1/vault_1.19.1_linux_arm64.zip
+  sha256: 27561edfbc3a59936c9a892d6a130ada5a224c91862523c1aa596bfd30cd45e3
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/secops/vault/ops2deb.yml
+++ b/blueprints/secops/vault/ops2deb.yml
@@ -98,6 +98,7 @@
       - 1.18.3
       - 1.18.4
       - 1.19.0
+      - 1.19.1
   homepage: https://www.hashicorp.com/products/vault
   summary: tool to create, manage and store secrets
   description: |-

--- a/blueprints/terminal/chezmoi/ops2deb.lock.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.35.2/chezmoi_2.35.2_linux_amd64.tar.gz
-  sha256: ca8c500767dc0017caa04c530d2848321c86b2fe00e43b57d11a30fca9647316
-  timestamp: 2023-07-19 12:34:22+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.35.2/chezmoi_2.35.2_linux_arm.tar.gz
-  sha256: 907922a94e241415d66d4401ed176834a19f8a006ed3922ab490ec097035ba38
-  timestamp: 2023-07-19 12:34:22+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.35.2/chezmoi_2.35.2_linux_arm64.tar.gz
-  sha256: cff86f6d8c814d5f029b1f20b7e86cfb6521d8a48f3a52c002812dc60399b881
-  timestamp: 2023-07-19 12:34:22+00:00
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.36.0/chezmoi_2.36.0_linux_amd64.tar.gz
   sha256: 23c31e4e6979adfadb917d98b7192e3ff5b86ad2ead24da25a714b20d2618cef
   timestamp: 2023-07-28 21:13:45+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.61.0/chezmoi_2.61.0_linux_arm64.tar.gz
   sha256: 4f49fd10159de7524189d16aa7f4bec0c1222f14d0465e3bc81b2d63e37b2b2e
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.62.1/chezmoi_2.62.1_linux_amd64.tar.gz
+  sha256: 318c95ae417b6f9f4aaa003927fc1c411346ce467fda64231923cef2266282be
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.62.1/chezmoi_2.62.1_linux_arm.tar.gz
+  sha256: 7337e58884cff5f32d502d56ef0a188aebdee474cc99d4d95cd7a4243563c1d6
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.62.1/chezmoi_2.62.1_linux_arm64.tar.gz
+  sha256: ae8c784fa09ed04e826c6974d81f612b98aaad89f0f102cf833b8680b3cfaa16
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/terminal/chezmoi/ops2deb.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 2.35.2
     - 2.36.0
     - 2.36.1
     - 2.37.0
@@ -55,6 +54,7 @@ matrix:
     - 2.59.1
     - 2.60.1
     - 2.61.0
+    - 2.62.1
 homepage: https://github.com/twpayne/chezmoi
 summary: manage your dotfiles across multiple diverse machines
 description: |-

--- a/blueprints/terminal/fzf/ops2deb.lock.yml
+++ b/blueprints/terminal/fzf/ops2deb.lock.yml
@@ -34,3 +34,9 @@
 - url: https://github.com/junegunn/fzf/releases/download/v0.61.0/fzf-0.61.0-linux_arm64.tar.gz
   sha256: 760f4f62c30af0f722430af099c40af191b3fe5a55b8f850926dac406f6bf9fe
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.61.1/fzf-0.61.1-linux_amd64.tar.gz
+  sha256: f728b94bbbf7008602581fc07ea00de5dccf55a2cb2bf9fd9a35f1071b3b9f6c
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.61.1/fzf-0.61.1-linux_arm64.tar.gz
+  sha256: 25f6295f718b572ac2ff7de1ffa9e39e619f4f9587386d85bf5b647f0b98fd6b
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/terminal/fzf/ops2deb.yml
+++ b/blueprints/terminal/fzf/ops2deb.yml
@@ -10,6 +10,7 @@ matrix:
     - 0.60.0
     - 0.60.3
     - 0.61.0
+    - 0.61.1
 homepage: https://junegunn.github.io/fzf/
 summary: A command-line fuzzy finder in Go
 description: |-

--- a/blueprints/terminal/gomplate/ops2deb.lock.yml
+++ b/blueprints/terminal/gomplate/ops2deb.lock.yml
@@ -64,3 +64,9 @@
 - url: https://github.com/hairyhenderson/gomplate/releases/download/v4.3.1/gomplate_linux-arm64
   sha256: 214aa853c42d344254da15cf2e163217a033e08fc0d3a7c3654f1775dc6e3c15
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/hairyhenderson/gomplate/releases/download/v4.3.2/gomplate_linux-amd64
+  sha256: 00880fc11fce111a0fe610d315ed85bac9c685ea294216eb2f17aa12a8b8f0e4
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/hairyhenderson/gomplate/releases/download/v4.3.2/gomplate_linux-arm64
+  sha256: a1ac7569f8576ccb3c128488775a3f37265436a1fdd7c7912875738091022fb0
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/terminal/gomplate/ops2deb.yml
+++ b/blueprints/terminal/gomplate/ops2deb.yml
@@ -15,6 +15,7 @@ matrix:
     - 4.2.0
     - 4.3.0
     - 4.3.1
+    - 4.3.2
 homepage: https://docs.gomplate.ca
 summary: flexible commandline tool for template rendering
 description: |-

--- a/blueprints/terminal/zellij/ops2deb.lock.yml
+++ b/blueprints/terminal/zellij/ops2deb.lock.yml
@@ -118,3 +118,9 @@
 - url: https://github.com/zellij-org/zellij/releases/download/v0.42.1/zellij-x86_64-unknown-linux-musl.tar.gz
   sha256: 0ac71035d6ab6c68c709cfbd638dbe00ba9215dfde59ee97fe322beb47bd10ff
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.42.2/zellij-aarch64-unknown-linux-musl.tar.gz
+  sha256: 757a69846095309abb163aa33d1b124dca1d748cc9ecb146e185ad4ef13b1c53
+  timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.42.2/zellij-x86_64-unknown-linux-musl.tar.gz
+  sha256: c2d4833512539455bfdddab5c297d43f7cc3b77d8b7e92ad03e2529111c7c652
+  timestamp: 2025-04-16 15:08:51+00:00

--- a/blueprints/terminal/zellij/ops2deb.yml
+++ b/blueprints/terminal/zellij/ops2deb.yml
@@ -24,6 +24,7 @@ matrix:
     - 0.41.2
     - 0.42.0
     - 0.42.1
+    - 0.42.2
 homepage: https://zellij.dev
 summary: terminal workspace with batteries included
 description: |-


### PR DESCRIPTION
Add fzf v0.61.1
Add chezmoi v2.62.1
Remove chezmoi v2.35.2
Add zellij v0.42.2
Add gomplate v4.3.2
Add lazygit v0.49.0
Add hugo v0.146.5
Remove hugo v0.124.1
Add github-cli v2.70.0
Remove github-cli v2.32.0
Add pdm v2.23.1
Add pyenv v2.5.5
Remove pyenv v2.3.12
Add uv v0.6.14
Add gitoxide v0.42.0
Add aws-iam-authenticator v0.6.31
Add rpk v25.1.1
Add helm v3.17.3
Add scw v2.39.0
Add skaffold v2.15.0
Add istioctl v1.25.2
Add k9s v0.50.3
Add resticprofile v0.30.0
Add mirrord v3.138.0
Remove mirrord v3.104.0
Remove mirrord v3.105.0
Add natscli v0.2.2
Add linkerd v25.4.2
Add terragrunt v0.77.17
Remove terragrunt v0.68.3
Remove terragrunt v0.68.4
Add jfrog-cli v2.75.0
Add cilium v0.18.3
Add logcli v3.4.3
Add argocd v2.14.10
Add terraform-docs v0.20.0
Add terraform v1.11.4
Remove terraform v1.4.0
Remove terraform v1.4.1
Add oc v4.18.9
Add dapr v1.15.1
Add docker-compose v2.35.0
Remove docker-compose v2.19.0
Add velero v1.16.0
Add olivetin v2025.4.14
Add vault v1.19.1
Add bitwarden-cli v2025.3.0
Add sops v3.10.2
Add cosign v2.5.0
Add signal-desktop v7.50.0
Remove signal-desktop v7.6.0
Add teams-for-linux v2.0.8