### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/balena-etcher/ops2deb.lock.yml
+++ b/blueprints/desktop/balena-etcher/ops2deb.lock.yml
@@ -16,3 +16,6 @@
 - url: https://github.com/balena-io/etcher/releases/download/v2.1.0/balena-etcher_2.1.0_amd64.deb
   sha256: e4cf558cbf0234e4030756f422ac04bde26b4c34fc295f7c01e71d171ffdd78a
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/balena-io/etcher/releases/download/v2.1.2/balena-etcher_2.1.2_amd64.deb
+  sha256: 327dcf59d1301d2e38701b61fc5eadd2d112c45ec4a2c39ecf1a5f9a94c079fe
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/desktop/balena-etcher/ops2deb.yml
+++ b/blueprints/desktop/balena-etcher/ops2deb.yml
@@ -7,6 +7,7 @@ matrix:
     - 1.19.25
     - 2.0.0
     - 2.1.0
+    - 2.1.2
 homepage: https://github.com/balena-io/etcher
 summary: flash OS images to SD cards and USB drives, safely and easily
 description: |-

--- a/blueprints/desktop/mattermost-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/mattermost-desktop/ops2deb.lock.yml
@@ -25,3 +25,6 @@
 - url: https://releases.mattermost.com/desktop/5.11.2/mattermost-desktop-5.11.2-linux-x64.tar.gz
   sha256: 479c8411df84ff588d6da1dfb284e883f64f3123d0c032e432b07cb26d76a0b7
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://releases.mattermost.com/desktop/5.12.0/mattermost-desktop-5.12.0-linux-x64.tar.gz
+  sha256: 3ff1480a274e7d7fe79c3d3a8dc9282ac4586372d61320580859c6869e72f322
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/desktop/mattermost-desktop/ops2deb.yml
+++ b/blueprints/desktop/mattermost-desktop/ops2deb.yml
@@ -10,6 +10,7 @@ matrix:
     - 5.10.2
     - 5.11.0
     - 5.11.2
+    - 5.12.0
 homepage: https://mattermost.com
 summary: desktop application for Mattermost
 description: |-

--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.9.0_amd64.deb
-  sha256: 22fd961b592f077b44885bb83b2d29a342a5a560b07da94334e5ecb4efc2f9ed
-  timestamp: 2024-05-15 21:05:45+00:00
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.10.0_amd64.deb
   sha256: 080a1f4671bd05668db4ff332f961f13dfa87dce7eb209e24db3c6b2712d9556
   timestamp: 2024-05-22 21:06:32+00:00
@@ -148,3 +145,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.53.0_amd64.deb
   sha256: e2f6033347d53a104f51fd0a3d5e3e7ea0a91f9e7ddbd18be6aae21d181ee920
   timestamp: 2025-05-02 00:31:12+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.55.0_amd64.deb
+  sha256: 4c113f32fd9c6118b0b7f3fe11ffc986bcc76eb27c94ceec1676c52171e82bd3
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -1,7 +1,6 @@
 name: signal-desktop
 matrix:
   versions:
-    - 7.9.0
     - 7.10.0
     - 7.11.0
     - 7.11.1
@@ -51,6 +50,7 @@ matrix:
     - 7.50.0
     - 7.52.0
     - 7.53.0
+    - 7.55.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
@@ -124,3 +124,6 @@
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.0.12/teams-for-linux_2.0.12_amd64.deb
   sha256: ff5896207fc9f779aef1ca746e5cf0f32f5a5defc55367f92d9a8b11dcb33baf
   timestamp: 2025-05-07 09:07:49+00:00
+- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.0.14/teams-for-linux_2.0.14_amd64.deb
+  sha256: 1a05b4fe9a289872f6fdac9d3fd7c57586d208be5b3156b4f1baf10b7e291d1b
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/desktop/teams-for-linux/ops2deb.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.yml
@@ -43,6 +43,7 @@ matrix:
     - 2.0.8
     - 2.0.11
     - 2.0.12
+    - 2.0.14
 homepage: https://github.com/IsmaelMartinez/teams-for-linux/
 summary: unofficial Microsoft Teams for Linux client
 description: |-

--- a/blueprints/dev/atlas/ops2deb.lock.yml
+++ b/blueprints/dev/atlas/ops2deb.lock.yml
@@ -70,3 +70,9 @@
 - url: https://release.ariga.io/atlas/atlas-community-linux-arm64-v0.32.1
   sha256: 28034cbfa2d3e14e997948e079f62ebda511edcbd7ecdfc5b4cc3bf48494e0f6
   timestamp: 2025-04-29 18:10:09+00:00
+- url: https://release.ariga.io/atlas/atlas-community-linux-amd64-v0.33.1
+  sha256: e20b91aad62a0e3a070235fb346d241840416182e758b33fef50e54304be1f2d
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://release.ariga.io/atlas/atlas-community-linux-arm64-v0.33.1
+  sha256: e25e32f44e4f8b33dfa80728664bc576e666751216ecdc9e09745465edae947b
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/atlas/ops2deb.yml
+++ b/blueprints/dev/atlas/ops2deb.yml
@@ -16,6 +16,7 @@ matrix:
     - 0.31.0
     - 0.32.0
     - 0.32.1
+    - 0.33.1
 homepage: https://atlasgo.io
 summary: manage your database schema as code
 description: |-

--- a/blueprints/dev/datanymizer/ops2deb.lock.yml
+++ b/blueprints/dev/datanymizer/ops2deb.lock.yml
@@ -7,3 +7,6 @@
 - url: https://github.com/datanymizer/datanymizer/releases/download/v0.7.1/pg_datanymizer-linux-x86_64.tar.gz
   sha256: dabedd6b2007d18ce4aba26f103a1f8efe365695c5f2ae6948cfce94953dd44d
   timestamp: 2024-08-28 12:10:45+00:00
+- url: https://github.com/datanymizer/datanymizer/releases/download/v0.7.2/pg_datanymizer-linux-x86_64.tar.gz
+  sha256: 9c3309bbf68cb9004f7492b3b24c5294ab4c84fa3e51e49dc7b561c780fd6301
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/datanymizer/ops2deb.yml
+++ b/blueprints/dev/datanymizer/ops2deb.yml
@@ -16,6 +16,7 @@
     versions:
       - 0.6.0
       - 0.7.1
+      - 0.7.2
   homepage: https://github.com/datanymizer/datanymizer
   summary: powerful postgres database anonymizer with flexible rules
   description: |-

--- a/blueprints/dev/github-cli/ops2deb.lock.yml
+++ b/blueprints/dev/github-cli/ops2deb.lock.yml
@@ -10,15 +10,6 @@
 - url: https://github.com/cli/cli/releases/download/v2.5.0/gh_2.5.0_linux_armv6.tar.gz
   sha256: 44e44829a5361957217bfd7c2c8c6dc88fc5f56a72f2e4df772e0ea551a493bd
   timestamp: 2022-02-02 23:13:50+00:00
-- url: https://github.com/cli/cli/releases/download/v2.34.0/gh_2.34.0_linux_amd64.tar.gz
-  sha256: 056c45c510ca77ec7e492023e1aa79c078b679932b6202188b7f5abd914df911
-  timestamp: 2023-09-06 12:32:39+00:00
-- url: https://github.com/cli/cli/releases/download/v2.34.0/gh_2.34.0_linux_arm64.tar.gz
-  sha256: dc7e6ec5f69e7417daa02963bacb4046e40435cba34e35b5cb016531d9f3295e
-  timestamp: 2023-09-06 12:32:39+00:00
-- url: https://github.com/cli/cli/releases/download/v2.34.0/gh_2.34.0_linux_armv6.tar.gz
-  sha256: 9ecd2f010dc582e235df179d69366a869091828c804ef94502a33e974177419f
-  timestamp: 2023-09-06 12:32:39+00:00
 - url: https://github.com/cli/cli/releases/download/v2.35.0/gh_2.35.0_linux_amd64.tar.gz
   sha256: 927614fbc6b391d136504ff2cc4b406f7082a2159ea51feb6f1db4fe6033feaa
   timestamp: 2023-09-19 09:16:45+00:00
@@ -460,3 +451,12 @@
 - url: https://github.com/cli/cli/releases/download/v2.72.0/gh_2.72.0_linux_armv6.tar.gz
   sha256: a505a64e16619f146c1abe7002a083d91a6bd05a4bda166c6c8f9005897613b2
   timestamp: 2025-05-02 00:31:12+00:00
