### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.7.0_amd64.deb
-  sha256: 5044a96d8678a11861405f0662b6ca9cd92a99e7c27d31358df0822bb72d20a9
-  timestamp: 2024-05-02 00:21:43+00:00
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.8.0_amd64.deb
   sha256: 80171f7b7954da99911d25cd35704553b42ff3705fe8e3efe4b33f1f178b9233
   timestamp: 2024-05-07 21:06:03+00:00
@@ -148,3 +145,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.50.0_amd64.deb
   sha256: 5411ee0dea8a2cc97e28bffee7ae8071e84db928e11b0369e374f9133f6200ab
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.52.0_amd64.deb
+  sha256: 1964de34a436965282b7a03cede574eabfb802652ff1efce79f075e31a0cbca9
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -1,7 +1,6 @@
 name: signal-desktop
 matrix:
   versions:
-    - 7.7.0
     - 7.8.0
     - 7.9.0
     - 7.10.0
@@ -51,6 +50,7 @@ matrix:
     - 7.47.0
     - 7.49.0
     - 7.50.0
+    - 7.52.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
@@ -118,3 +118,6 @@
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.0.8/teams-for-linux_2.0.8_amd64.deb
   sha256: a59ce79a3f3ef48590131e09b82a1dfe37330d908759c6f1d8ee1aa9476e8c42
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.0.11/teams-for-linux_2.0.11_amd64.deb
+  sha256: b5465b6c8aad5992085075ab58f1e917d8d25cb96c1657ac708c0cc04b5d074c
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/desktop/teams-for-linux/ops2deb.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.yml
@@ -41,6 +41,7 @@ matrix:
     - 1.13.1
     - 1.14.0
     - 2.0.8
+    - 2.0.11
 homepage: https://github.com/IsmaelMartinez/teams-for-linux/
 summary: unofficial Microsoft Teams for Linux client
 description: |-

--- a/blueprints/dev/atlas/ops2deb.lock.yml
+++ b/blueprints/dev/atlas/ops2deb.lock.yml
@@ -64,3 +64,9 @@
 - url: https://release.ariga.io/atlas/atlas-community-linux-arm64-v0.32.0
   sha256: ac6422c046ab676bea1b517d884c9ad9538018e2effad41e6a9740a4e5ae685b
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.32.1
+  sha256: bf4791a6f40db14dc0ca3116cd0df64a92f6d0bc1902d08940f95a5bbd4160fb
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://release.ariga.io/atlas/atlas-community-linux-arm64-v0.32.1
+  sha256: 28034cbfa2d3e14e997948e079f62ebda511edcbd7ecdfc5b4cc3bf48494e0f6
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/dev/atlas/ops2deb.yml
+++ b/blueprints/dev/atlas/ops2deb.yml
@@ -15,6 +15,7 @@ matrix:
     - 0.30.0
     - 0.31.0
     - 0.32.0
+    - 0.32.1
 homepage: https://atlasgo.io
 summary: manage your database schema as code
 description: |-

--- a/blueprints/dev/github-cli/ops2deb.lock.yml
+++ b/blueprints/dev/github-cli/ops2deb.lock.yml
@@ -10,15 +10,6 @@
 - url: https://github.com/cli/cli/releases/download/v2.5.0/gh_2.5.0_linux_armv6.tar.gz
   sha256: 44e44829a5361957217bfd7c2c8c6dc88fc5f56a72f2e4df772e0ea551a493bd
   timestamp: 2022-02-02 23:13:50+00:00
-- url: https://github.com/cli/cli/releases/download/v2.32.1/gh_2.32.1_linux_amd64.tar.gz
-  sha256: 5c9a70b6411cc9774f5f4e68f9227d5d55ca0bfbd00dfc6353081c9b705c8939
-  timestamp: 2023-07-27 09:16:48+00:00
-- url: https://github.com/cli/cli/releases/download/v2.32.1/gh_2.32.1_linux_arm64.tar.gz
-  sha256: 78a934fa06ba9ffdf84f83a94e4da8ef2ecd6c2a037085d154050a90554e1060
-  timestamp: 2023-07-27 09:16:48+00:00
-- url: https://github.com/cli/cli/releases/download/v2.32.1/gh_2.32.1_linux_armv6.tar.gz
-  sha256: eba94fa78f3906beaa1e2171fbdaf07e58acdc72f4a27da9d95cfde9a6881ae8
-  timestamp: 2023-07-27 09:16:48+00:00
 - url: https://github.com/cli/cli/releases/download/v2.33.0/gh_2.33.0_linux_amd64.tar.gz
   sha256: c46d0adae4dbd0589a62b6a1d822b84ca5184ee78d246d21d5c082ab9f38a04e
   timestamp: 2023-08-21 18:19:27+00:00
@@ -460,3 +451,12 @@
 - url: https://github.com/cli/cli/releases/download/v2.70.0/gh_2.70.0_linux_armv6.tar.gz
   sha256: b5845b9e40a65bcc2bba8950f6be2cc312c4648c293a50881e42bd17e1553b74
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/cli/cli/releases/download/v2.71.2/gh_2.71.2_linux_amd64.tar.gz
+  sha256: 6e52767d7ab14f6849c38b9da1daade4c674f3fde75e0434ede33d921bb75d35
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/cli/cli/releases/download/v2.71.2/gh_2.71.2_linux_arm64.tar.gz
+  sha256: d94cf5f23041b70dfb670d45b70e79bb2e714d61acd8e9b713989a1598269834
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/cli/cli/releases/download/v2.71.2/gh_2.71.2_linux_armv6.tar.gz
+  sha256: 96f7b4fc5fd5c48e2593b94daa4f1182cdded73746aefdca128d735c5db96426
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/dev/github-cli/ops2deb.yml
+++ b/blueprints/dev/github-cli/ops2deb.yml
@@ -38,7 +38,6 @@
       - arm64
       - armhf
     versions:
-      - 2.32.1
       - 2.33.0
       - 2.34.0
       - 2.35.0
@@ -88,6 +87,7 @@
       - 2.68.1
       - 2.69.0
       - 2.70.0
+      - 2.71.2
   homepage: https://github.com/cli/cli
   summary: GitHub on the command line
   description: |-

--- a/blueprints/dev/gitoxide/ops2deb.lock.yml
+++ b/blueprints/dev/gitoxide/ops2deb.lock.yml
@@ -28,3 +28,6 @@
 - url: https://github.com/Byron/gitoxide/releases/download/v0.42.0/gitoxide-max-pure-v0.42.0-x86_64-unknown-linux-musl.tar.gz
   sha256: 72bec56a1dcef03e97673679961184a18c24cefbfcddd5cf4e0d320d0d2c4e76
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/Byron/gitoxide/releases/download/v0.44.0/gitoxide-max-pure-v0.44.0-x86_64-unknown-linux-musl.tar.gz
+  sha256: 1389c55f7632b3ccc0627c136714031e9a457f1d65733b53a8a2199426036f2a
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/dev/gitoxide/ops2deb.yml
+++ b/blueprints/dev/gitoxide/ops2deb.yml
@@ -11,6 +11,7 @@ matrix:
     - 0.40.0
     - 0.41.0
     - 0.42.0
