### PR TITLE
feat: add mob ensemble programming tool

### DIFF
--- a/blueprints/dev/mob/ops2deb.lock.yml
+++ b/blueprints/dev/mob/ops2deb.lock.yml
@@ -1,0 +1,3 @@
+- url: https://github.com/remotemobprogramming/mob/releases/download/v5.4.0/mob_v5.4.0_linux_amd64.tar.gz
+  sha256: 2807c8c2d2e46becb3b172733f8a1dece90308639cf9c4b2e345ddd529faaec1
+  timestamp: 2025-04-25 14:16:59+00:00

--- a/blueprints/dev/mob/ops2deb.yml
+++ b/blueprints/dev/mob/ops2deb.yml
@@ -1,0 +1,15 @@
+name: mob
+matrix:
+  architectures:
+    - amd64
+  versions:
+    - 5.4.0
+homepage: https://mob.sh/
+summary: Fast git handover for remote pair/mob programming
+description: |-
+  Switch to a separate branch with mob start and handover to the next person with
+  mob next. Repeat. When you’re done, get your changes into the staging area of
+  the main branch with mob done and commit them.
+fetch: https://github.com/remotemobprogramming/mob/releases/download/v{{version}}/mob_v{{version}}_linux_{{arch}}.tar.gz
+install:
+  - mob:/usr/bin


### PR DESCRIPTION
https://mob.sh/

Fast [git handover](https://www.remotemobprogramming.org/#git-handover) for remote pair/mob programming.

- **mob** is [an open source command line tool written in go](https://github.com/remotemobprogramming/mob)
- **mob** is the fastest way to [hand over code via git](https://www.remotemobprogramming.org/#git-handover)
- **mob** keeps your branches clean and only creates WIP commits on temporary branches
- **mob** has a shared team timer [timer.mob.sh](https://timer.mob.sh)
- **mob** is on 'assess' in the [Thoughtworks Technology Radar](https://twitter.com/simonharrer/status/1453372354097205253?s=20)
- **mob** has [VSCode integration](https://marketplace.visualstudio.com/items?itemName=alessandrosangalli.mob-vscode-gui)