+- url: https://github.com/cli/cli/releases/download/v2.73.0/gh_2.73.0_linux_amd64.tar.gz
+  sha256: 9ebc6b751ee182fdb291ceb2213cc17abb1624b30f6d7a3913097af41f48b1b4
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/cli/cli/releases/download/v2.73.0/gh_2.73.0_linux_arm64.tar.gz
+  sha256: cc2fc6a3ce9d00435a8bceebf89c37bff8a773c5ef2d74203f6f5ce4fb10d66a
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/cli/cli/releases/download/v2.73.0/gh_2.73.0_linux_armv6.tar.gz
+  sha256: 27772410c5da6d1cf037c3b5e491978246ba79a25d4e823484aecc6e5a616092
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/github-cli/ops2deb.yml
+++ b/blueprints/dev/github-cli/ops2deb.yml
@@ -38,7 +38,6 @@
       - arm64
       - armhf
     versions:
-      - 2.34.0
       - 2.35.0
       - 2.36.0
       - 2.37.0
@@ -88,6 +87,7 @@
       - 2.70.0
       - 2.71.2
       - 2.72.0
+      - 2.73.0
   homepage: https://github.com/cli/cli
   summary: GitHub on the command line
   description: |-

--- a/blueprints/dev/hugo/ops2deb.lock.yml
+++ b/blueprints/dev/hugo/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_linux-amd64.tar.gz
-  sha256: 1f25fce9c8bb0e6dfa99af118dd20d4a210d53d76203b399f0589a98750cc5cf
-  timestamp: 2024-04-22 18:06:06+00:00
-- url: https://github.com/gohugoio/hugo/releases/download/v0.125.3/hugo_extended_0.125.3_linux-arm64.tar.gz
-  sha256: fe8c7379102947723c99e8addb01a4b62a3cac9f242950f4ec0ed3fdf8aa2578
-  timestamp: 2024-04-22 18:06:06+00:00
 - url: https://github.com/gohugoio/hugo/releases/download/v0.125.4/hugo_extended_0.125.4_linux-amd64.tar.gz
   sha256: a416f563c6c9cd773dae1a8a7c70596ef4afd45e36436e9c6b7822df56dc4b65
   timestamp: 2024-04-25 15:06:04+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/gohugoio/hugo/releases/download/v0.147.2/hugo_extended_0.147.2_linux-arm64.tar.gz
   sha256: 1f788c5dd4260bb3ecebd3da5d3e6a0680bb5e888fe558ce4a4f5e137e6977a0
   timestamp: 2025-05-06 15:08:51+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.147.5/hugo_extended_0.147.5_linux-amd64.tar.gz
+  sha256: 734d1db3c6f42f6f353f4a6a7d345057b442a33e1ecacc2434d5421d33720aea
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.147.5/hugo_extended_0.147.5_linux-arm64.tar.gz
+  sha256: 3a3c0de0d75a2e63d314e1a52f705d7cfc56588299f62cc8a20549f867b8c728
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/hugo/ops2deb.yml
+++ b/blueprints/dev/hugo/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 0.125.3
     - 0.125.4
     - 0.125.5
     - 0.125.6
@@ -54,6 +53,7 @@ matrix:
     - 0.147.0
     - 0.147.1
     - 0.147.2
+    - 0.147.5
 revision: "2"
 homepage: https://gohugo.io/
 summary: fast and flexible Static Site Generator

--- a/blueprints/dev/kubebuilder/ops2deb.lock.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.lock.yml
@@ -190,3 +190,9 @@
 - url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.2/kubebuilder_linux_arm64
   sha256: 77ae785ea75d76ad191caa6bf69001faade8019ed771a19a0f174def3baf29ed
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.6.0/kubebuilder_linux_amd64
+  sha256: 73b05e081316e675eaca815dc62f13264a580d4d7940c381ae69e14b990d8128
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.6.0/kubebuilder_linux_arm64
+  sha256: 324b7a9a2ad53f93c8008eaf2d8472e365b1577a9766bf421fd86131e99adab6
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/kubebuilder/ops2deb.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.yml
@@ -36,6 +36,7 @@ matrix:
     - 4.5.0
     - 4.5.1
     - 4.5.2
+    - 4.6.0
 homepage: https://book.kubebuilder.io
 summary: SDK for building Kubernetes APIs using CRDs
 description: |-

--- a/blueprints/dev/lazygit/ops2deb.lock.yml
+++ b/blueprints/dev/lazygit/ops2deb.lock.yml
@@ -46,3 +46,9 @@
 - url: https://github.com/jesseduffield/lazygit/releases/download/v0.50.0/lazygit_0.50.0_Linux_x86_64.tar.gz
   sha256: bb2bc0ac8b1e2678c650c5aa8a6fa1595e46f8825ce7e6a3833ca95768179881
   timestamp: 2025-05-03 03:21:50+00:00
+- url: https://github.com/jesseduffield/lazygit/releases/download/v0.51.1/lazygit_0.51.1_Linux_arm64.tar.gz
+  sha256: 7bc02920a09215ed88467870d8757dbbf448da967c8fc97d5523071e3ec15133
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/jesseduffield/lazygit/releases/download/v0.51.1/lazygit_0.51.1_Linux_x86_64.tar.gz
+  sha256: 97513712342d105113bb22cd360987613306cf359a944f929d1872dc9cb4ccfb
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/lazygit/ops2deb.yml
+++ b/blueprints/dev/lazygit/ops2deb.yml
@@ -12,6 +12,7 @@ matrix:
     - 0.48.0
     - 0.49.0
     - 0.50.0
+    - 0.51.1
 homepage: https://github.com/jesseduffield/lazygit
 summary: a lazier way to manage everything git
 description: A simple terminal UI for git, written in Go with the gocui library.

--- a/blueprints/dev/pdm/ops2deb.lock.yml
+++ b/blueprints/dev/pdm/ops2deb.lock.yml
@@ -136,3 +136,6 @@
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.24.1.tar.gz
   sha256: a5db19cbedb0807b29ade34eba6ea5f6b7494bf73755fe34ffcdfa55ac80e096
   timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.24.2.tar.gz
+  sha256: c28b3b5cb78d2912aa09e2a4481580a6187eca1960bd43264ad2c6dc3bc024f8
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/pdm/ops2deb.yml
+++ b/blueprints/dev/pdm/ops2deb.yml
@@ -47,6 +47,7 @@ matrix:
     - 2.23.0
     - 2.23.1
     - 2.24.1
+    - 2.24.2
 homepage: https://pdm.fming.dev/
 summary: modern Python package and dependency manager supporting the latest PEP standards
 description: |-

--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.13.zip
-  sha256: 250208d8e6826ade84c9cf84c54d60fefcaf06dd679dd74f3250d5b7fdff71b4
-  timestamp: 2023-02-15 07:25:57+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.14.zip
   sha256: b4c26c9a007e7564807178e22d356caf7ce8dccb7c268748977bdef8a9783e9b
   timestamp: 2023-03-01 07:26:38+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.5.5.zip
   sha256: a77a8cabc576f6693b120f4fbdc743259ee3822a7b2b1e4fa80faf1608ba3f60
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.5.7.zip
+  sha256: 0a34f5c6e5ff96de0fc76324b7a47e9b67ca930231b981b2e450adf90d89c227
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.3.13
       - 2.3.14
       - 2.3.15
       - 2.3.16
@@ -73,6 +72,7 @@
       - 2.5.3
       - 2.5.4
       - 2.5.5
+      - 2.5.7
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/dev/scala-cli/ops2deb.lock.yml
+++ b/blueprints/dev/scala-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/VirtusLab/scala-cli/releases/download/v0.1.3/scala-cli-x86_64-pc-linux.deb
-  sha256: 08369461e8475b2e50a2523edb8876aedd2eac2eab6eb948701cd4dd1e1a0bb1
-  timestamp: 2022-04-04 20:26:56+00:00
 - url: https://github.com/VirtusLab/scala-cli/releases/download/v0.1.4/scala-cli-x86_64-pc-linux.deb
   sha256: 447c2ad852fa79cf590f1a9d6403b2fcb750c7e54f18a00a486edb3f99c2cb6b
   timestamp: 2022-04-19 17:23:57+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/VirtusLab/scala-cli/releases/download/v1.7.1/scala-cli-x86_64-pc-linux.deb
   sha256: b03a960d6f83a2d30fa771db5775677a2ccddb6555a140780c02a69588fda1a7
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/VirtusLab/scala-cli/releases/download/v1.8.0/scala-cli-x86_64-pc-linux.deb
+  sha256: 1ac5cc716e86f3534d5b7b7e16c68e7864c0d93aa6f10745f5a0e0575f2b9180
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/scala-cli/ops2deb.yml
+++ b/blueprints/dev/scala-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: scala-cli
 matrix:
   versions:
-    - 0.1.3
     - 0.1.4
     - 0.1.5
     - 0.1.6
@@ -51,6 +50,7 @@ matrix:
     - 1.6.2
     - 1.7.0
     - 1.7.1
+    - 1.8.0
 homepage: https://scala-cli.virtuslab.org/
 summary: command-line tool to interact with the Scala language
 description: |-

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -511,3 +511,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.7.3/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 17fc118ba4d7e9303f84fcabdc0a593fc3480ba76eb6980668fdbbb96fe88562
   timestamp: 2025-05-07 21:06:31+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.7.8/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: 4d18efb46f93fa942dc4c212dea3b6b07e3db62fe57d0c3d08de6bf5d9f9bb51
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.7.8/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: 7d61c6e18e81447482dc80c090c65a6615a1232512899943566baf2808ca37bb
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.7.8/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 285981409c746508c1fd125f66a1ea654e487bf1e4d9f45371a062338f788adb
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -94,6 +94,7 @@
       - 0.6.17
       - 0.7.2
       - 0.7.3
+      - 0.7.8
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/devops/argocd/ops2deb.lock.yml
+++ b/blueprints/devops/argocd/ops2deb.lock.yml
@@ -202,3 +202,9 @@
 - url: https://github.com/argoproj/argo-cd/releases/download/v3.0.0/argocd-linux-arm64
   sha256: bf31a4eaf259297d9619c79e278fca6b1e651f62443595208760aca9f9eceb2f
   timestamp: 2025-05-06 12:12:51+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v3.0.3/argocd-linux-amd64
+  sha256: 0973a5f14b2bdfb5e03263cca17ddd5fc20704e524f22fb2f8f412b4a87b7a1b
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v3.0.3/argocd-linux-arm64
+  sha256: e1af8e4e0262f5ee5975cd3c444674622f9b2496b3115c0983b7ae811dfe03fe
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/argocd/ops2deb.yml
+++ b/blueprints/devops/argocd/ops2deb.yml
@@ -38,6 +38,7 @@ matrix:
     - 2.14.10
     - 2.14.11
     - 3.0.0
+    - 3.0.3
 homepage: https://github.com/argoproj/argo-cd
 summary: continuous delivery tool for Kubernetes
 description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.

--- a/blueprints/devops/carvel-kapp/ops2deb.lock.yml
+++ b/blueprints/devops/carvel-kapp/ops2deb.lock.yml
@@ -178,3 +178,9 @@
 - url: https://github.com/vmware-tanzu/carvel-kapp/releases/download/v0.64.1/kapp-linux-arm64
   sha256: a74f11266571fab611d6d371f8ebc275fd16d7545ec00a8d178f2ac33e72d17c
   timestamp: 2025-03-23 18:08:35+00:00
+- url: https://github.com/vmware-tanzu/carvel-kapp/releases/download/v0.64.2/kapp-linux-amd64
+  sha256: 475ed4fc7ee538efceeb02972524a17cb580d9b3e59ab16c7a18de02427daedc
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/vmware-tanzu/carvel-kapp/releases/download/v0.64.2/kapp-linux-arm64
+  sha256: bffda57ed0c83cd2a8cc6faaaf97b3aa71f000658258eeaae6b0a31531a0e03a
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/carvel-kapp/ops2deb.yml
+++ b/blueprints/devops/carvel-kapp/ops2deb.yml
@@ -34,6 +34,7 @@ matrix:
     - 0.63.3
     - 0.64.0
     - 0.64.1
+    - 0.64.2
 homepage: https://carvel.dev/kapp/
 summary: simple deployment tool focused on the concept of "Kubernetes application"
 description: |-

--- a/blueprints/devops/clusterctl/ops2deb.lock.yml
+++ b/blueprints/devops/clusterctl/ops2deb.lock.yml
@@ -94,3 +94,9 @@
 - url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.1/clusterctl-linux-arm64
   sha256: 9640cc08e3fa2584afc00b7934edca00d803d50722b641b305b90f9c2a6c3361
   timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/clusterctl-linux-amd64
+  sha256: d169eaaec17f98fd22a1f5faa60644383fa50f8e88d96c2009ad66a5753c562c
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.2/clusterctl-linux-arm64
+  sha256: 806c8bc68a606506734efc5e0d03cfcf9532844446ca5969905052667ee097a2
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/clusterctl/ops2deb.yml
+++ b/blueprints/devops/clusterctl/ops2deb.yml
@@ -20,6 +20,7 @@ matrix:
     - 1.9.5
     - 1.9.6
     - 1.10.1
+    - 1.10.2
 homepage: https://cluster-api.sigs.k8s.io/
 summary: Kubernetes project offering declarative APIs for managing multiple clusters
 description: |-

--- a/blueprints/devops/docker-compose/ops2deb.lock.yml
+++ b/blueprints/devops/docker-compose/ops2deb.lock.yml
@@ -1,15 +1,6 @@
 - url: https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64
   sha256: f3f10cf3dbb8107e9ba2ea5f23c1d2159ff7321d16f0a23051d68d8e2547b323
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/docker/compose/releases/download/v2.20.1/docker-compose-linux-aarch64
-  sha256: d6edfe561d64a6948a087ff20a29ce9abfca0f1df11ef1b79dfe4910c9f88e4b
-  timestamp: 2023-07-18 21:13:52+00:00
-- url: https://github.com/docker/compose/releases/download/v2.20.1/docker-compose-linux-armv7
-  sha256: 6e6deec5284d56f38c927269ea79db947445ec262b3494f96f267951f37f70ef
-  timestamp: 2023-07-18 21:13:52+00:00
-- url: https://github.com/docker/compose/releases/download/v2.20.1/docker-compose-linux-x86_64
-  sha256: 804aa825c58b375901ba9dc9d0aa1648ce305d903a58f2a5c42bb5c6873b02bf
-  timestamp: 2023-07-18 21:13:52+00:00
 - url: https://github.com/docker/compose/releases/download/v2.20.2/docker-compose-linux-aarch64
   sha256: e63a24e57d2104a09b37ee6aa04c76f4ae85bdf7a59e1bf79adc6d5f55340a31
   timestamp: 2023-07-19 15:17:51+00:00
@@ -451,3 +442,12 @@
 - url: https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64
   sha256: 065ff3887656b88d475fd96d4bd8206ee484e31bbc2137ae5adfcd9e86eac602
   timestamp: 2025-05-07 12:12:40+00:00
+- url: https://github.com/docker/compose/releases/download/v2.36.2/docker-compose-linux-aarch64
+  sha256: d1148609319706a57b755ff0f61d604a63a8cf57adb24c17535baa766ff14b4f
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/docker/compose/releases/download/v2.36.2/docker-compose-linux-armv7
+  sha256: 9e9d20ebc4a094ee7788fbb5bddf70b0b319a55eee134db195d1e47f078ae0dc
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/docker/compose/releases/download/v2.36.2/docker-compose-linux-x86_64
+  sha256: 9040bd35b2cc0783ce6c5de491de7e52e24d4137dbfc5de8a524f718fc23556c
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/docker-compose/ops2deb.yml
+++ b/blueprints/devops/docker-compose/ops2deb.yml
@@ -18,7 +18,6 @@
       - arm64
       - armhf
     versions:
-      - 2.20.1
       - 2.20.2
       - 2.20.3
       - 2.21.0
@@ -68,6 +67,7 @@
       - 2.35.0
       - 2.35.1
       - 2.36.0
+      - 2.36.2
   homepage: https://docs.docker.com/compose
   summary: lightweight development environments using Docker
   description: |-