+    - 0.44.0
 homepage: https://github.com/Byron/gitoxide
 summary: idiomatic, lean, fast & safe pure Rust implementation of Git
 description: |-

--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -253,3 +253,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.55.0/downloads/glab_1.55.0_linux_arm64.deb
   sha256: 36c7368617111148dd34e5cd86ffa11665f76101e4ba396db943f8d17ceaa989
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.56.0/downloads/glab_1.56.0_linux_amd64.deb
+  sha256: 44844169064c15c34f26207cece04872ca400993b29a7eac12047135e0fbebb0
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.56.0/downloads/glab_1.56.0_linux_arm64.deb
+  sha256: 8b1335b5dde39a7a06c7aa12637857aeb27463f2ef08c0e26cb1b8589cdaa974
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -65,6 +65,7 @@
       - 1.53.0
       - 1.54.0
       - 1.55.0
+      - 1.56.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-

--- a/blueprints/dev/go-task/ops2deb.lock.yml
+++ b/blueprints/dev/go-task/ops2deb.lock.yml
@@ -136,3 +136,9 @@
 - url: https://github.com/go-task/task/releases/download/v3.42.1/task_linux_arm64.tar.gz
   sha256: 3019dd489ec70a56498ceb919aca06ff46ccf8e7fdd0c99913c9bb27dbd7a44d
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://github.com/go-task/task/releases/download/v3.43.3/task_linux_amd64.tar.gz
+  sha256: 9f93a694464addaf5205661fc43fc9b9fa2b31596731e91510b41811da79fe21
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/go-task/task/releases/download/v3.43.3/task_linux_arm64.tar.gz
+  sha256: b52835656febfcbaaa4513b8aa7b7ff3b57361de482d6cec8c895710d8648625
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/dev/go-task/ops2deb.yml
+++ b/blueprints/dev/go-task/ops2deb.yml
@@ -27,6 +27,7 @@ matrix:
     - 3.40.1
     - 3.41.0
     - 3.42.1
+    - 3.43.3
 homepage: https://taskfile.dev/
 summary: task runner / simpler Make alternative written in Go
 fetch: https://github.com/go-task/task/releases/download/v{{version}}/task_linux_{{arch}}.tar.gz

--- a/blueprints/dev/hugo/ops2deb.lock.yml
+++ b/blueprints/dev/hugo/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/gohugoio/hugo/releases/download/v0.125.0/hugo_extended_0.125.0_linux-amd64.tar.gz
-  sha256: 73d9e96248fa59d285b179da02008c5f8dceda26445e8946289cf61e9bc20c39
-  timestamp: 2024-04-16 18:06:25+00:00
-- url: https://github.com/gohugoio/hugo/releases/download/v0.125.0/hugo_extended_0.125.0_linux-arm64.tar.gz
-  sha256: 92e28702e6e292bca95c1d44f49453ad185c461add45d20f4d1ed0b0562b3622
-  timestamp: 2024-04-16 18:06:25+00:00
 - url: https://github.com/gohugoio/hugo/releases/download/v0.125.1/hugo_extended_0.125.1_linux-amd64.tar.gz
   sha256: 093b28a446d6b84582208956b561ec2f0f77ca4fdc906214296c6003b2ae34f7
   timestamp: 2024-04-18 09:06:34+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/gohugoio/hugo/releases/download/v0.146.5/hugo_extended_0.146.5_linux-arm64.tar.gz
   sha256: 8318167ced2f2a40338a960372865f6f167f2d6d5a37abc68b804d0de78b4404
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.147.0/hugo_extended_0.147.0_linux-amd64.tar.gz
+  sha256: 8dc6e2d7c7c1a3ecf7abf756068af1b30c8197108ae0cc7ffd83ef2b88f0c26d
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.147.0/hugo_extended_0.147.0_linux-arm64.tar.gz
+  sha256: dc85bc0101c03a8eb5238bbc1e44ed9ce586f4eb294696f9f8d8a6d4232934b5
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/dev/hugo/ops2deb.yml
+++ b/blueprints/dev/hugo/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 0.125.0
     - 0.125.1
     - 0.125.2
     - 0.125.3
@@ -54,6 +53,7 @@ matrix:
     - 0.144.2
     - 0.145.0
     - 0.146.5
+    - 0.147.0
 revision: "2"
 homepage: https://gohugo.io/
 summary: fast and flexible Static Site Generator

--- a/blueprints/dev/pdm/ops2deb.lock.yml
+++ b/blueprints/dev/pdm/ops2deb.lock.yml
@@ -133,3 +133,6 @@
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.23.1.tar.gz
   sha256: f58e57062fce7beae68d5fbba5e5ff56a0877866d1bc561ec871327c8dd52857
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.24.1.tar.gz
+  sha256: a5db19cbedb0807b29ade34eba6ea5f6b7494bf73755fe34ffcdfa55ac80e096
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/dev/pdm/ops2deb.yml
+++ b/blueprints/dev/pdm/ops2deb.yml
@@ -46,6 +46,7 @@ matrix:
     - 2.22.4
     - 2.23.0
     - 2.23.1
+    - 2.24.1
 homepage: https://pdm.fming.dev/
 summary: modern Python package and dependency manager supporting the latest PEP standards
 description: |-

--- a/blueprints/dev/typos-cli/ops2deb.lock.yml
+++ b/blueprints/dev/typos-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/crate-ci/typos/releases/download/v1.20.6/typos-v1.20.6-x86_64-unknown-linux-musl.tar.gz
-  sha256: bceb5e6a9bde42e8147809bb894835aad65563fc90ac8f0c512ec750b5fb0ed7
-  timestamp: 2024-04-09 18:06:15+00:00
 - url: https://github.com/crate-ci/typos/releases/download/v1.20.7/typos-v1.20.7-x86_64-unknown-linux-musl.tar.gz
   sha256: 90ec15ee370cabe01111e8fb488e9b96382c6e27e3444d285df49387fedb5c52
   timestamp: 2024-04-09 21:06:05+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/crate-ci/typos/releases/download/v1.31.1/typos-v1.31.1-x86_64-unknown-linux-musl.tar.gz
   sha256: f683c2abeaff70379df7176110100e18150ecd17a4b9785c32908aca11929993
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/crate-ci/typos/releases/download/v1.31.2/typos-v1.31.2-x86_64-unknown-linux-musl.tar.gz
+  sha256: db179d95b35b5e84e7e85e85aef6302c93ffc26e849fe966e1bb7f121d97976e
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/dev/typos-cli/ops2deb.yml
+++ b/blueprints/dev/typos-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: typos-cli
 matrix:
   versions:
-    - 1.20.6
     - 1.20.7
     - 1.20.8
     - 1.20.9
@@ -51,6 +50,7 @@ matrix:
     - 1.29.9
     - 1.30.2
     - 1.31.1
+    - 1.31.2
 homepage: https://github.com/crate-ci/typos/
 summary: source code spell checker
 description: |-

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -484,3 +484,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.6.14/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 0aaf451c391d3913823bfb8ed354b446dcfd0553a32ed8266611e4181c61fd51
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.17/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: 98750f5c0cd9eb520799d10649efb18441b616150f07e6c1125f616a3fd137e8
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.17/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: efc12955d7a6120ea0be2de5ee03dbb33d0d7d9de9dbe0dce560514f2ee129d3
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.6.17/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 720ec28f7a94aa8cd91d3d57dec1434d64b9ae13d1dd6a25f4c0cdb837ba9cf6
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -91,6 +91,7 @@
       - 0.6.9
       - 0.6.12
       - 0.6.14
+      - 0.6.17
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/devops/argo/ops2deb.lock.yml
+++ b/blueprints/devops/argo/ops2deb.lock.yml
@@ -112,3 +112,9 @@
 - url: https://github.com/argoproj/argo-workflows/releases/download/v3.6.5/argo-linux-arm64.gz
   sha256: 486483254ccf772acc5789c16ed78909b3680a46774c596884336b620e0ffa6c
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.6.6/argo-linux-amd64.gz
+  sha256: 5fd2c357527d1482b3a201dc3d482f2f23ac78781b5abf22aed772efd8f5f383
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v3.6.6/argo-linux-arm64.gz
+  sha256: b1be8603ea8bba7ffb36243eb4f1c2b004557466c10f3dc96fb1e123dbb25400
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/argo/ops2deb.yml
+++ b/blueprints/devops/argo/ops2deb.yml
@@ -23,6 +23,7 @@ matrix:
     - 3.6.3
     - 3.6.4
     - 3.6.5
+    - 3.6.6
 homepage: https://argo-workflows.readthedocs.io
 summary: Workflow Engine for Kubernetes
 description: |-

--- a/blueprints/devops/argocd/ops2deb.lock.yml
+++ b/blueprints/devops/argocd/ops2deb.lock.yml
@@ -190,3 +190,9 @@
 - url: https://github.com/argoproj/argo-cd/releases/download/v2.14.10/argocd-linux-arm64
   sha256: d9406019f11f3df4d1287adc86b1e4218feb1fbee018c30f14210568eb7f9ce0
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v2.14.11/argocd-linux-amd64
+  sha256: 78438cfffeb56b34dae868c16154a481b177af68ee6fcb5e11730ae476a1b252
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v2.14.11/argocd-linux-arm64
+  sha256: 209f976280ca649b5d33834c8c4438ea18e7776a59e5b587932ccf0db5742534
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/argocd/ops2deb.yml
+++ b/blueprints/devops/argocd/ops2deb.yml
@@ -36,6 +36,7 @@ matrix:
     - 2.14.7
     - 2.14.9
     - 2.14.10
+    - 2.14.11
 homepage: https://github.com/argoproj/argo-cd
 summary: continuous delivery tool for Kubernetes
 description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.

--- a/blueprints/devops/aws-iam-authenticator/ops2deb.lock.yml
+++ b/blueprints/devops/aws-iam-authenticator/ops2deb.lock.yml
@@ -112,3 +112,9 @@
 - url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.31/aws-iam-authenticator_0.6.31_linux_arm64
   sha256: a38e26787110fecc1104d346a23f9864070f7c4a29aea09d41e3a280d2bde53c
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.1/aws-iam-authenticator_0.7.1_linux_amd64
+  sha256: 4b33629b01051671d72aa4e98d96709f9653d80f45c33988e9ce12c7be2c508a
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.1/aws-iam-authenticator_0.7.1_linux_arm64
+  sha256: f23a69dd275bcca4b79c53683e78f60ccfa361503d5d1048c4ac735640deeebd
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/aws-iam-authenticator/ops2deb.yml
+++ b/blueprints/devops/aws-iam-authenticator/ops2deb.yml
@@ -23,6 +23,7 @@ matrix:
     - 0.6.29
     - 0.6.30
     - 0.6.31
+    - 0.7.1
 homepage: https://github.com/kubernetes-sigs/aws-iam-authenticator
 summary: Kubernetes authentication using AWS IAM
 description: A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster.

--- a/blueprints/devops/clusterctl/ops2deb.lock.yml
+++ b/blueprints/devops/clusterctl/ops2deb.lock.yml
@@ -88,3 +88,9 @@
 - url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/clusterctl-linux-arm64
   sha256: 49e80b6d6ac8ec4cf916ad434b12e703cd87b3edd3ee853b80da2510e6839d34
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.1/clusterctl-linux-amd64
+  sha256: 3edcac3d89a010b18771854814b1bf9570b8aa6149fd59aa1df9737bdaf31e40
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.1/clusterctl-linux-arm64
+  sha256: 9640cc08e3fa2584afc00b7934edca00d803d50722b641b305b90f9c2a6c3361
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/clusterctl/ops2deb.yml
+++ b/blueprints/devops/clusterctl/ops2deb.yml
@@ -19,6 +19,7 @@ matrix:
     - 1.9.4
     - 1.9.5
     - 1.9.6
+    - 1.10.1
 homepage: https://cluster-api.sigs.k8s.io/
 summary: Kubernetes project offering declarative APIs for managing multiple clusters
 description: |-

--- a/blueprints/devops/docker-compose/ops2deb.lock.yml
+++ b/blueprints/devops/docker-compose/ops2deb.lock.yml
@@ -1,15 +1,6 @@
 - url: https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64
   sha256: f3f10cf3dbb8107e9ba2ea5f23c1d2159ff7321d16f0a23051d68d8e2547b323
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/docker/compose/releases/download/v2.19.1/docker-compose-linux-aarch64
-  sha256: 35db0e5207c66e002bfde3cab84e907aa7e552812803bebebf990487729eb2bf
-  timestamp: 2023-06-30 01:47:38+00:00
-- url: https://github.com/docker/compose/releases/download/v2.19.1/docker-compose-linux-armv7
-  sha256: bc9646ecf835e5e2665b7de6455c07cb21d4e892a4c212f9ca9f3024a26ff880
-  timestamp: 2023-06-30 01:47:38+00:00
-- url: https://github.com/docker/compose/releases/download/v2.19.1/docker-compose-linux-x86_64
-  sha256: 8d3ecd3e48c598ba2e2d8eb3b59380f74c8c0c46259008fcd16d0dc058aaebd1
-  timestamp: 2023-06-30 01:47:38+00:00
 - url: https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-aarch64
   sha256: f82c5bc86cb0937628ae616087224aa7d02372d50e638eca646d5834c6766ee7
   timestamp: 2023-07-11 15:20:18+00:00
