### PR TITLE
feat(dev): add controller-gen (part of kubebuilder)

### DIFF
--- a/blueprints/dev/controller-gen/ops2deb.lock.yml
+++ b/blueprints/dev/controller-gen/ops2deb.lock.yml
@@ -1,0 +1,6 @@
+- url: https://github.com/kubernetes-sigs/controller-tools/releases/download/v0.18.0/controller-gen-linux-amd64
+  sha256: d191eea7a8471a99105a0cf0686e5bfbe13a7d1838287287d251b755e5c54d9b
+  timestamp: 2025-06-03 14:34:06+00:00
+- url: https://github.com/kubernetes-sigs/controller-tools/releases/download/v0.18.0/controller-gen-linux-arm64
+  sha256: a7e21df58b107f8ccba7e07fea9e60cdff561c3d27da93e6db84fa2ea014a2c4
+  timestamp: 2025-06-03 14:34:06+00:00

--- a/blueprints/dev/controller-gen/ops2deb.yml
+++ b/blueprints/dev/controller-gen/ops2deb.yml
@@ -1,0 +1,20 @@
+name: controller-gen
+matrix:
+  architectures:
+    - amd64
+    - arm64
+  versions:
+    - 0.18.0
+homepage: https://book.kubebuilder.io
+summary: code generator for Kubernetes controllers and CRDs
+description: |-
+  Kubebuilder makes use of this tool for generating utility code and Kubernetes
+  YAML. This code and config generation is controlled by the presence of special
+  "marker comments" in Go code.
+
+  Controller-gen is built out of different "generators" (which specify what to
+  generate) and "output rules" (which specify how and where to write the
+  results).
+fetch: https://github.com/kubernetes-sigs/controller-tools/releases/download/v{{version}}/controller-gen-linux-{{arch}}
+install:
+  - controller-gen-linux-{{arch}}:/usr/bin/controller-gen


### PR DESCRIPTION
The tool *controller-gen* is used to maintain sources as generated by *kubebuilder* and *operator-sdk*, both which are already part of WakeMeOps.