--- a/blueprints/devops/helm/ops2deb.lock.yml
+++ b/blueprints/devops/helm/ops2deb.lock.yml
@@ -280,3 +280,9 @@
 - url: https://get.helm.sh/helm-v3.17.3-linux-arm.tar.gz
   sha256: 60d76d1e12d3e058a9e9a8209eff748a6fab5948028a1f0860f48e141243d33d
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://get.helm.sh/helm-v3.18.0-linux-amd64.tar.gz
+  sha256: 961e587fc2c03807f8a99ac25ef063fa9e6915f1894729399cbb95d2a79af931
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://get.helm.sh/helm-v3.18.0-linux-arm.tar.gz
+  sha256: 88f6264801fd9c5bb3d2d24c7b3da4e239d137b39bacd18d25b22823e6bd31f7
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/helm/ops2deb.yml
+++ b/blueprints/devops/helm/ops2deb.yml
@@ -80,6 +80,7 @@
       - 3.17.1
       - 3.17.2
       - 3.17.3
+      - 3.18.0
   homepage: https://helm.sh
   summary: Kubernetes package manager
   description: |-

--- a/blueprints/devops/helmfile/ops2deb.lock.yml
+++ b/blueprints/devops/helmfile/ops2deb.lock.yml
@@ -220,3 +220,9 @@
 - url: https://github.com/helmfile/helmfile/releases/download/v1.0.0/helmfile_1.0.0_linux_arm64.tar.gz
   sha256: 965805dd2eb8a6c0db9dd411bcef38099383573ef9225ffff6be43422ede0c8e
   timestamp: 2025-05-02 00:31:12+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.1.0/helmfile_1.1.0_linux_amd64.tar.gz
+  sha256: 7c7a628d967aed264d94162dc39036740878dae8514cb5f1060f447feb6469d4
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.1.0/helmfile_1.1.0_linux_arm64.tar.gz
+  sha256: 324c9caeb5268ee79051945b966afa941f60e50e31a339f0bcdfe68519261eed
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/helmfile/ops2deb.yml
+++ b/blueprints/devops/helmfile/ops2deb.yml
@@ -109,6 +109,7 @@
       - 1.0.0-rc.0
       - 1.0.0-rc.7
       - 1.0.0
+      - 1.1.0
   homepage: https://helmfile.readthedocs.io/
   summary: deploy Kubernetes Helm Charts
   description: |-

--- a/blueprints/devops/jfrog-cli/ops2deb.lock.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.lock.yml
@@ -226,3 +226,9 @@
 - url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.75.1/jfrog-cli-linux-arm64/jf
   sha256: 45f3df5f89cbf54d01909091a000d648c6f8e25d6c70b10653ae2e3f40737cb0
   timestamp: 2025-05-07 12:12:40+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.76.0/jfrog-cli-linux-amd64/jf
+  sha256: f675aceb76a191262346ee9de7df50b695daf420bb0270cebc4983ad87912695
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.76.0/jfrog-cli-linux-arm64/jf
+  sha256: 2827cd6519c3b52c36e27770e49a2308ee0dcb989a2ea6ebd71148626e9cc710
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/jfrog-cli/ops2deb.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.yml
@@ -42,6 +42,7 @@ matrix:
     - 2.74.1
     - 2.75.0
     - 2.75.1
+    - 2.76.0
 homepage: https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli
 summary: client that provides a simple interface that automates access to the JFrog
   products

--- a/blueprints/devops/k9s/ops2deb.lock.yml
+++ b/blueprints/devops/k9s/ops2deb.lock.yml
@@ -421,3 +421,12 @@
 - url: https://github.com/derailed/k9s/releases/download/v0.50.5/k9s_Linux_armv7.tar.gz
   sha256: 8cf3585d6d1bd3e4882b58cdb7a6112873301f11a705115db774fdfa05468c2c
   timestamp: 2025-05-08 06:10:11+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.6/k9s_Linux_amd64.tar.gz
+  sha256: 5fc98f2dcf1d8fac6251f5a1ae1dc6fe7fe2b2d43b13bb3039e51ad492e2a70e
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.6/k9s_Linux_arm64.tar.gz
+  sha256: fc5b3e3ceb3418807ec1393572643e2d2262d08dfd71a8292a4c5b17a1e50875
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.6/k9s_Linux_armv7.tar.gz
+  sha256: 2587bb89536db22e684e230dda360eddabf6e0062b25902996e35feea8940b19
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/k9s/ops2deb.yml
+++ b/blueprints/devops/k9s/ops2deb.yml
@@ -90,6 +90,7 @@
       - 0.50.3
       - 0.50.4
       - 0.50.5
+      - 0.50.6
   homepage: https://k9scli.io
   summary: manage your Kubernetes clusters with style
   description: |-

--- a/blueprints/devops/kind/ops2deb.lock.yml
+++ b/blueprints/devops/kind/ops2deb.lock.yml
@@ -100,3 +100,9 @@
 - url: https://github.com/kubernetes-sigs/kind/releases/download/v0.27.0/kind-linux-arm64
   sha256: 5e4507a41c69679562610b1be82ba4f80693a7826f4e9c6e39236169a3e4f9d0
   timestamp: 2025-02-15 03:08:26+00:00
+- url: https://github.com/kubernetes-sigs/kind/releases/download/v0.29.0/kind-linux-amd64
+  sha256: c72eda46430f065fb45c5f70e7c957cc9209402ef309294821978677c8fb3284
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/kubernetes-sigs/kind/releases/download/v0.29.0/kind-linux-arm64
+  sha256: 03d45095dbd9cc1689f179a3e5e5da24b77c2d1b257d7645abf1b4174bebcf2a
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/kind/ops2deb.yml
+++ b/blueprints/devops/kind/ops2deb.yml
@@ -62,6 +62,7 @@
       - 0.25.0
       - 0.26.0
       - 0.27.0
+      - 0.29.0
   homepage: https://kind.sigs.k8s.io
   summary: deploy Kubernetes cluster in Docker
   description: |-

--- a/blueprints/devops/kompose/ops2deb.lock.yml
+++ b/blueprints/devops/kompose/ops2deb.lock.yml
@@ -106,3 +106,12 @@
 - url: https://github.com/kubernetes/kompose/releases/download/v1.35.0/kompose-linux-arm64
   sha256: 4ae1893bb7288ce20add71fd2dfc34094cb7359dc40beed3da0919d31c331ded
   timestamp: 2024-12-12 15:06:54+00:00
+- url: https://github.com/kubernetes/kompose/releases/download/v1.36.0/kompose-linux-amd64
+  sha256: 459d86a14a2172d8384007ff296f74f3c625dde15b6c8dc971f4985891aef3a7
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/kubernetes/kompose/releases/download/v1.36.0/kompose-linux-arm
+  sha256: 1f1af77ec4489de19029d59c62a99569d506fc8c4be0ca272b8bb0c76840d04b
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/kubernetes/kompose/releases/download/v1.36.0/kompose-linux-arm64
+  sha256: 27a07a05c10e9414d837c4cf578c8bdd4c8ec28aa606ffcb781c252f363806fe
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/kompose/ops2deb.yml
+++ b/blueprints/devops/kompose/ops2deb.yml
@@ -33,6 +33,7 @@
       - 1.33.0
       - 1.34.0
       - 1.35.0
+      - 1.36.0
   homepage: https://kompose.io
   summary: convert docker-compose.yaml into k8s deployments and services
   description: |-

--- a/blueprints/devops/kubectl/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl/ops2deb.lock.yml
@@ -397,3 +397,12 @@
 - url: https://dl.k8s.io/release/v1.33.0/bin/linux/arm64/kubectl
   sha256: 48541d119455ac5bcc5043275ccda792371e0b112483aa0b29378439cf6322b9
   timestamp: 2025-04-29 18:10:09+00:00
+- url: https://dl.k8s.io/release/v1.33.1/bin/linux/amd64/kubectl
+  sha256: 5de4e9f2266738fd112b721265a0c1cd7f4e5208b670f811861f699474a100a3
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://dl.k8s.io/release/v1.33.1/bin/linux/arm/kubectl
+  sha256: 6b1cd6e2bf05c6adaa76b952f9c4ea775f5255913974ccdb12145175d4809e93
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://dl.k8s.io/release/v1.33.1/bin/linux/arm64/kubectl
+  sha256: d595d1a26b7444e0beb122e25750ee4524e74414bbde070b672b423139295ce6
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/kubectl/ops2deb.yml
+++ b/blueprints/devops/kubectl/ops2deb.yml
@@ -93,6 +93,7 @@
       - 1.32.2
       - 1.32.3
       - 1.33.0