@@ -451,3 +442,12 @@
 - url: https://github.com/docker/compose/releases/download/v2.35.0/docker-compose-linux-x86_64
   sha256: dba1915cf2f282527f5df0cd7a94b9503047ed200317801853abe8f22c8cd493
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/docker/compose/releases/download/v2.35.1/docker-compose-linux-aarch64
+  sha256: a91e930a076b91e6c69f11d1dbe3c06729ae765fb9dbb3f97cb808e784647399
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/docker/compose/releases/download/v2.35.1/docker-compose-linux-armv7
+  sha256: 50aba1c8fe1eb8efefede3dab9e6c2226ba756a5ffa5cf4f4f5baadaee9a7455
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/docker/compose/releases/download/v2.35.1/docker-compose-linux-x86_64
+  sha256: 7bdb2ce2916e5dd0354e5d129892bf96fdcdb1a9ab8eed69b9173e131db4c230
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/docker-compose/ops2deb.yml
+++ b/blueprints/devops/docker-compose/ops2deb.yml
@@ -18,7 +18,6 @@
       - arm64
       - armhf
     versions:
-      - 2.19.1
       - 2.20.0
       - 2.20.1
       - 2.20.2
@@ -68,6 +67,7 @@
       - 2.33.1
       - 2.34.0
       - 2.35.0
+      - 2.35.1
   homepage: https://docs.docker.com/compose
   summary: lightweight development environments using Docker
   description: |-

--- a/blueprints/devops/iamlive/ops2deb.lock.yml
+++ b/blueprints/devops/iamlive/ops2deb.lock.yml
@@ -196,3 +196,9 @@
 - url: https://github.com/iann0036/iamlive/releases/download/v1.1.23/iamlive-v1.1.23-linux-arm64.tar.gz
   sha256: 0acb20f770c4c7c4dc2c30d910e161c1d7a0c1e7501b9c295ad54f5ce84bc161
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/iann0036/iamlive/releases/download/v1.1.24/iamlive-v1.1.24-linux-amd64.tar.gz
+  sha256: 0173d9a59e2c8cef6792d48476df55bda01f95b92ee59095ed6a257fef6f26e8
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/iann0036/iamlive/releases/download/v1.1.24/iamlive-v1.1.24-linux-arm64.tar.gz
+  sha256: 595448d0d3936964f3802da7a82373c7e70ecc8001bd6bdb0fd8aff750942881
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/iamlive/ops2deb.yml
+++ b/blueprints/devops/iamlive/ops2deb.yml
@@ -37,6 +37,7 @@ matrix:
     - 1.1.19
     - 1.1.22
     - 1.1.23
+    - 1.1.24
 homepage: https://github.com/iann0036/iamlive
 summary: generate policies from AWS calls
 description: |-

--- a/blueprints/devops/k9s/ops2deb.lock.yml
+++ b/blueprints/devops/k9s/ops2deb.lock.yml
@@ -403,3 +403,12 @@
 - url: https://github.com/derailed/k9s/releases/download/v0.50.3/k9s_Linux_armv7.tar.gz
   sha256: cdf5889aa61b303d3277329f80ce9b188e92cc44cffb05eda57363834c67853e
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.4/k9s_Linux_amd64.tar.gz
+  sha256: 1b658c6188339c9f8f271a22339b62d2653da0d636c855629019588d57e5570d
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.4/k9s_Linux_arm64.tar.gz
+  sha256: 697a1e934f4cf19168895da86381db977a8f6004ada4510ef73bc3651c77b44a
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.4/k9s_Linux_armv7.tar.gz
+  sha256: 8d7557d8796e890fc49b903add84e75fce60070834170c9c96079aeac6b2a708
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/k9s/ops2deb.yml
+++ b/blueprints/devops/k9s/ops2deb.yml
@@ -88,6 +88,7 @@
       - 0.40.8
       - 0.40.10
       - 0.50.3
+      - 0.50.4
   homepage: https://k9scli.io
   summary: manage your Kubernetes clusters with style
   description: |-

--- a/blueprints/devops/kube-score/ops2deb.lock.yml
+++ b/blueprints/devops/kube-score/ops2deb.lock.yml
@@ -73,3 +73,12 @@
 - url: https://github.com/zegl/kube-score/releases/download/v1.19.0/kube-score_1.19.0_linux_armv6.tar.gz
   sha256: 6931b3835a1fd63ea087b02518fdc2ace707098e7d45e4d30acef2c8e4bc796f
   timestamp: 2024-10-01 12:10:23+00:00
+- url: https://github.com/zegl/kube-score/releases/download/v1.20.0/kube-score_1.20.0_linux_amd64.tar.gz
+  sha256: ff777b4b3f45905b2d22c69e93c57a7a170e61529a79d54e59cb95cca4bc2a55
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/zegl/kube-score/releases/download/v1.20.0/kube-score_1.20.0_linux_arm64.tar.gz
+  sha256: 0fafe8a00cbc98935f0c0953ba91e83e199f65e56d6816e7b2d2af5da1862051
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/zegl/kube-score/releases/download/v1.20.0/kube-score_1.20.0_linux_armv6.tar.gz
+  sha256: 2a388d24d1316a81b91129094a589d8a1fcb339794f89247b4eb952a8d542559
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/kube-score/ops2deb.yml
+++ b/blueprints/devops/kube-score/ops2deb.yml
@@ -76,6 +76,7 @@
       - 1.17.0
       - 1.18.0
       - 1.19.0
+      - 1.20.0
   homepage: https://github.com/zegl/kube-score
   summary: Kubernetes object analysis for improved reliability and security
   description: |-

--- a/blueprints/devops/kubectl-oidc-login/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl-oidc-login/ops2deb.lock.yml
@@ -40,3 +40,9 @@
 - url: https://github.com/int128/kubelogin/releases/download/v1.32.3/kubelogin_linux_arm64.zip
   sha256: 4de7356c5eda64e5dc8e3a373f5bb99e1736d8edf4383e2d978839c4f6417938
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/int128/kubelogin/releases/download/v1.32.4/kubelogin_linux_amd64.zip
+  sha256: 667f3b4c753d52e45898e77865a0bb25c9741c860a6ea30e087c93090872041a
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/int128/kubelogin/releases/download/v1.32.4/kubelogin_linux_arm64.zip
+  sha256: 718c74a48f0148888f2ffa1aa16be5eaf5ea0a66fe843bc3d1f3d63d36ed9448
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/kubectl-oidc-login/ops2deb.yml
+++ b/blueprints/devops/kubectl-oidc-login/ops2deb.yml
@@ -11,6 +11,7 @@ matrix:
     - 1.32.1
     - 1.32.2
     - 1.32.3
+    - 1.32.4
 homepage: https://github.com/int128/kubelogin
 summary: Kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)
 description: |-

