### PR TITLE
feat(secops): Add gitleaks

### DIFF
--- a/blueprints/secops/gitleaks/ops2deb.lock.yml
+++ b/blueprints/secops/gitleaks/ops2deb.lock.yml
@@ -1,0 +1,78 @@
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.23.0/gitleaks_8.23.0_linux_arm64.tar.gz
+  sha256: 8a921ff79e8d69349742981ea2c72f02a0a132e633da9d45036714ff676a7625
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.23.0/gitleaks_8.23.0_linux_x64.tar.gz
+  sha256: d1c542f88efe2383469fef9c9bdddc809408ed8b5ba808b262720c03fddd8f8e
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.23.1/gitleaks_8.23.1_linux_arm64.tar.gz
+  sha256: 23774e6fdf4be9268fb966b59ab2aebcd83a83bdacb81822e044475fa250e430
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.23.1/gitleaks_8.23.1_linux_x64.tar.gz
+  sha256: 6fac0fe2602d8aeaf5135b7a957bbac27984b1ad14def0574be0e115e3d73252
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.23.2/gitleaks_8.23.2_linux_arm64.tar.gz
+  sha256: 02b782d21e095b1bb9bb1294bbc3e9f9ff854bd298e5a2e4cc605b8500c574d8
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.23.2/gitleaks_8.23.2_linux_x64.tar.gz
+  sha256: 5d73b332b17936427bff36524e341cd3c3ea0034c6008106238f413a403bd476
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.23.3/gitleaks_8.23.3_linux_arm64.tar.gz
+  sha256: da070bbe1f2489674d212cfbfb4627336246529868d9c054a0e6b794f48f86a8
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.23.3/gitleaks_8.23.3_linux_x64.tar.gz
+  sha256: 73a35edc2285afd689e712b8e0ebad3f2eaf94b0d67cd6e1f0ec693ac751bb4a
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.24.0/gitleaks_8.24.0_linux_arm64.tar.gz
+  sha256: 3755cc9b81f2466ad308f722a064ca04df27f59d551396183efe07978fef8fcb
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.24.0/gitleaks_8.24.0_linux_x64.tar.gz
+  sha256: cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.24.2/gitleaks_8.24.2_linux_arm64.tar.gz
+  sha256: 574a6d52573c61173add7ddb5e3cc68c0e82cb0735818a1eeb9a0a2de1643fbc
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.24.2/gitleaks_8.24.2_linux_x64.tar.gz
+  sha256: fa0500f6b7e41d28791ebc680f5dd9899cd42b58629218a5f041efa899151a8e
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_arm64.tar.gz
+  sha256: 5f2edbe1f49f7b920f9e06e90759947d3c5dfc16f752fb93aaafc17e9d14cf07
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz
+  sha256: 9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.25.0/gitleaks_8.25.0_linux_arm64.tar.gz
+  sha256: 390f67bbc18b1bda3bb7e1c052fad7e1a9df1287037c28ace27e23d9c68a6923
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.25.0/gitleaks_8.25.0_linux_x64.tar.gz
+  sha256: ad50ede2cc7985a42240ffcad32c5f67e50446db8e6ed347d0eebc71d36c2f6d
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.25.1/gitleaks_8.25.1_linux_arm64.tar.gz
+  sha256: 262811de1ef1e328eba99a976d9df8a9def2fb04f6f977ab1120d8710cadb354
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.25.1/gitleaks_8.25.1_linux_x64.tar.gz
+  sha256: 3000d057342489827ee127310771873000b658f2987be7bbd21968ab7443913a
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.26.0/gitleaks_8.26.0_linux_arm64.tar.gz
+  sha256: 5f1f97ada8c297c2a49ff31114f3c66ad49af27c2404fe013da3dc21e82da98c
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.26.0/gitleaks_8.26.0_linux_x64.tar.gz
+  sha256: 32faa8a77f6ce4b483921072ea89f78a794ad1d96471f2ad6e01ad3b0ebafa00
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.27.0/gitleaks_8.27.0_linux_arm64.tar.gz
+  sha256: 7df9471047e31316b2b0e21314c6ef0f1704dfbb8220c3b755cfcb9f849510eb
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.27.0/gitleaks_8.27.0_linux_x64.tar.gz
+  sha256: ba75459d765ebc9e940c0123a2d41a29e87be674b5ecaaacd5f82f26009255d5
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.27.1/gitleaks_8.27.1_linux_arm64.tar.gz
+  sha256: 4ae6f6b7538d99c8c51e0aa93cec21dc6da96763f0aa69e7bb08af75b46dfc02
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.27.1/gitleaks_8.27.1_linux_x64.tar.gz
+  sha256: 2efef1dbdb2c4f887cedc76724ec0e2186086665b14a22c737f5fe64c02d2a97
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_arm64.tar.gz
+  sha256: fd59a77b3d898ab14782264bf7a22db457871db56debc5d7ac3e30b64b379921
+  timestamp: 2025-06-10 20:21:46+00:00
+- url: https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_x64.tar.gz
+  sha256: 141c3b2dede46d8b3a53b47116da756bd223decc0374797559a6b50ecba5590c
+  timestamp: 2025-06-10 20:21:46+00:00

--- a/blueprints/secops/gitleaks/ops2deb.yml
+++ b/blueprints/secops/gitleaks/ops2deb.yml
@@ -1,0 +1,38 @@
+name: gitleaks
+matrix:
+  architectures:
+    - arm64
+    - amd64
+  versions:
+    - 8.27.2
+    - 8.27.1
+    - 8.27.0
+    - 8.26.0
+    - 8.25.1
+    - 8.25.0
+    - 8.24.3
+    - 8.24.2
+    - 8.24.0
+    - 8.23.3
+    - 8.23.2
+    - 8.23.1
+    - 8.23.0
+homepage: https://github.com/gitleaks/gitleaks
+summary: Gitleaks is a tool for detecting secrets like passwords, API keys, and tokens
+  in git repos, files, and whatever else you wanna throw at it via stdin.
+description: |-
+  Gitleaks is an open source (MIT licensed) secret scanner for git repositories,
+  files, directories, and stdin.
+  With over 20 million docker downloads, 19k GitHub stars, 14 million GitHub
+  downloads,
+  thousands of weekly clones, and over 850k homebrew installs, gitleaks is the
+  most trusted open source secret scanner among security professionals,
+  enterprises, and developers.
+  Gitleaks is maintained by Zach Rice.
+fetch:
+  url: https://github.com/gitleaks/gitleaks/releases/download/v{{version}}/gitleaks_{{version}}_linux_{{target}}.tar.gz
+  targets:
+    amd64: x64
+    arm64: arm64
+install:
+  - gitleaks:/usr/bin

--- a/blueprints/secops/gitleaks/ops2deb.yml
+++ b/blueprints/secops/gitleaks/ops2deb.yml
@@ -18,8 +18,7 @@ matrix:
     - 8.23.1
     - 8.23.0
 homepage: https://github.com/gitleaks/gitleaks
-summary: Gitleaks is a tool for detecting secrets like passwords, API keys, and tokens
-  in git repos, files, and whatever else you wanna throw at it via stdin.
+summary: Find secrets with Gitleaks
 description: |-
   Gitleaks is an open source (MIT licensed) secret scanner for git repositories,
   files, directories, and stdin.


### PR DESCRIPTION
This PR adds gitleaks. 
Includes all releases for arm64 and amd64 released in 2025.

Resolves #3268.

If some changes are needed for this to be merged, feel free to give me a hint.