+      - 1.33.1
   homepage: https://github.com/kubernetes/kubectl
   summary: command line client for controlling a Kubernetes cluster
   description: |-

--- a/blueprints/devops/linkerd/ops2deb.lock.yml
+++ b/blueprints/devops/linkerd/ops2deb.lock.yml
@@ -442,3 +442,12 @@
 - url: https://github.com/linkerd/linkerd2/releases/download/edge-25.5.1/linkerd2-cli-edge-25.5.1-linux-arm64
   sha256: b278dc87684820f6b5937f7feb81949e8c2de31c13c4a5896a466fdf51f106d1
   timestamp: 2025-05-03 00:29:47+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.5.4/linkerd2-cli-edge-25.5.4-linux-amd64
+  sha256: cc9ec20853536bb51059809d38f1b2be7a0fa23d9a8805107b1324503e2b95bb
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.5.4/linkerd2-cli-edge-25.5.4-linux-arm
+  sha256: b9e9b70e7ef4d4e0ada8fa6b09ed2313649489e673fd4185bce935b039336488
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.5.4/linkerd2-cli-edge-25.5.4-linux-arm64
+  sha256: 68bb1de03ff44ee430daa89b2f11d7a6de1e22d376198176b8ba5a6acef0dbbe
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/linkerd/ops2deb.yml
+++ b/blueprints/devops/linkerd/ops2deb.yml
@@ -67,6 +67,7 @@
       - 25.4.2
       - 25.4.4
       - 25.5.1
+      - 25.5.4
   homepage: https://linkerd.io
   summary: ultralight service mesh for Kubernetes
   description: |-

--- a/blueprints/devops/logcli/ops2deb.lock.yml
+++ b/blueprints/devops/logcli/ops2deb.lock.yml
@@ -313,3 +313,12 @@
 - url: https://github.com/grafana/loki/releases/download/v3.5.0/logcli-linux-arm64.zip
   sha256: 95f601d46e84a49eb3f2683b28594c0c86fd467a9a33973653f4b832b2cb3542
   timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.5.1/logcli-linux-amd64.zip
+  sha256: fbb3ccc3edfaf14610de6fdd07432736732bd9dfbd609dfacaa3435d2a4e5835
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.5.1/logcli-linux-arm.zip
+  sha256: 9349691a7e105b490072ff1a2f086b21cb7936da6bd0ba6517dc0ce732a85053
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.5.1/logcli-linux-arm64.zip
+  sha256: d93268dc25e481c4407c968c631223eabd414327dbd622c78cede70668ec164e
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/logcli/ops2deb.yml
+++ b/blueprints/devops/logcli/ops2deb.yml
@@ -40,6 +40,7 @@ matrix:
     - 3.4.2
     - 3.4.3
     - 3.5.0
+    - 3.5.1
 homepage: https://github.com/grafana/loki
 summary: command-line interface for loki
 description: It facilitates running LogQL queries against a Loki instance.

--- a/blueprints/devops/minikube/ops2deb.lock.yml
+++ b/blueprints/devops/minikube/ops2deb.lock.yml
@@ -166,3 +166,12 @@
 - url: https://storage.googleapis.com/minikube/releases/v1.35.0/minikube-linux-arm64
   sha256: 75549bfdbc3fe483c060e5aa5b848374426552d7e346df8bd15ad77532243767
   timestamp: 2025-01-28 09:07:22+00:00
+- url: https://storage.googleapis.com/minikube/releases/v1.36.0/minikube-linux-amd64
+  sha256: cddeab5ab86ab98e4900afac9d62384dae0941498dfbe712ae0c8868250bc3d7
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://storage.googleapis.com/minikube/releases/v1.36.0/minikube-linux-arm
+  sha256: 6b5de419c665c5b3afa513c4d0a4387e973a1048a335f0ce879410bda3d3315f
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://storage.googleapis.com/minikube/releases/v1.36.0/minikube-linux-arm64
+  sha256: 6fe9adf0c40c75346a0528e609b3d4119ab192e2506d0401cc89adee051a48ea
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/minikube/ops2deb.yml
+++ b/blueprints/devops/minikube/ops2deb.yml
@@ -97,6 +97,7 @@
       - 1.33.1
       - 1.34.0
       - 1.35.0
+      - 1.36.0
   homepage: https://minikube.sigs.k8s.io
   summary: quickly set up a local Kubernetes cluster
   description: |-

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.107.0/mirrord_linux_aarch64.zip
-  sha256: c6c6a3ceb36a3c3fa1a927854c2a1693ca461394ce1b9062b8825594da33f0e9
-  timestamp: 2024-06-25 09:05:57+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.107.0/mirrord_linux_x86_64.zip
-  sha256: bf9eadafc99a71bace76d8bcd1763dd24bcd3e8fc752d5941ab4ff2fe7f384a5
-  timestamp: 2024-06-25 09:05:57+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.108.0/mirrord_linux_aarch64.zip
   sha256: 19d30c8ec11c0ce53ebf86330164a58f4310ac01b4e0584e1c8bd156fed33de1
   timestamp: 2024-07-09 09:06:44+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.141.0/mirrord_linux_x86_64.zip
   sha256: 87104bcbe9842ecc347eef53c414349574f97b5d2ee50876db11457eccd9b43d
   timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.142.2/mirrord_linux_aarch64.zip
+  sha256: 3f398c1c0ba7478a74880d5715292fd59f839490bf760e899141bf400aa9d1bf
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.142.2/mirrord_linux_x86_64.zip
+  sha256: bbb89173e921cdf49d4597f378b90225bc3fa98387855da94f6a8ffc839b638d
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.107.0
     - 3.108.0
     - 3.109.0
     - 3.110.0
@@ -54,6 +53,7 @@ matrix:
     - 3.137.0
     - 3.138.0
     - 3.141.0
+    - 3.142.2
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-

--- a/blueprints/devops/natscli/ops2deb.lock.yml
+++ b/blueprints/devops/natscli/ops2deb.lock.yml
@@ -103,3 +103,12 @@
 - url: https://github.com/nats-io/natscli/releases/download/v0.2.2/nats-0.2.2-linux-arm7.zip
   sha256: a7c0589889938982d5f5c33cade289558a74c01284f1f0f0c97e27a5f9a58870
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.3/nats-0.2.3-linux-amd64.zip
+  sha256: 89988cb2ace7f571aa284391e04f91c510c3987afb721e2743d52cea7649182c
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.3/nats-0.2.3-linux-arm64.zip
+  sha256: 1e5e13dc687f2c420d789c1ae80df39b6f7bb5c78c6fddc45f20dfa73e155600
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.3/nats-0.2.3-linux-arm7.zip
+  sha256: 4106d154abd19971a971c980d7284872b267ec49b989562c4c68fc2c7083bc42
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/natscli/ops2deb.yml
+++ b/blueprints/devops/natscli/ops2deb.yml
@@ -43,6 +43,7 @@
       - 0.1.6
       - 0.2.0
       - 0.2.2
+      - 0.2.3
   homepage: https://github.com/nats-io/natscli
   summary: command-line interface for NATS
   description: |-

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -130,3 +130,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.12/openshift-client-linux.tar.gz
   sha256: 636696e58f5a3f972f62026f1b4d49817aa064fbd5ebe3013543fd41961e9d35
   timestamp: 2025-05-02 03:24:26+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.15/openshift-client-linux-arm64.tar.gz
+  sha256: 110cae6116a60f02e31fbae93643b3327045a4a155c95ac09b63a6714c032851
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.15/openshift-client-linux.tar.gz
+  sha256: d1850d9115e7f06b942ccf34f0e4e9936c584d530f5068a73a802f828e0c708b
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -25,6 +25,7 @@ matrix:
     - 4.18.9
     - 4.18.11
     - 4.18.12
+    - 4.18.15
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/rancher/ops2deb.lock.yml
+++ b/blueprints/devops/rancher/ops2deb.lock.yml
@@ -94,3 +94,9 @@
 - url: https://github.com/rancher/cli/releases/download/v2.11.1/rancher-linux-arm-v2.11.1.tar.gz
   sha256: 7cfe0b4e8c0465708dd4870a1599af4c5e3aa3ffe59ea48d4ce002aa38e55600
   timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.11.2/rancher-linux-amd64-v2.11.2.tar.gz