--- a/blueprints/devops/kubectl/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl/ops2deb.lock.yml
@@ -388,3 +388,12 @@
 - url: https://dl.k8s.io/release/v1.32.3/bin/linux/arm64/kubectl
   sha256: 6c2c91e760efbf3fa111a5f0b99ba8975fb1c58bb3974eca88b6134bcf3717e2
   timestamp: 2025-03-13 09:08:24+00:00
+- url: https://dl.k8s.io/release/v1.33.0/bin/linux/amd64/kubectl
+  sha256: 9efe8d3facb23e1618cba36fb1c4e15ac9dc3ed5a2c2e18109e4a66b2bac12dc
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://dl.k8s.io/release/v1.33.0/bin/linux/arm/kubectl
+  sha256: bbb4b4906d483f62b0fc3a0aea3ddac942820984679ad11635b81ee881d69ab3
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://dl.k8s.io/release/v1.33.0/bin/linux/arm64/kubectl
+  sha256: 48541d119455ac5bcc5043275ccda792371e0b112483aa0b29378439cf6322b9
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/kubectl/ops2deb.yml
+++ b/blueprints/devops/kubectl/ops2deb.yml
@@ -92,6 +92,7 @@
       - 1.32.1
       - 1.32.2
       - 1.32.3
+      - 1.33.0
   homepage: https://github.com/kubernetes/kubectl
   summary: command line client for controlling a Kubernetes cluster
   description: |-

--- a/blueprints/devops/kubelogin/ops2deb.lock.yml
+++ b/blueprints/devops/kubelogin/ops2deb.lock.yml
@@ -106,3 +106,9 @@
 - url: https://github.com/Azure/kubelogin/releases/download/v0.2.7/kubelogin-linux-arm64.zip
   sha256: 417ad3e7a3ed5595431a13b4a72f2b29c3a3ce4445e88516680a5dbdd4962b53
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.8/kubelogin-linux-amd64.zip
+  sha256: 4d9ef72db9d298bceae76e7ba04fabe354b2bf8af1d79fad5b6edacb85c8fb97
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.8/kubelogin-linux-arm64.zip
+  sha256: d755d4febd0a488b2f9f426d4fc71bc55fb68c361dc2de26d5a5df25235b81d2
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/kubelogin/ops2deb.yml
+++ b/blueprints/devops/kubelogin/ops2deb.yml
@@ -22,6 +22,7 @@ matrix:
     - 0.1.7
     - 0.2.2
     - 0.2.7
+    - 0.2.8
 homepage: https://github.com/Azure/kubelogin
 summary: Kubernetes credential (exec) plugin implementing azure authentication
 description: |-

--- a/blueprints/devops/linkerd/ops2deb.lock.yml
+++ b/blueprints/devops/linkerd/ops2deb.lock.yml
@@ -424,3 +424,12 @@
 - url: https://github.com/linkerd/linkerd2/releases/download/edge-25.4.2/linkerd2-cli-edge-25.4.2-linux-arm64
   sha256: 9f7d0c889c8cc137e38c4b66c0b30742008f489f5e81d4c43c6f7f80a54a2241
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.4.4/linkerd2-cli-edge-25.4.4-linux-amd64
+  sha256: a786097526da780d72389e90e1f3a397e97be553c82376a2791e3aa4589ea6cf
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.4.4/linkerd2-cli-edge-25.4.4-linux-arm
+  sha256: 65dd1d8c22ba8f1b02d43441d2f59f19657476066859b0114ef9dcf786181141
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.4.4/linkerd2-cli-edge-25.4.4-linux-arm64
+  sha256: db28547640a53e88a653c915501ae28850fde398b81f71ddbcc87ac5733d1b56
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/linkerd/ops2deb.yml
+++ b/blueprints/devops/linkerd/ops2deb.yml
@@ -65,6 +65,7 @@
       - 23.12.4
       - 25.4.1
       - 25.4.2
+      - 25.4.4
   homepage: https://linkerd.io
   summary: ultralight service mesh for Kubernetes
   description: |-

--- a/blueprints/devops/logcli/ops2deb.lock.yml
+++ b/blueprints/devops/logcli/ops2deb.lock.yml
@@ -304,3 +304,12 @@
 - url: https://github.com/grafana/loki/releases/download/v3.4.3/logcli-linux-arm64.zip
   sha256: 7b03b828ed850afd698f1539331bf2c4d344005e1940b3579de9ca4c5e561091
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.5.0/logcli-linux-amd64.zip
+  sha256: a68658c14347b64d6bf0e8f5445400fbb8b9ad7d260aff9dfa80b66b040ef3f5
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.5.0/logcli-linux-arm.zip
+  sha256: 8c5bc39d3ed57db11e84636cb9fe6c1694f3c67eb93f39f3c4d4ca956210aacd
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.5.0/logcli-linux-arm64.zip
+  sha256: 95f601d46e84a49eb3f2683b28594c0c86fd467a9a33973653f4b832b2cb3542
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/logcli/ops2deb.yml
+++ b/blueprints/devops/logcli/ops2deb.yml
@@ -39,6 +39,7 @@ matrix:
     - 3.4.1
     - 3.4.2
     - 3.4.3
+    - 3.5.0
 homepage: https://github.com/grafana/loki
 summary: command-line interface for loki
 description: It facilitates running LogQL queries against a Loki instance.

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.106.0/mirrord_linux_aarch64.zip
-  sha256: 7132d9de773f74551bd0af33a0cdb68e6de758b5724457f25458247997a64730
-  timestamp: 2024-06-18 15:05:55+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.106.0/mirrord_linux_x86_64.zip
-  sha256: fde9d9443afd288b12c8b4a77f4a0d7da47a4ae9631b96aacef759f91d27f2d0
-  timestamp: 2024-06-18 15:05:55+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.107.0/mirrord_linux_aarch64.zip
   sha256: c6c6a3ceb36a3c3fa1a927854c2a1693ca461394ce1b9062b8825594da33f0e9
   timestamp: 2024-06-25 09:05:57+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.138.0/mirrord_linux_x86_64.zip
   sha256: 9999cdd57f824f09a0ec46e53ebe85ed7a95e578cde11a37a149bd2c57ef9542
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.141.0/mirrord_linux_aarch64.zip
+  sha256: bb564bcd07a5dd128dfc9231b8b1671225fba01076d0c0683656185ac6d8519a
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.141.0/mirrord_linux_x86_64.zip
+  sha256: 87104bcbe9842ecc347eef53c414349574f97b5d2ee50876db11457eccd9b43d
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.106.0
     - 3.107.0
     - 3.108.0
     - 3.109.0
@@ -54,6 +53,7 @@ matrix:
     - 3.136.0
     - 3.137.0
     - 3.138.0