+  sha256: 543927e5a901e2998e6490cdec95ee5d3d0f478299bc2347a9e515fe28ac25f3
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.11.2/rancher-linux-arm-v2.11.2.tar.gz
+  sha256: 979efc08e0f065cc960eedce1eb6c5ebaa4977d7e9df1386da4557245ace5294
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/rancher/ops2deb.yml
+++ b/blueprints/devops/rancher/ops2deb.yml
@@ -46,6 +46,7 @@
       - 2.10.1
       - 2.11.0
       - 2.11.1
+      - 2.11.2
   homepage: https://github.com/rancher/cli
   summary: command-line interface for rancher
   description: |-

--- a/blueprints/devops/rclone/ops2deb.lock.yml
+++ b/blueprints/devops/rclone/ops2deb.lock.yml
@@ -259,3 +259,12 @@
 - url: https://github.com/rclone/rclone/releases/download/v1.69.2/rclone-v1.69.2-linux-arm64.zip
   sha256: ae719c9fb1cc90ebebfc85570310307a72fd9d77f26ea089893b64fa6f856f3d
   timestamp: 2025-05-02 00:31:12+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.69.3/rclone-v1.69.3-linux-amd64.zip
+  sha256: 14c841f24de6dfb5b914900b345b02e6a00278ad20e7502041d856a4f1d4e221
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.69.3/rclone-v1.69.3-linux-arm.zip
+  sha256: 5e0d0856e146661a3dee38cfe1c81040457cf21a89c5bd84ba94a2a578bf9527
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.69.3/rclone-v1.69.3-linux-arm64.zip
+  sha256: c23f03c11931b2dd4c6ccc091a11ec508f1ca936cc8916ac69669be5b433941c
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/rclone/ops2deb.yml
+++ b/blueprints/devops/rclone/ops2deb.yml
@@ -66,6 +66,7 @@
       - 1.69.0
       - 1.69.1
       - 1.69.2
+      - 1.69.3
   revision: "2"
   homepage: https://rclone.org/
   summary: rsync for cloud storage

--- a/blueprints/devops/terraform/ops2deb.lock.yml
+++ b/blueprints/devops/terraform/ops2deb.lock.yml
@@ -28,15 +28,6 @@
 - url: https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_arm64.zip
   sha256: 2f72982008c52d2d57294ea50794d7c6ae45d2948e08598bfec3e492bce8d96e
   timestamp: 2022-03-02 22:16:55+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.2/terraform_1.4.2_linux_amd64.zip
-  sha256: 9f3ca33d04f5335472829d1df7785115b60176d610ae6f1583343b0a2221a931
-  timestamp: 2023-03-16 15:21:04+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.2/terraform_1.4.2_linux_arm.zip
-  sha256: dbb1e7179279bd739ff889b994738f25a80a8eac5ae255b50bdf5f86b9eda28b
-  timestamp: 2023-03-16 15:21:04+00:00
-- url: https://releases.hashicorp.com/terraform/1.4.2/terraform_1.4.2_linux_arm64.zip
-  sha256: 39c182670c4e63e918e0a16080b1cc47bb16e158d7da96333d682d6a9cb8eb91
-  timestamp: 2023-03-16 15:21:04+00:00
 - url: https://releases.hashicorp.com/terraform/1.4.3/terraform_1.4.3_linux_amd64.zip
   sha256: 2252ee6ac8437b93db2b2ba341edc87951e2916afaeb50a88b858e80796e9111
   timestamp: 2023-03-30 18:21:15+00:00
@@ -478,3 +469,12 @@
 - url: https://releases.hashicorp.com/terraform/1.11.4/terraform_1.11.4_linux_arm64.zip
   sha256: a43d1d0da9b9bab214a8305a39db0e40869572594ccf50c416a7756499143633
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://releases.hashicorp.com/terraform/1.12.1/terraform_1.12.1_linux_amd64.zip
+  sha256: dcaf8ba801660a431a6769ec44ba53b66c1ad44637512ef3961f7ffe4397ef7c
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://releases.hashicorp.com/terraform/1.12.1/terraform_1.12.1_linux_arm.zip
+  sha256: 552a2dba27b8da9c0f59342a854c5b0e77250362c83964b84a8d0e2defb59ef2
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://releases.hashicorp.com/terraform/1.12.1/terraform_1.12.1_linux_arm64.zip
+  sha256: 70e8c1776646f2af83ccad6113b8bb4768e6f7dc65335ae11ffd095eca3b0d4c
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/terraform/ops2deb.yml
+++ b/blueprints/devops/terraform/ops2deb.yml
@@ -40,7 +40,6 @@
       - arm64
       - armhf
     versions:
-      - 1.4.2
       - 1.4.3
       - 1.4.4
       - 1.4.5
@@ -90,6 +89,7 @@
       - 1.11.2
       - 1.11.3
       - 1.11.4
+      - 1.12.1
   homepage: https://www.terraform.io
   summary: tool for building, changing, and versioning infrastructure safely
   description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.8/terragrunt_linux_amd64
-  sha256: ce7cd945682fbbadae19abda264a60afe15b5e5dd4de028b125a12cda7d67129
-  timestamp: 2024-11-07 18:07:48+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.8/terragrunt_linux_arm64
-  sha256: 9224abf5851ff2292daceaa11f2b9eef9f8953e1c5640360522b8b8f8b2b9352
-  timestamp: 2024-11-07 18:07:48+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.68.9/terragrunt_linux_amd64
   sha256: e8660d4afd56e77c3d340c24672b93730313e33d38b47da026bcc275b8241d56
   timestamp: 2024-11-08 18:07:58+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.78.1/terragrunt_linux_arm64
   sha256: 97806e28655b5762bdfc1433e47b3d503a8176f094135664f5fb35de7fa9027a
   timestamp: 2025-05-06 12:12:51+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.80.2/terragrunt_linux_amd64
+  sha256: 53e8883387cab941d4d7352dd34ac05e97355bd0cbb1898786b8374bfd1b1304
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.80.2/terragrunt_linux_arm64
+  sha256: 2a93844aad3f4102482cfbf5c1335deecc71ebed5db79d08907c4e93f6718681
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.68.8
       - 0.68.9
       - 0.68.10
       - 0.68.12
@@ -75,6 +74,7 @@
       - 0.77.22
       - 0.78.0
       - 0.78.1
+      - 0.80.2
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/devops/tflint/ops2deb.lock.yml
+++ b/blueprints/devops/tflint/ops2deb.lock.yml
@@ -184,3 +184,9 @@
 - url: https://github.com/terraform-linters/tflint/releases/download/v0.57.0/tflint_linux_arm64.zip
   sha256: 095705da7a40c1673505b1c789250f288f616c24632e05660d96bacebedcfbd5
   timestamp: 2025-05-03 15:06:10+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.58.0/tflint_linux_amd64.zip
+  sha256: 1e8ccdf3e4b57ba154545b4343621bf46f25ca8f5cc97e36432469752f7ef0c0
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.58.0/tflint_linux_arm64.zip
+  sha256: 7500c93e69ba0f37a4bb5f403cdbaec7230fa65044f39affa1939d8e0df01ad9
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/tflint/ops2deb.yml
+++ b/blueprints/devops/tflint/ops2deb.yml
@@ -35,6 +35,7 @@ matrix:
     - 0.55.1
     - 0.56.0
     - 0.57.0
+    - 0.58.0
 homepage: https://github.com/terraform-linters/tflint
 summary: pluggable Terraform linter
 description: |-

--- a/blueprints/devops/velero/ops2deb.lock.yml
+++ b/blueprints/devops/velero/ops2deb.lock.yml
@@ -232,3 +232,12 @@
 - url: https://github.com/vmware-tanzu/velero/releases/download/v1.16.0/velero-v1.16.0-linux-arm64.tar.gz
   sha256: ac2ada82bbd08e33b951a085c4ee30e28b9343b83525c93aab468c4999e91a7e
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/vmware-tanzu/velero/releases/download/v1.16.1/velero-v1.16.1-linux-amd64.tar.gz
+  sha256: 0a576053cd051268aee40a3ebc9fbf8f72c4fa6a03792100d9009c50367e795f
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/vmware-tanzu/velero/releases/download/v1.16.1/velero-v1.16.1-linux-arm.tar.gz
+  sha256: d6e2c2727596942ba3f6a78c886fd74ef28bff71205682d2dcb6b411c88f2867
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/vmware-tanzu/velero/releases/download/v1.16.1/velero-v1.16.1-linux-arm64.tar.gz
+  sha256: 97f2e992bf62cda4678c8a9b853a2bca4b243635662ab4cdd6e5fa88f5e2742f
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/velero/ops2deb.yml
+++ b/blueprints/devops/velero/ops2deb.yml
@@ -74,6 +74,7 @@
       - 1.15.1
       - 1.15.2
       - 1.16.0