+    - 3.141.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -118,3 +118,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.9/openshift-client-linux.tar.gz
   sha256: 1e2d73c870756e3940dcb6c1112c7aa7f702a89cfdb992d11079ac852b4ea05c
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.11/openshift-client-linux-arm64.tar.gz
+  sha256: 7184b3938a651151c55d7be5f2b357de22409cac4daba8a54d0971c9c74c75b1
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.11/openshift-client-linux.tar.gz
+  sha256: 24ae3bff9bccac861006b5aa3482ca435e2e9dcbc099987820080ef176d25f94
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -23,6 +23,7 @@ matrix:
     - 4.18.6
     - 4.18.7
     - 4.18.9
+    - 4.18.11
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/olivetin/ops2deb.lock.yml
+++ b/blueprints/devops/olivetin/ops2deb.lock.yml
@@ -250,3 +250,12 @@
 - url: https://github.com/OliveTin/OliveTin/releases/download/2025.4.14/OliveTin_linux_armv7.deb
   sha256: 941de7a28064531b27757d49df9386706b1e9d97389303f9fa0ec6bf58ac3da6
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/OliveTin/OliveTin/releases/download/2025.4.22/OliveTin_linux_amd64.deb
+  sha256: f2dc4ab4ade7e145405a18ef34ebc49a7669f0d3ceeea1950793cc1cc1035780
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/OliveTin/OliveTin/releases/download/2025.4.22/OliveTin_linux_arm64.deb
+  sha256: 3d86e498520d029ee411dbd5aef1117552b28aa472ba8f9fe3fbb56b6b9f00d4
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/OliveTin/OliveTin/releases/download/2025.4.22/OliveTin_linux_armv7.deb
+  sha256: a34d12aa1214b2f774f068e440b4eae5896206b4edb550cd8d3f1b4af7913b5a
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/olivetin/ops2deb.yml
+++ b/blueprints/devops/olivetin/ops2deb.yml
@@ -33,6 +33,7 @@ matrix:
     - 2025.2.19
     - 2025.3.28
     - 2025.4.14
+    - 2025.4.22
 revision: "2"
 summary: safe and simple access to predefined shell commands from a web interface
 description: |-

--- a/blueprints/devops/opentofu/ops2deb.lock.yml
+++ b/blueprints/devops/opentofu/ops2deb.lock.yml
@@ -100,3 +100,9 @@
 - url: https://github.com/opentofu/opentofu/releases/download/v1.9.0/tofu_1.9.0_linux_arm64.zip
   sha256: c66ae849239c2c98bad79e68aae2bd72aac40c03f1071608febcc3a1b51586fc
   timestamp: 2025-01-09 18:08:32+00:00
+- url: https://github.com/opentofu/opentofu/releases/download/v1.9.1/tofu_1.9.1_linux_amd64.zip
+  sha256: 19eda43eaa45bef3e21d87c58f31a6df73e8534ea30e78619a463bdfdb889cd2
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/opentofu/opentofu/releases/download/v1.9.1/tofu_1.9.1_linux_arm64.zip
+  sha256: 733f41baef5923178385c1fc441140988aa98ba41e7669def97e3418347b4ed6
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/opentofu/ops2deb.yml
+++ b/blueprints/devops/opentofu/ops2deb.yml
@@ -21,6 +21,7 @@ matrix:
     - 1.8.7
     - 1.8.8
     - 1.9.0
+    - 1.9.1
 homepage: https://opentofu.org
 summary: lets you declaratively manage your cloud infrastructure
 description: |-

--- a/blueprints/devops/pluto/ops2deb.lock.yml
+++ b/blueprints/devops/pluto/ops2deb.lock.yml
@@ -142,3 +142,9 @@
 - url: https://github.com/FairwindsOps/pluto/releases/download/v5.21.3/pluto_5.21.3_linux_arm64.tar.gz
   sha256: cd7d5ee5be5abd975cf389b43bbcdadde811c4bb3dfcb24b80b2e3c1f22d60ba
   timestamp: 2025-02-20 16:11:59+00:00
+- url: https://github.com/FairwindsOps/pluto/releases/download/v5.21.4/pluto_5.21.4_linux_amd64.tar.gz
+  sha256: 2d158b0e5ace567ef81d00beadb2bc17f4b1e6826fbb4067a55557fd14ad1804
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/FairwindsOps/pluto/releases/download/v5.21.4/pluto_5.21.4_linux_arm64.tar.gz
+  sha256: 8982bbb2c70b684d8973bd2709a708afa059915485908af7c24abf7e38bca37d
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/pluto/ops2deb.yml
+++ b/blueprints/devops/pluto/ops2deb.yml
@@ -28,6 +28,7 @@ matrix:
     - 5.21.0
     - 5.21.1
     - 5.21.3
+    - 5.21.4
 homepage: https://github.com/FairwindsOps/pluto/
 summary: discover deprecated apiversions in kubernetes
 description: |-

--- a/blueprints/devops/rancher/ops2deb.lock.yml
+++ b/blueprints/devops/rancher/ops2deb.lock.yml
@@ -88,3 +88,9 @@
 - url: https://github.com/rancher/cli/releases/download/v2.11.0/rancher-linux-arm-v2.11.0.tar.gz
   sha256: 5c595e5018ed9c70c11e085d0dfffc280c69c0e251018e621213b3aa0bd28fcd
   timestamp: 2025-04-02 21:14:21+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.11.1/rancher-linux-amd64-v2.11.1.tar.gz
+  sha256: dd3b7520a8702149a02213b2ce0e5eec1e18f4077604d1e01f4d5a6f6afa2c40
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.11.1/rancher-linux-arm-v2.11.1.tar.gz
+  sha256: 7cfe0b4e8c0465708dd4870a1599af4c5e3aa3ffe59ea48d4ce002aa38e55600
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/rancher/ops2deb.yml
+++ b/blueprints/devops/rancher/ops2deb.yml
@@ -45,6 +45,7 @@
       - 2.10.0
       - 2.10.1
       - 2.11.0
+      - 2.11.1
   homepage: https://github.com/rancher/cli
   summary: command-line interface for rancher
   description: |-

--- a/blueprints/devops/rpk/ops2deb.lock.yml
+++ b/blueprints/devops/rpk/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/redpanda-data/redpanda/releases/download/v23.2.18/rpk-linux-amd64.zip
-  sha256: d061ec6df84b5f36d4151598b1419d68a013188998617f3f132469209c888626
-  timestamp: 2023-12-14 18:01:17+00:00
-- url: https://github.com/redpanda-data/redpanda/releases/download/v23.2.18/rpk-linux-arm64.zip
-  sha256: b492274a68759a116365e6df5c122dcd9aa4f5e8e0948f208383c60d1e7d23e4
-  timestamp: 2023-12-14 18:01:17+00:00
 - url: https://github.com/redpanda-data/redpanda/releases/download/v23.2.19/rpk-linux-amd64.zip
   sha256: c50f052188743c172d3e9f9b1aa704498f235a92b4b3673bf11309b34d98a81b
   timestamp: 2023-12-14 21:15:12+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.1/rpk-linux-arm64.zip
   sha256: 34bde67e5772746884fcc88e6ba41d561ccb1d088b3cc04a7d65394b47fcf1af
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.2/rpk-linux-amd64.zip
+  sha256: e5d76f9040c46ab24c685fa2111d9c54d5830b4d3741aac2250e59da4a560d59
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.2/rpk-linux-arm64.zip
+  sha256: e621dc9de03a59c620586a6e047a9fec80df6ca52367d831e613f2d288569bbe
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/rpk/ops2deb.yml
+++ b/blueprints/devops/rpk/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 23.2.18
     - 23.2.19
     - 23.2.20
     - 23.2.21