+      - 1.16.1
   homepage: https://velero.io
   summary: backup and migrate Kubernetes applications and their persistent volumes
   description: |-

--- a/blueprints/devops/zli/ops2deb.lock.yml
+++ b/blueprints/devops/zli/ops2deb.lock.yml
@@ -16,3 +16,9 @@
 - url: https://github.com/project-zot/zot/releases/download/v2.1.2/zli-linux-arm64
   sha256: 9cd3dc9129650ce8b21a3694958717a6730fed02f682f60e8cdf980701eca5d2
   timestamp: 2025-01-28 09:07:22+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.3/zli-linux-amd64
+  sha256: 5671811d4b96d3c7c42b929f8b374ae57b1e0aa7ad2aaa8de454ffdf862749ed
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.3/zli-linux-arm64
+  sha256: 5fe1baf51b2f3ba52852178057006bcf0c07872bfdcc7fd9732ae20b62215d55
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/devops/zli/ops2deb.yml
+++ b/blueprints/devops/zli/ops2deb.yml
@@ -7,6 +7,7 @@ matrix:
     - 2.1.0
     - 2.1.1
     - 2.1.2
+    - 2.1.3
 homepage: https://zotregistry.dev
 summary: tool for OCI-native container image registry, simplified
 description: |-

--- a/blueprints/devops/zot/ops2deb.lock.yml
+++ b/blueprints/devops/zot/ops2deb.lock.yml
@@ -16,3 +16,9 @@
 - url: https://github.com/project-zot/zot/releases/download/v2.1.2/zot-linux-arm64
   sha256: ff580cf7e16da3afe6482fd84c5b33cd79b10b1877557acce64f5613b71355dc
   timestamp: 2025-01-28 09:07:22+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.3/zot-linux-amd64
+  sha256: 26288282dd5b1d4c7a8fb5fa4633caa2858e2b712426b33f7b714bd8ca67fdaa
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.3/zot-linux-arm64
+  sha256: 7b5cc55d8685c2869644bfb7cba8325ee76f8fb920dd2ac579d0487efcf5d500
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/devops/zot/ops2deb.yml
+++ b/blueprints/devops/zot/ops2deb.yml
@@ -6,6 +6,7 @@ matrix:
   versions:
     - 2.1.1
     - 2.1.2
+    - 2.1.3
 homepage: https://zotregistry.dev
 summary: OCI-native container image registry, simplified
 description: |-

--- a/blueprints/secops/boundary/ops2deb.lock.yml
+++ b/blueprints/secops/boundary/ops2deb.lock.yml
@@ -358,3 +358,12 @@
 - url: https://releases.hashicorp.com/boundary/0.19.1/boundary_0.19.1_linux_arm64.zip
   sha256: ba2eda1f28bb3563db06d6ecca0c2ef240fffa4d754fb78e88e7a3158e086157
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://releases.hashicorp.com/boundary/0.19.2/boundary_0.19.2_linux_amd64.zip
+  sha256: e3a628fca49adc9d5b6e8946c5d3835fa09878be60210de8e9946339b0f4820f
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://releases.hashicorp.com/boundary/0.19.2/boundary_0.19.2_linux_arm.zip
+  sha256: 3caaf8b44d223594d2e9c790be00c0830fd923d10fa65c818d3dbe895e703118
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://releases.hashicorp.com/boundary/0.19.2/boundary_0.19.2_linux_arm64.zip
+  sha256: 03db0cfe813df0c2d08ec23c8c2b03da5a9ae31bd38e695bf45fa6564d57add3
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/secops/boundary/ops2deb.yml
+++ b/blueprints/secops/boundary/ops2deb.yml
@@ -84,6 +84,7 @@
       - 0.18.2
       - 0.19.0
       - 0.19.1
+      - 0.19.2
   homepage: https://www.boundaryproject.io
   summary: provide simple and secure access to hosts and services
   description: |-

--- a/blueprints/secops/vault/ops2deb.lock.yml
+++ b/blueprints/secops/vault/ops2deb.lock.yml
@@ -469,3 +469,12 @@
 - url: https://releases.hashicorp.com/vault/1.19.3/vault_1.19.3_linux_arm64.zip
   sha256: 5f6d16c59166a1b0cc651238d7af2377da02028302b17174e561288eef4b6c80
   timestamp: 2025-05-02 00:31:12+00:00
+- url: https://releases.hashicorp.com/vault/1.19.4/vault_1.19.4_linux_amd64.zip
+  sha256: d8621f31427ecb6712923fc2db207b3b3c04711b722b11f34627cd4cf837a9c6
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://releases.hashicorp.com/vault/1.19.4/vault_1.19.4_linux_arm.zip
+  sha256: 0ac16fd75c16e11e1d59f2d156926b68118aa6dd9ec0b5be7069681c9bd7464d
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://releases.hashicorp.com/vault/1.19.4/vault_1.19.4_linux_arm64.zip
+  sha256: ed407354d118b841086fdc1786f2e6b0d52dadf84659529f1a7db24912fc6698
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/secops/vault/ops2deb.yml
+++ b/blueprints/secops/vault/ops2deb.yml
@@ -101,6 +101,7 @@
       - 1.19.1
       - 1.19.2
       - 1.19.3
+      - 1.19.4
   homepage: https://www.hashicorp.com/products/vault
   summary: tool to create, manage and store secrets
   description: |-

--- a/blueprints/secops/vuls-scanner/ops2deb.lock.yml
+++ b/blueprints/secops/vuls-scanner/ops2deb.lock.yml
@@ -388,3 +388,9 @@
 - url: https://github.com/future-architect/vuls/releases/download/v0.31.1/vuls-scanner_0.31.1_linux_arm64.tar.gz
   sha256: f820b5cdd956a45c7d46001d6ce2ed0a9add1d32579eab4bc8637eec98d0a45f
   timestamp: 2025-05-08 12:11:50+00:00
+- url: https://github.com/future-architect/vuls/releases/download/v0.32.0/vuls-scanner_0.32.0_linux_amd64.tar.gz
+  sha256: 320a8ba1b20638f98fa13da806fd96cc694296cb55019cf922a90c0e271af59f
+  timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/future-architect/vuls/releases/download/v0.32.0/vuls-scanner_0.32.0_linux_arm64.tar.gz
+  sha256: efbbbcd0760064cd44a1a13c550a2b742832760bb0adba26b59895d31ad4b7e8
+  timestamp: 2025-05-25 09:07:54+00:00

--- a/blueprints/secops/vuls-scanner/ops2deb.yml
+++ b/blueprints/secops/vuls-scanner/ops2deb.yml
@@ -86,6 +86,7 @@
     versions:
       - 0.30.0
       - 0.31.1
+      - 0.32.0
   homepage: https://vuls.io/
   summary: agent-less vulnerability scanner
   description: |-

--- a/blueprints/terminal/chezmoi/ops2deb.lock.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.37.0/chezmoi_2.37.0_linux_amd64.tar.gz
-  sha256: 6391f4a159031b14fd4a8569130969c7ccb701660a896558d7146aaee8a2b9eb
-  timestamp: 2023-08-06 21:13:06+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.37.0/chezmoi_2.37.0_linux_arm.tar.gz
-  sha256: 200455daee46921aad1255e7b2a79b1f2c61c6171be66a606dc4aec66050414c
-  timestamp: 2023-08-06 21:13:06+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.37.0/chezmoi_2.37.0_linux_arm64.tar.gz
-  sha256: 91d74900c0bbc4ba3ab1063a832a6423bed9904f97e7a643ad527d2190c57492
-  timestamp: 2023-08-06 21:13:06+00:00
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.38.0/chezmoi_2.38.0_linux_amd64.tar.gz
   sha256: 2c4c0f1245a8cecc10143a3484e7e249297efe5e5aadbbed3445ce4c622c13b9
   timestamp: 2023-08-21 21:13:42+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.62.3/chezmoi_2.62.3_linux_arm64.tar.gz
   sha256: 41eb4df215e33442bea7a02290917ba2db5463b0103d3a4d6109ea9fb25f85f7
   timestamp: 2025-05-07 00:31:09+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.62.5/chezmoi_2.62.5_linux_amd64.tar.gz