@@ -54,6 +53,7 @@ matrix:
     - 24.3.8
     - 24.3.9
     - 25.1.1
+    - 25.1.2
 homepage: https://redpanda.com/
 summary: interact with your Redpanda clusters
 description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.5/terragrunt_linux_amd64
-  sha256: 3372f4c5535d20c88f0b8b8b64705698f770534f8b9cbef524050dc4afb39eb5
-  timestamp: 2024-10-28 15:06:57+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.5/terragrunt_linux_arm64
-  sha256: 4840276515ddd8ce6af376b31ff22a1917d94ebe84367429b25db47b6a7ac97a
-  timestamp: 2024-10-28 15:06:57+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.6/terragrunt_linux_amd64
   sha256: e26c02f65e7478a570a2ece6773bba705c432921088556f6e4fd91f4749d87a2
   timestamp: 2024-10-29 18:08:13+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.77.17/terragrunt_linux_arm64
   sha256: 10df92b305dc282f55b2b5acea88d5cf8f87b2f30d2dca67f52ea1fa04d7685d
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.77.22/terragrunt_linux_amd64
+  sha256: 42036586250f5db53dd2460427c5df43420fa22b935998f1530181474f525386
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.77.22/terragrunt_linux_arm64
+  sha256: 95ec4306cb3c68dd3625386f61cd535315fc242945fd8c070ab17bd23c2f4d78
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.68.5
       - 0.68.6
       - 0.68.7
       - 0.68.8
@@ -75,6 +74,7 @@
       - 0.76.6
       - 0.77.6
       - 0.77.17
+      - 0.77.22
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/devops/undock/ops2deb.lock.yml
+++ b/blueprints/devops/undock/ops2deb.lock.yml
@@ -7,3 +7,6 @@
 - url: https://github.com/crazy-max/undock/releases/download/v0.9.0/undock_0.9.0_linux_amd64.tar.gz
   sha256: e4666d854dc719ad20e53576c86b2ad4d64c64b24e4872e391f3696b98fa6f8c
   timestamp: 2025-01-11 15:06:07+00:00
+- url: https://github.com/crazy-max/undock/releases/download/v0.10.0/undock_0.10.0_linux_amd64.tar.gz
+  sha256: e21b8f5fe55ad4914210b1706aa442ba8e12b5d8bcd46e2f5b4837993dbaea58
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/devops/undock/ops2deb.yml
+++ b/blueprints/devops/undock/ops2deb.yml
@@ -6,6 +6,7 @@ matrix:
     - 0.7.0
     - 0.8.0
     - 0.9.0
+    - 0.10.0
 homepage: https://crazymax.dev/undock/
 summary: extracting files from container images
 description: |-

--- a/blueprints/secops/kyverno/ops2deb.lock.yml
+++ b/blueprints/secops/kyverno/ops2deb.lock.yml
@@ -40,3 +40,9 @@
 - url: https://github.com/kyverno/kyverno/releases/download/v1.13.4/kyverno-cli_v1.13.4_linux_x86_64.tar.gz
   sha256: abd318dbb971ab6de2bbe3b7226f4a03230d5c9c651df8a29b6b5e085a55aeeb
   timestamp: 2025-02-08 09:06:07+00:00
+- url: https://github.com/kyverno/kyverno/releases/download/v1.14.0/kyverno-cli_v1.14.0_linux_arm64.tar.gz
+  sha256: 5c5cacd6bb0969cfe493df0b4ea0d80903f1279f8c13f275e74be7b4a0ea234d
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/kyverno/kyverno/releases/download/v1.14.0/kyverno-cli_v1.14.0_linux_x86_64.tar.gz
+  sha256: 569978ffff26577c0b8fb1efe4956b8ddbaff0616389f120ca9e810ba8f178cb
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/secops/kyverno/ops2deb.yml
+++ b/blueprints/secops/kyverno/ops2deb.yml
@@ -11,6 +11,7 @@ matrix:
     - 1.13.2
     - 1.13.3
     - 1.13.4
+    - 1.14.0
 homepage: https://kyverno.io
 summary: set of tools to manage the complete Policy-as-Code (PaC) lifecycle for Kubernetes
   and other cloud native environments

--- a/blueprints/secops/trivy/ops2deb.lock.yml
+++ b/blueprints/secops/trivy/ops2deb.lock.yml
@@ -676,3 +676,9 @@
 - url: https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-ARM64.tar.gz
   sha256: e3ff876fd6fa95919de02c38258acdb26b8f71be1b89c5cb7831f6ec29719ca5
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.61.1/trivy_0.61.1_Linux-64bit.tar.gz
+  sha256: dcc6f48c383833f3a8ee0380f7990a17c89e36553cdf34e1f2d3159f9d8270ec
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.61.1/trivy_0.61.1_Linux-ARM64.tar.gz
+  sha256: a2f28808626ae08877279e13a32d9cc8f845bdfdc762a692b2f32768326208a6
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/secops/trivy/ops2deb.yml
+++ b/blueprints/secops/trivy/ops2deb.yml
@@ -114,6 +114,7 @@
       - 0.59.1
       - 0.60.0
       - 0.61.0
+      - 0.61.1
   homepage: https://www.aquasec.com/products/trivy/
   summary: vulnerability and misconfiguration scanner
   description: |-

--- a/blueprints/secops/vault/ops2deb.lock.yml
+++ b/blueprints/secops/vault/ops2deb.lock.yml
@@ -451,3 +451,12 @@
 - url: https://releases.hashicorp.com/vault/1.19.1/vault_1.19.1_linux_arm64.zip
   sha256: 27561edfbc3a59936c9a892d6a130ada5a224c91862523c1aa596bfd30cd45e3
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://releases.hashicorp.com/vault/1.19.2/vault_1.19.2_linux_amd64.zip
+  sha256: c6781c3e0ec431f39bcc8f1443d09f3b8944c90c348e91aa13182b4e1fd2797f
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://releases.hashicorp.com/vault/1.19.2/vault_1.19.2_linux_arm.zip
+  sha256: 42dc71105c45670c299130ca53547062961d8221f7179cf65ffb33825a32048a
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://releases.hashicorp.com/vault/1.19.2/vault_1.19.2_linux_arm64.zip
+  sha256: 73655835f07c407087fa951be617b3214c3e52e6bda7537290c8268c8a75b1a5
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/secops/vault/ops2deb.yml
+++ b/blueprints/secops/vault/ops2deb.yml
@@ -99,6 +99,7 @@
       - 1.18.4
       - 1.19.0
       - 1.19.1