+  sha256: a8a8dc36ff5b84889e855793dabdee45f93d747e6d795f12d443ca9359f30775
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.62.5/chezmoi_2.62.5_linux_arm.tar.gz
+  sha256: 25fe99b79470598940f1ddd6158a08a971c9dfd230b036128047c71681f9594f
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.62.5/chezmoi_2.62.5_linux_arm64.tar.gz
+  sha256: e3443d4f8cc21b35e3954c5c7af00017682d9bc1892100e7c0ef6366d71c7b53
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/terminal/chezmoi/ops2deb.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 2.37.0
     - 2.38.0
     - 2.39.0
     - 2.39.1
@@ -55,6 +54,7 @@ matrix:
     - 2.62.1
     - 2.62.2
     - 2.62.3
+    - 2.62.5
 homepage: https://github.com/twpayne/chezmoi
 summary: manage your dotfiles across multiple diverse machines
 description: |-

--- a/blueprints/terminal/eza/ops2deb.lock.yml
+++ b/blueprints/terminal/eza/ops2deb.lock.yml
@@ -295,3 +295,12 @@
 - url: http://deb.gierens.de/pool/main/e/eza/eza_0.20.22_armhf.deb
   sha256: f168f0f34c3b42e8d928941f970408cb44b9a3545d2bb5b08480723e17d533e0
   timestamp: 2025-03-13 09:08:24+00:00
+- url: http://deb.gierens.de/pool/main/e/eza/eza_0.21.3_amd64.deb
+  sha256: 9691f0d7e0fa6d28d16f09305c10e90fb7b3663f13c2f8da5094809026084afd
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: http://deb.gierens.de/pool/main/e/eza/eza_0.21.3_arm64.deb
+  sha256: e6e8abbea4efae7a1a329cbfdcfb7a2156a1835365f1ca69f39a45b1a62048a5
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: http://deb.gierens.de/pool/main/e/eza/eza_0.21.3_armhf.deb
+  sha256: 51dc220771e5a206a973ad6f10873badc42ba53563f60a3c78999fe7afaf1790
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/terminal/eza/ops2deb.yml
+++ b/blueprints/terminal/eza/ops2deb.yml
@@ -38,6 +38,7 @@ matrix:
     - 0.20.11
     - 0.20.13
     - 0.20.22
+    - 0.21.3
 homepage: https://github.com/eza-community/eza
 summary: modern, maintained replacement for ls, built on exa
 description: |-

--- a/blueprints/terminal/mdbook/ops2deb.lock.yml
+++ b/blueprints/terminal/mdbook/ops2deb.lock.yml
@@ -79,3 +79,6 @@
 - url: https://github.com/rust-lang/mdBook/releases/download/v0.4.49/mdbook-v0.4.49-x86_64-unknown-linux-gnu.tar.gz
   sha256: 91dfb340d0d138bfb3af101556be1dd3faaf8233ba3a3ff55dc84f2f1219250d
   timestamp: 2025-05-06 00:30:50+00:00
+- url: https://github.com/rust-lang/mdBook/releases/download/v0.4.50/mdbook-v0.4.50-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 3ef89127718054bccdfda4c62c3cab644d645adc25b7010bc10af62686929fc4
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/terminal/mdbook/ops2deb.yml
+++ b/blueprints/terminal/mdbook/ops2deb.yml
@@ -28,6 +28,7 @@ matrix:
     - 0.4.47
     - 0.4.48
     - 0.4.49
+    - 0.4.50
 homepage: https://rust-lang.github.io/mdBook/
 summary: create book from markdown files
 description: |-

--- a/blueprints/terminal/nushell/ops2deb.lock.yml
+++ b/blueprints/terminal/nushell/ops2deb.lock.yml
@@ -298,3 +298,9 @@
 - url: https://github.com/nushell/nushell/releases/download/0.104.0/nu-0.104.0-x86_64-unknown-linux-gnu.tar.gz
   sha256: ad72e032e266f4a75803dd92b63dbeb5d9a68a33a3c713336f8a24c740fdc9b6
   timestamp: 2025-05-02 00:31:12+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.104.1/nu-0.104.1-aarch64-unknown-linux-gnu.tar.gz
+  sha256: 5c59225c5ef2d48b88a85f3a8767b9d9da1e820e324561a8cd42074798851ac2
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.104.1/nu-0.104.1-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 1774c84f0ffd1d5f10e879921a762b01300a16b32f4f684a398ddcb191358c4c
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/terminal/nushell/ops2deb.yml
+++ b/blueprints/terminal/nushell/ops2deb.yml
@@ -116,6 +116,7 @@
       - 0.102.0
       - 0.103.0
       - 0.104.0
+      - 0.104.1
   homepage: https://www.nushell.sh/
   summary: new type of shell written in rust
   description: |-

--- a/blueprints/terminal/yq/ops2deb.lock.yml
+++ b/blueprints/terminal/yq/ops2deb.lock.yml
@@ -367,3 +367,12 @@
 - url: https://github.com/mikefarah/yq/releases/download/v4.45.2/yq_linux_arm64
   sha256: 8a8aa1e6b43e6d239f8b122997e26e0d0e32b369f50409aadf98e34bcb240595
   timestamp: 2025-05-03 09:06:33+00:00
+- url: https://github.com/mikefarah/yq/releases/download/v4.45.4/yq_linux_amd64
+  sha256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/mikefarah/yq/releases/download/v4.45.4/yq_linux_arm
+  sha256: d52f3b3e552ee288dca27812865984bcaddb37a3f5bed67b22d4343bb70e8b3e
+  timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/mikefarah/yq/releases/download/v4.45.4/yq_linux_arm64
+  sha256: a02cc637409db44a9f9cb55ea92c40019582ba88083c4d930a727ec4b59ed439
+  timestamp: 2025-05-25 09:07:55+00:00

--- a/blueprints/terminal/yq/ops2deb.yml
+++ b/blueprints/terminal/yq/ops2deb.yml
@@ -64,6 +64,7 @@
       - 4.44.6
       - 4.45.1
       - 4.45.2
+      - 4.45.4
   revision: "2"
   homepage: https://github.com/mikefarah/yq
   summary: portable command-line YAML processor


### PR DESCRIPTION
Add vuls-scanner v0.32.0
Add vault v1.19.4
Add boundary v0.19.2
Add kind v0.29.0
Add velero v1.16.1
Add natscli v0.2.3
Add rclone v1.69.3
Add k9s v0.50.6
Add zot v2.1.3
Add oc v4.18.15
Add clusterctl v1.10.2
Add helmfile v1.1.0
Add kubectl v1.33.1
Add tflint v0.58.0
Add mirrord v3.142.2
Remove mirrord v3.107.0
Add helm v3.18.0
Add docker-compose v2.36.2
Remove docker-compose v2.20.1
Add terragrunt v0.80.2
Remove terragrunt v0.68.8
Add argocd v3.0.3
Add rancher v2.11.2
Add linkerd v25.5.4
Add kompose v1.36.0
Add minikube v1.36.0
Add terraform v1.12.1
Remove terraform v1.4.2
Add logcli v3.5.1
Add zli v2.1.3
Add carvel-kapp v0.64.2
Add jfrog-cli v2.76.0
Add atlas v0.33.1
Add kubebuilder v4.6.0
Add lazygit v0.51.1
Add github-cli v2.73.0
Remove github-cli v2.34.0
Add pyenv v2.5.7
Remove pyenv v2.3.13
Add scala-cli v1.8.0
Remove scala-cli v0.1.3
Add uv v0.7.8
Add hugo v0.147.5
Remove hugo v0.125.3
Add datanymizer v0.7.2
Add pdm v2.24.2
Add mattermost-desktop v5.12.0
Add balena-etcher v2.1.2
Add teams-for-linux v2.0.14
Add signal-desktop v7.55.0
Remove signal-desktop v7.9.0
Add nushell v0.104.1
Add mdbook v0.4.50
Add chezmoi v2.62.5
Remove chezmoi v2.37.0
Add eza v0.21.3
Add yq v4.45.4