+      - 1.19.2
   homepage: https://www.hashicorp.com/products/vault
   summary: tool to create, manage and store secrets
   description: |-

--- a/blueprints/terminal/chezmoi/ops2deb.lock.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.36.0/chezmoi_2.36.0_linux_amd64.tar.gz
-  sha256: 23c31e4e6979adfadb917d98b7192e3ff5b86ad2ead24da25a714b20d2618cef
-  timestamp: 2023-07-28 21:13:45+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.36.0/chezmoi_2.36.0_linux_arm.tar.gz
-  sha256: 9ab4aa75b703e8f828b80da5d6a3788ccc5045ff5c53e09bcdbcd72eae3405c0
-  timestamp: 2023-07-28 21:13:45+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.36.0/chezmoi_2.36.0_linux_arm64.tar.gz
-  sha256: e498bbce66cf723e092f68fb338d967b00e83635d178e7805eff5d3e55bd234a
-  timestamp: 2023-07-28 21:13:45+00:00
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.36.1/chezmoi_2.36.1_linux_amd64.tar.gz
   sha256: 8104825fc3aa1e39b259fdc8e93e0cdaa2f833df11d59d976f37021947f9c4c1
   timestamp: 2023-07-30 15:15:25+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.62.1/chezmoi_2.62.1_linux_arm64.tar.gz
   sha256: ae8c784fa09ed04e826c6974d81f612b98aaad89f0f102cf833b8680b3cfaa16
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.62.2/chezmoi_2.62.2_linux_amd64.tar.gz
+  sha256: b3e2305024cbd9b8201aea511a3d94bdaacc7f1e8dad75f1f5df6459ad0d90c0
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.62.2/chezmoi_2.62.2_linux_arm.tar.gz
+  sha256: 881d7ba3bf44f13afcc23504a1c4aecdcb0ea80a94048e9e81c8ee78ad111921
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.62.2/chezmoi_2.62.2_linux_arm64.tar.gz
+  sha256: a2834070a0a759ab0b6be5e3c3ea1c7e29c427863c2c5d61a85540cabbb5e2f6
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/terminal/chezmoi/ops2deb.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 2.36.0
     - 2.36.1
     - 2.37.0
     - 2.38.0
@@ -55,6 +54,7 @@ matrix:
     - 2.60.1
     - 2.61.0
     - 2.62.1
+    - 2.62.2
 homepage: https://github.com/twpayne/chezmoi
 summary: manage your dotfiles across multiple diverse machines
 description: |-

--- a/blueprints/terminal/fzf/ops2deb.lock.yml
+++ b/blueprints/terminal/fzf/ops2deb.lock.yml
@@ -40,3 +40,9 @@
 - url: https://github.com/junegunn/fzf/releases/download/v0.61.1/fzf-0.61.1-linux_arm64.tar.gz
   sha256: 25f6295f718b572ac2ff7de1ffa9e39e619f4f9587386d85bf5b647f0b98fd6b
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.61.3/fzf-0.61.3-linux_amd64.tar.gz
+  sha256: 6a4f4b211b6b8944c7320f66db468d731888aa86b19d5b0ccdf28fa0d0e06e47
+  timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.61.3/fzf-0.61.3-linux_arm64.tar.gz
+  sha256: 0a15108bbf20f563e620cb7527515b7db6fcf6ecfec2a2540a58585b9f02c3c6
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/terminal/fzf/ops2deb.yml
+++ b/blueprints/terminal/fzf/ops2deb.yml
@@ -11,6 +11,7 @@ matrix:
     - 0.60.3
     - 0.61.0
     - 0.61.1
+    - 0.61.3
 homepage: https://junegunn.github.io/fzf/
 summary: A command-line fuzzy finder in Go
 description: |-

--- a/blueprints/terminal/gopass/ops2deb.lock.yml
+++ b/blueprints/terminal/gopass/ops2deb.lock.yml
@@ -7,3 +7,6 @@
 - url: https://github.com/gopasspw/gopass/releases/download/v1.15.15/gopass-1.15.15-linux-amd64.tar.gz
   sha256: eebd930145957a2ccfcfd0b71ca86769d5ab19eb5dc385978502d0774891fb21
   timestamp: 2024-11-24 18:07:59+00:00
+- url: https://github.com/gopasspw/gopass/releases/download/v1.15.16/gopass-1.15.16-linux-amd64.tar.gz
+  sha256: 5fea0741e1eb2fb684b99890536f107b276467fa768b6107284ecd36d1b43d60
+  timestamp: 2025-04-29 18:10:09+00:00

--- a/blueprints/terminal/gopass/ops2deb.yml
+++ b/blueprints/terminal/gopass/ops2deb.yml
@@ -6,6 +6,7 @@ matrix:
     - 1.15.13
     - 1.15.14
     - 1.15.15
+    - 1.15.16
 homepage: https://github.com/gopasspw/gopass
 summary: password manager for teams
 description: |-


### PR DESCRIPTION
Add fzf v0.61.3
Add gopass v1.15.16
Add chezmoi v2.62.2
Remove chezmoi v2.36.0
Add rpk v25.1.2
Remove rpk v23.2.18
Add docker-compose v2.35.1
Remove docker-compose v2.19.1
Add kubelogin v0.2.8
Add argo v3.6.6
Add oc v4.18.11
Add iamlive v1.1.24
Add kube-score v1.20.0
Add olivetin v2025.4.22
Add rancher v2.11.1
Add aws-iam-authenticator v0.7.1
Add argocd v2.14.11
Add kubectl v1.33.0
Add pluto v5.21.4
Add terragrunt v0.77.22
Remove terragrunt v0.68.5
Add mirrord v3.141.0
Remove mirrord v3.106.0
Add undock v0.10.0
Add kubectl-oidc-login v1.32.4
Add logcli v3.5.0
Add k9s v0.50.4
Add linkerd v25.4.4
Add clusterctl v1.10.1
Add opentofu v1.9.1
Add teams-for-linux v2.0.11
Add signal-desktop v7.52.0
Remove signal-desktop v7.7.0
Add glab v1.56.0
Add pdm v2.24.1
Add atlas v0.32.1
Add github-cli v2.71.2
Remove github-cli v2.32.1
Add gitoxide v0.44.0
Add typos-cli v1.31.2
Remove typos-cli v1.20.6
Add uv v0.6.17
Add go-task v3.43.3
Add hugo v0.147.0
Remove hugo v0.125.0
Add vault v1.19.2
Add trivy v0.61.1
Add kyverno v1.14.0