### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.15.0_amd64.deb
-  sha256: 520595c4b3aaba5fd7b0cfbed426a2efeb248c1c907c60cef200550c936ffedc
-  timestamp: 2024-07-09 09:06:44+00:00
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.16.0_amd64.deb
   sha256: 0df3d06f74c6855559ef079b368326ca18e144a28ede559fd76648a62ec3eed7
   timestamp: 2024-07-17 18:07:22+00:00
@@ -148,3 +145,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.60.0_amd64.deb
   sha256: 836631aa7bb5d8a8e20aa3a1afbf87a7a366b1af424b3b0c245c1878347cf1e9
   timestamp: 2025-07-03 00:32:44+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.62.0_amd64.deb
+  sha256: 6c986a073600d737156b3af121d3e7d3162cd7d594beda251a6c74c441f8be04
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -1,7 +1,6 @@
 name: signal-desktop
 matrix:
   versions:
-    - 7.15.0
     - 7.16.0
     - 7.17.0
     - 7.18.0
@@ -51,6 +50,7 @@ matrix:
     - 7.58.0
     - 7.59.0
     - 7.60.0
+    - 7.62.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
@@ -136,3 +136,6 @@
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.0.17/teams-for-linux_2.0.17_amd64.deb
   sha256: 6751bdbe484ca26666009c091afec7bae6a7de1e81081e19900ff5c35a968695
   timestamp: 2025-06-16 12:12:47+00:00
+- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.1.0/teams-for-linux_2.1.0_amd64.deb
+  sha256: c0ebc758df993589050e2ed6890b985ff540f8740b5d843c3b0baace7f8afd21
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/desktop/teams-for-linux/ops2deb.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.yml
@@ -47,6 +47,7 @@ matrix:
     - 2.0.15
     - 2.0.16
     - 2.0.17
+    - 2.1.0
 homepage: https://github.com/IsmaelMartinez/teams-for-linux/
 summary: unofficial Microsoft Teams for Linux client
 description: |-

--- a/blueprints/dev/github-cli/ops2deb.lock.yml
+++ b/blueprints/dev/github-cli/ops2deb.lock.yml
@@ -10,15 +10,6 @@
 - url: https://github.com/cli/cli/releases/download/v2.5.0/gh_2.5.0_linux_armv6.tar.gz
   sha256: 44e44829a5361957217bfd7c2c8c6dc88fc5f56a72f2e4df772e0ea551a493bd
   timestamp: 2022-02-02 23:13:50+00:00
-- url: https://github.com/cli/cli/releases/download/v2.38.0/gh_2.38.0_linux_amd64.tar.gz
-  sha256: c56b80a03c3b4216cd1ab63f6c7bfa4c356c67bce265fc067953bec10cdf0f97
-  timestamp: 2023-11-01 12:32:57+00:00
-- url: https://github.com/cli/cli/releases/download/v2.38.0/gh_2.38.0_linux_arm64.tar.gz
-  sha256: 45b659115d5d969ace158e4f88b8e66b880d7d355203793e544d794ca31a4ba2
-  timestamp: 2023-11-01 12:32:57+00:00
-- url: https://github.com/cli/cli/releases/download/v2.38.0/gh_2.38.0_linux_armv6.tar.gz
-  sha256: ff69d5271d6c26d908de9235eae940716cfd9572eb1704da0099abf4a422a70f
-  timestamp: 2023-11-01 12:32:57+00:00
 - url: https://github.com/cli/cli/releases/download/v2.39.0/gh_2.39.0_linux_amd64.tar.gz
   sha256: da8a96f8a5a8011a1d7f65ebefd57be4048b4bdb1c2059d7cb99bc82075d6d60
   timestamp: 2023-11-14 09:16:47+00:00
@@ -460,3 +451,12 @@
 - url: https://github.com/cli/cli/releases/download/v2.74.2/gh_2.74.2_linux_armv6.tar.gz
   sha256: 89eebbeafe95db513ff43dc6d116aea7e3c12926d75f9f328fcd604e6bf6645f
   timestamp: 2025-06-18 18:09:36+00:00
+- url: https://github.com/cli/cli/releases/download/v2.76.0/gh_2.76.0_linux_amd64.tar.gz
+  sha256: bc46a0f43fa357cdfcffc77f92a48303f5bacd97cf3e59a807da2682ca4126da
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/cli/cli/releases/download/v2.76.0/gh_2.76.0_linux_arm64.tar.gz
+  sha256: f09e870529ddaeb6ea015a9ab867df019a913fb6d2fda4f15e80003828a439fc
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/cli/cli/releases/download/v2.76.0/gh_2.76.0_linux_armv6.tar.gz
+  sha256: 4b79eb0e54befd4412f6c6247e843b5e13790e95f466b3456b19b1f2bd1b4f24
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/dev/github-cli/ops2deb.yml
+++ b/blueprints/dev/github-cli/ops2deb.yml
@@ -38,7 +38,6 @@
       - arm64
       - armhf
     versions:
-      - 2.38.0
       - 2.39.0
       - 2.39.1
       - 2.39.2
@@ -88,6 +87,7 @@
       - 2.74.0
       - 2.74.1
       - 2.74.2
+      - 2.76.0
   homepage: https://github.com/cli/cli
   summary: GitHub on the command line
   description: |-

--- a/blueprints/dev/gitoxide/ops2deb.lock.yml
+++ b/blueprints/dev/gitoxide/ops2deb.lock.yml
@@ -31,3 +31,6 @@
 - url: https://github.com/Byron/gitoxide/releases/download/v0.44.0/gitoxide-max-pure-v0.44.0-x86_64-unknown-linux-musl.tar.gz
   sha256: 1389c55f7632b3ccc0627c136714031e9a457f1d65733b53a8a2199426036f2a
   timestamp: 2025-04-29 18:10:09+00:00
+- url: https://github.com/Byron/gitoxide/releases/download/v0.45.0/gitoxide-max-pure-v0.45.0-x86_64-unknown-linux-musl.tar.gz
+  sha256: 33c6bad156f1ee9f9ee68afd0d9445ee68217a4c3a4618316ca874ddd543eab7
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/dev/gitoxide/ops2deb.yml
+++ b/blueprints/dev/gitoxide/ops2deb.yml
@@ -12,6 +12,7 @@ matrix:
     - 0.41.0
     - 0.42.0
     - 0.44.0
+    - 0.45.0
 homepage: https://github.com/Byron/gitoxide
 summary: idiomatic, lean, fast & safe pure Rust implementation of Git
 description: |-

--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -313,3 +313,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.61.0/downloads/glab_1.61.0_linux_arm64.deb
   sha256: f628a54bda37506829922a06e0b77ba9bc8d7d91a1ad0237014ca201e20a0664
   timestamp: 2025-06-25 12:12:40+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.63.0/downloads/glab_1.63.0_linux_amd64.deb
+  sha256: a4157876e839744ed5d0d1de5541e6cd1196f74110b97fd613297842224a0b01
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.63.0/downloads/glab_1.63.0_linux_arm64.deb
+  sha256: 57867d2b00fec6f61a58efdb20666edb2481ada995d7870f588e4e68f133d901
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -75,6 +75,7 @@
       - 1.60.1
       - 1.60.2
       - 1.61.0
+      - 1.63.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-

--- a/blueprints/dev/hugo/ops2deb.lock.yml
+++ b/blueprints/dev/hugo/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/gohugoio/hugo/releases/download/v0.126.0/hugo_extended_0.126.0_linux-amd64.tar.gz
-  sha256: 86050a01e89fac27ac743f4a7baf8c8d34b1320fe690f5153445893f5eede06e
-  timestamp: 2024-05-14 15:06:29+00:00
-- url: https://github.com/gohugoio/hugo/releases/download/v0.126.0/hugo_extended_0.126.0_linux-arm64.tar.gz
-  sha256: 866bb830daa38e6647c3d3ee89830600d07575838543d9c6cb06198ebec44bef
-  timestamp: 2024-05-14 15:06:29+00:00
 - url: https://github.com/gohugoio/hugo/releases/download/v0.126.1/hugo_extended_0.126.1_linux-amd64.tar.gz
   sha256: fb97fc338fca83f2472e0d008c39d6e2b9a062553f2ac96ada6b087538d832f7
   timestamp: 2024-05-15 12:09:33+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/gohugoio/hugo/releases/download/v0.147.9/hugo_extended_0.147.9_linux-arm64.tar.gz
   sha256: e340a4192ef392ef4ef20bf736bf3f17e2b9651e86e31a71f5a48831ebdd2a76
   timestamp: 2025-06-23 09:09:46+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.148.1/hugo_extended_0.148.1_linux-amd64.tar.gz
+  sha256: 7059e6037aacd7530482985db89420f22a554138a38b748c887873827a8447d5
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.148.1/hugo_extended_0.148.1_linux-arm64.tar.gz
+  sha256: 40697173a737d5760fc7d2691ca36f0d71be2b2f33ef179ccd2545908d03fc5f
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/dev/hugo/ops2deb.yml
+++ b/blueprints/dev/hugo/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 0.126.0
     - 0.126.1
     - 0.126.3
     - 0.127.0
@@ -54,6 +53,7 @@ matrix:
     - 0.147.7
     - 0.147.8
     - 0.147.9
+    - 0.148.1
 revision: "2"
 homepage: https://gohugo.io/
 summary: fast and flexible Static Site Generator

--- a/blueprints/dev/kubebuilder/ops2deb.lock.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.lock.yml
@@ -196,3 +196,9 @@
 - url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.6.0/kubebuilder_linux_arm64
   sha256: 324b7a9a2ad53f93c8008eaf2d8472e365b1577a9766bf421fd86131e99adab6
   timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.7.0/kubebuilder_linux_amd64
+  sha256: e7cdfac83cf32ccf67ea07e7d256cee3129b6783577836fb85c4341d5d7f03e7
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.7.0/kubebuilder_linux_arm64
+  sha256: 20228f6bc8374735181a580376a442ac565699628d60b0acce1c00908ea512ed
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/dev/kubebuilder/ops2deb.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.yml
@@ -37,6 +37,7 @@ matrix:
     - 4.5.1
     - 4.5.2
     - 4.6.0
+    - 4.7.0
 homepage: https://book.kubebuilder.io
 summary: SDK for building Kubernetes APIs using CRDs
 description: |-

--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.18.zip
-  sha256: 3b591f98114e5c68fadc9b6870d1b59ba4a40c5c4b470ba4712c9e07a27926cc
-  timestamp: 2023-05-25 09:16:48+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.19.zip
   sha256: 1cc827f3b75ba6c4f3205652e7fdcb2a384724672e8fdd21028be25176d100d2
   timestamp: 2023-06-08 12:32:39+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.3.zip
   sha256: 13fb00a842f2bf2cc31bc5f6c33469c742d6101f71b763cc01e4b000e9bad8a4
   timestamp: 2025-06-18 21:07:06+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.4.zip
+  sha256: 9e30e095fd98599a010ef9f7ac931136c830f74a9abbac93e0eb6c73cf9fe67f
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.3.18
       - 2.3.19
       - 2.3.20
       - 2.3.21
@@ -73,6 +72,7 @@
       - 2.6.1
       - 2.6.2
       - 2.6.3
+      - 2.6.4
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/dev/scala-cli/ops2deb.lock.yml
+++ b/blueprints/dev/scala-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/VirtusLab/scala-cli/releases/download/v0.1.6/scala-cli-x86_64-pc-linux.deb
-  sha256: a507af660ec5f14bbc51839c9903e03a5b0a4d2668475184ab3037219d4fe9e9
-  timestamp: 2022-05-24 17:24:50+00:00
 - url: https://github.com/VirtusLab/scala-cli/releases/download/v0.1.7/scala-cli-x86_64-pc-linux.deb
   sha256: ebf345fed5181f84afe3b372fdcd92d96bf76eba75308b7a08033c45528e9240
   timestamp: 2022-06-06 20:26:08+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/VirtusLab/scala-cli/releases/download/v1.8.3/scala-cli-x86_64-pc-linux.deb
   sha256: 495be37e24bf1e16cd9225fd5ae2b503ea1e9e96e230d5a03e0f9d9f0d6e619c
   timestamp: 2025-06-26 12:12:33+00:00
+- url: https://github.com/VirtusLab/scala-cli/releases/download/v1.8.4/scala-cli-x86_64-pc-linux.deb
+  sha256: 1bfd6994001e1318e211e608ed3ade873364a58b4c938e6ecbf740da95fd480d
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/dev/scala-cli/ops2deb.yml
+++ b/blueprints/dev/scala-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: scala-cli
 matrix:
   versions:
-    - 0.1.6
     - 0.1.7
     - 0.1.8
     - 0.1.9
@@ -51,6 +50,7 @@ matrix:
     - 1.8.0
     - 1.8.1
     - 1.8.3
+    - 1.8.4
 homepage: https://scala-cli.virtuslab.org/
 summary: command-line tool to interact with the Scala language
 description: |-

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -619,3 +619,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.7.19/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 5ad6f11d5a04cb3af2418666031f20b63190f82032ec5a7f3a174385cc5567e4
   timestamp: 2025-07-03 00:32:44+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.8.0/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: c5a7c042e40a9acb693c5ee01f26db047b07e4f3f301470b38ee4a2f3e0e831b
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.8.0/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: 57c891ebe985ef1c4e83bbc60b9d2fce40fd6e383db451ac1fc04d60a415022d
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.8.0/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: a7d74ee5c5ff3069b9d88236a05f293cc4e2809bad872f3a88a384489ba3675e
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -106,6 +106,7 @@
       - 0.7.17
       - 0.7.18
       - 0.7.19
+      - 0.8.0
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/devops/argocd/ops2deb.lock.yml
+++ b/blueprints/devops/argocd/ops2deb.lock.yml
@@ -226,3 +226,9 @@
 - url: https://github.com/argoproj/argo-cd/releases/download/v3.0.6/argocd-linux-arm64
   sha256: 428ce0f030fd32ecf3cd6b89af169eb1f854479e86186ca623b456065cf963fa
   timestamp: 2025-06-10 00:32:28+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v3.0.11/argocd-linux-amd64
+  sha256: 8320c021c085ed0d4fc3a7a7916c730f5836c6f6f9b10483164b5aabfaa640cd
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v3.0.11/argocd-linux-arm64
+  sha256: 2f8e5c9167b647b5784745c276ec04320374607913ac35ed3ea4e25a29f2e770
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/devops/argocd/ops2deb.yml
+++ b/blueprints/devops/argocd/ops2deb.yml
@@ -42,6 +42,7 @@ matrix:
     - 3.0.4
     - 3.0.5
     - 3.0.6
+    - 3.0.11
 homepage: https://github.com/argoproj/argo-cd
 summary: continuous delivery tool for Kubernetes
 description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.

--- a/blueprints/devops/aws-iam-authenticator/ops2deb.lock.yml
+++ b/blueprints/devops/aws-iam-authenticator/ops2deb.lock.yml
@@ -130,3 +130,9 @@
 - url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.3/aws-iam-authenticator_0.7.3_linux_arm64
   sha256: 6b44989176d1abb9178b514d07e191b9c410b7eb83b42e1aeedacbd5f72a8900
   timestamp: 2025-06-19 00:32:23+00:00
+- url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.4/aws-iam-authenticator_0.7.4_linux_amd64
+  sha256: 85c20d45e1067535db642f5fa1666e13de1761ae8577d13526bf19c1a8caabac
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.4/aws-iam-authenticator_0.7.4_linux_arm64
+  sha256: 34468975cf1b293cca0304081264f8ddb052e84f0703afce6875f7d1ef5a0bc9
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/aws-iam-authenticator/ops2deb.yml
+++ b/blueprints/devops/aws-iam-authenticator/ops2deb.yml
@@ -26,6 +26,7 @@ matrix:
     - 0.7.1
     - 0.7.2
     - 0.7.3
+    - 0.7.4
 homepage: https://github.com/kubernetes-sigs/aws-iam-authenticator
 summary: Kubernetes authentication using AWS IAM
 description: A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster.

--- a/blueprints/devops/clusterctl/ops2deb.lock.yml
+++ b/blueprints/devops/clusterctl/ops2deb.lock.yml
@@ -106,3 +106,9 @@
 - url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.3/clusterctl-linux-arm64
   sha256: 0151f9fdd82897605d0e93d80de4c988b662ee30656a88989bf890c3db5ca2a5
   timestamp: 2025-06-17 21:06:43+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/clusterctl-linux-amd64
+  sha256: 61969d735eb4984ad93beb36e7623cdf256b40cceabec927d41e2a90ddf794ce
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/clusterctl-linux-arm64
+  sha256: 28bc478ca240dd899fa611d27868901d51d7d75d9612b1f45d607553897337ed
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/devops/clusterctl/ops2deb.yml
+++ b/blueprints/devops/clusterctl/ops2deb.yml
@@ -22,6 +22,7 @@ matrix:
     - 1.10.1
     - 1.10.2
     - 1.10.3
+    - 1.10.4
 homepage: https://cluster-api.sigs.k8s.io/
 summary: Kubernetes project offering declarative APIs for managing multiple clusters
 description: |-

--- a/blueprints/devops/docker-compose/ops2deb.lock.yml
+++ b/blueprints/devops/docker-compose/ops2deb.lock.yml
@@ -1,15 +1,6 @@
 - url: https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64
   sha256: f3f10cf3dbb8107e9ba2ea5f23c1d2159ff7321d16f0a23051d68d8e2547b323
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-aarch64
-  sha256: 27b3cb1f066cdba191c4df96255a3d7178294763c9d67fba528f769968fc2e65
-  timestamp: 2023-11-16 09:17:21+00:00
-- url: https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-armv7
-  sha256: 347b65d0cec622976bb753550d2708c8c9c760d55c1b5952a6800f5fadd4781c
-  timestamp: 2023-11-16 09:17:21+00:00
-- url: https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-linux-x86_64
-  sha256: 4f9b5313cf3eb1651b65aa6fc2fe1f59eb3812b7566f7c1b853be429b81bf3ab
-  timestamp: 2023-11-16 09:17:21+00:00
 - url: https://github.com/docker/compose/releases/download/v2.23.2/docker-compose-linux-aarch64
   sha256: f0d0b5fb35b2cd06823d3838a5163067ae54b7663bafafc875b3dd73d12285f0
   timestamp: 2023-11-22 18:22:09+00:00
@@ -451,3 +442,12 @@
 - url: https://github.com/docker/compose/releases/download/v2.38.1/docker-compose-linux-x86_64
   sha256: d94a60549c6916499ce41959941e6c88b67c23ed98d1c5eee2cfc4a2d58aa24b
   timestamp: 2025-06-30 21:06:59+00:00
+- url: https://github.com/docker/compose/releases/download/v2.38.2/docker-compose-linux-aarch64
+  sha256: 4d0f7678dd3338452beba4518e36a8e22b20cad79ba2535c687da554dc3997fb
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/docker/compose/releases/download/v2.38.2/docker-compose-linux-armv7
+  sha256: ec4786c5c33393d5e366fd6186cbfa116ae30a083666afefc428e4688a222c27
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/docker/compose/releases/download/v2.38.2/docker-compose-linux-x86_64
+  sha256: 486b3ffc0f806ca2efbc430cef89955386011662f0c76bad17c103d059cfa9cf
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/docker-compose/ops2deb.yml
+++ b/blueprints/devops/docker-compose/ops2deb.yml
@@ -18,7 +18,6 @@
       - arm64
       - armhf
     versions:
-      - 2.23.1
       - 2.23.2
       - 2.23.3
       - 2.24.0
@@ -68,6 +67,7 @@
       - 2.37.2
       - 2.37.3
       - 2.38.1
+      - 2.38.2
   homepage: https://docs.docker.com/compose
   summary: lightweight development environments using Docker
   description: |-

--- a/blueprints/devops/flux/ops2deb.lock.yml
+++ b/blueprints/devops/flux/ops2deb.lock.yml
@@ -16,15 +16,6 @@
 - url: https://github.com/fluxcd/flux2/releases/download/v0.24.1/flux_0.24.1_linux_amd64.tar.gz
   sha256: 3373a272ff888772e40647e90ba41dfa232e7482df62b10735cdd86a25e42178
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/fluxcd/flux2/releases/download/v0.29.2/flux_0.29.2_linux_amd64.tar.gz
-  sha256: 2684556bcfa785612f1546427d819ac65d211e6e342e3a796196e760fdafa8aa
-  timestamp: 2022-04-21 14:39:20+00:00
-- url: https://github.com/fluxcd/flux2/releases/download/v0.29.2/flux_0.29.2_linux_arm.tar.gz
-  sha256: 1c4347d19762e9841479a8fea3c709a082e2b1e7cf4f0653f80d9fe66e09a687
-  timestamp: 2022-04-21 14:39:20+00:00
-- url: https://github.com/fluxcd/flux2/releases/download/v0.29.2/flux_0.29.2_linux_arm64.tar.gz
-  sha256: f67bc91c336d810f4622f7585719a0deb2d9bfe833e7b15fa8865cc27a35bba4
-  timestamp: 2022-04-21 14:39:20+00:00
 - url: https://github.com/fluxcd/flux2/releases/download/v0.29.3/flux_0.29.3_linux_amd64.tar.gz
   sha256: 612a7ee0a96a8214bc85a8e7ba1b1d816a0121bab73e1e03be7f32a1a25f29ee
   timestamp: 2022-04-22 14:42:06+00:00
@@ -466,3 +457,12 @@
 - url: https://github.com/fluxcd/flux2/releases/download/v2.6.3/flux_2.6.3_linux_arm64.tar.gz
   sha256: a8901ac1733c622e23eea6b9c8c0cb2e0f9379b319f6fa92f0d1096f25d4660e
   timestamp: 2025-06-27 12:12:11+00:00
+- url: https://github.com/fluxcd/flux2/releases/download/v2.6.4/flux_2.6.4_linux_amd64.tar.gz
+  sha256: 9d3e21ad53baa0d5a062e1bd6f1a22d18b95906c682845bca9ffa272cff8a590
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/fluxcd/flux2/releases/download/v2.6.4/flux_2.6.4_linux_arm.tar.gz
+  sha256: eb8bd66939ad160215462ec3646299a4876c94f9755cc06a77b151783f87e90f
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/fluxcd/flux2/releases/download/v2.6.4/flux_2.6.4_linux_arm64.tar.gz
+  sha256: 674e605f527841bb9b50a692b3ce497752cfc81438f85b4d1523d86aca637353
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/devops/flux/ops2deb.yml
+++ b/blueprints/devops/flux/ops2deb.yml
@@ -36,7 +36,6 @@
       - arm64
       - armhf
     versions:
-      - 0.29.2
       - 0.29.3
       - 0.29.4
       - 0.29.5
@@ -86,6 +85,7 @@
       - 2.6.1
       - 2.6.2
       - 2.6.3
+      - 2.6.4
   homepage: https://fluxcd.io
   summary: open and extensible continuous delivery solution for Kubernetes
   description: |-

--- a/blueprints/devops/goreleaser/ops2deb.lock.yml
+++ b/blueprints/devops/goreleaser/ops2deb.lock.yml
@@ -142,3 +142,9 @@
 - url: https://github.com/goreleaser/goreleaser/releases/download/v2.10.2/goreleaser_Linux_x86_64.tar.gz
   sha256: 7557d103d66efad2cc3c61c458b6ec948d8cb0c49f734fbb94075e9f774076df
   timestamp: 2025-06-09 03:32:23+00:00
+- url: https://github.com/goreleaser/goreleaser/releases/download/v2.11.0/goreleaser_Linux_arm64.tar.gz
+  sha256: b06def64ee10adfef205cbe3a4c321aa86339a8e7ca0003b768ed680f6ab3000
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/goreleaser/goreleaser/releases/download/v2.11.0/goreleaser_Linux_x86_64.tar.gz
+  sha256: da8383cb2e1e848372a337922333ec883b8607c2ba70a2a68a0f33022fb7ebfd
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/goreleaser/ops2deb.yml
+++ b/blueprints/devops/goreleaser/ops2deb.yml
@@ -28,6 +28,7 @@ matrix:
     - 2.9.0
     - 2.10.1
     - 2.10.2
+    - 2.11.0
 homepage: https://goreleaser.com
 summary: release Go projects as fast and easily as possible
 description: |-

--- a/blueprints/devops/helm/ops2deb.lock.yml
+++ b/blueprints/devops/helm/ops2deb.lock.yml
@@ -304,3 +304,9 @@
 - url: https://get.helm.sh/helm-v3.18.3-linux-arm.tar.gz
   sha256: 5ec62879f57d6acc0436440c88459d2a5c8de233273e73ff6498d79fd2d92653
   timestamp: 2025-06-16 21:07:05+00:00
+- url: https://get.helm.sh/helm-v3.18.4-linux-amd64.tar.gz
+  sha256: f8180838c23d7c7d797b208861fecb591d9ce1690d8704ed1e4cb8e2add966c1
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://get.helm.sh/helm-v3.18.4-linux-arm.tar.gz
+  sha256: 34ea88aef15fd822e839da262176a36e865bb9cfdb89b1f723811c0cc527f981
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/helm/ops2deb.yml
+++ b/blueprints/devops/helm/ops2deb.yml
@@ -84,6 +84,7 @@
       - 3.18.1
       - 3.18.2
       - 3.18.3
+      - 3.18.4
   homepage: https://helm.sh
   summary: Kubernetes package manager
   description: |-

--- a/blueprints/devops/helmfile/ops2deb.lock.yml
+++ b/blueprints/devops/helmfile/ops2deb.lock.yml
@@ -238,3 +238,9 @@
 - url: https://github.com/helmfile/helmfile/releases/download/v1.1.2/helmfile_1.1.2_linux_arm64.tar.gz
   sha256: 9a7ef45f38c24c4a3e56973da1bd7e13d3d106fb6f15624910be754f4d74c980
   timestamp: 2025-06-12 12:12:15+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.1.3/helmfile_1.1.3_linux_amd64.tar.gz
+  sha256: 80733cd836f8b0d5b2271bf7b4a25b86abf80c4e5890b8ff2635d7a529a6df1b
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.1.3/helmfile_1.1.3_linux_arm64.tar.gz
+  sha256: c2a4d75ec93e9cbe050f81a38d26178383da3f0ff960018b04dadebe1d2458a1
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/helmfile/ops2deb.yml
+++ b/blueprints/devops/helmfile/ops2deb.yml
@@ -112,6 +112,7 @@
       - 1.1.0
       - 1.1.1
       - 1.1.2
+      - 1.1.3
   homepage: https://helmfile.readthedocs.io/
   summary: deploy Kubernetes Helm Charts
   description: |-

--- a/blueprints/devops/iamlive/ops2deb.lock.yml
+++ b/blueprints/devops/iamlive/ops2deb.lock.yml
@@ -208,3 +208,9 @@
 - url: https://github.com/iann0036/iamlive/releases/download/v1.1.25/iamlive-v1.1.25-linux-arm64.tar.gz
   sha256: 6a6c15de0c76373aeadc39667b88fa20620cb8f0c7b9cbd0b931d2f0df649fe8
   timestamp: 2025-06-07 09:06:48+00:00
+- url: https://github.com/iann0036/iamlive/releases/download/v1.1.26/iamlive-v1.1.26-linux-amd64.tar.gz
+  sha256: 4edf412742b62768232ef964482113aba49db3a2436d64b835abadddbacbf50b
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/iann0036/iamlive/releases/download/v1.1.26/iamlive-v1.1.26-linux-arm64.tar.gz
+  sha256: 5cd3b425cdecf8bb230b4a3feae551366ab8096682e314886b55738a74f916f7
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/iamlive/ops2deb.yml
+++ b/blueprints/devops/iamlive/ops2deb.yml
@@ -39,6 +39,7 @@ matrix:
     - 1.1.23
     - 1.1.24
     - 1.1.25
+    - 1.1.26
 homepage: https://github.com/iann0036/iamlive
 summary: generate policies from AWS calls
 description: |-

--- a/blueprints/devops/infracost/ops2deb.lock.yml
+++ b/blueprints/devops/infracost/ops2deb.lock.yml
@@ -202,3 +202,9 @@
 - url: https://github.com/infracost/infracost/releases/download/v0.10.41/infracost-linux-arm64.tar.gz
   sha256: 4f643c8f4894dc924f7e8dd861b28e17a9d8cc773b3f2d15c000409252749488
   timestamp: 2025-03-13 09:08:25+00:00
+- url: https://github.com/infracost/infracost/releases/download/v0.10.42/infracost-linux-amd64.tar.gz
+  sha256: 2eb36de6730634ffe6c12bbdc6d42c45c4b718a664e1d9b94c6478a8f3a575bf
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/infracost/infracost/releases/download/v0.10.42/infracost-linux-arm64.tar.gz
+  sha256: f8bae6a02181c1250a9147dc00ec89cfdfbfad74f76770aca4cec0db2aed6e2f
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/devops/infracost/ops2deb.yml
+++ b/blueprints/devops/infracost/ops2deb.yml
@@ -38,6 +38,7 @@ matrix:
     - 0.10.39
     - 0.10.40
     - 0.10.41
+    - 0.10.42
 homepage: https://www.infracost.io
 summary: cloud cost estimates for Terraform in pull requests
 description: |-

--- a/blueprints/devops/k9s/ops2deb.lock.yml
+++ b/blueprints/devops/k9s/ops2deb.lock.yml
@@ -439,3 +439,12 @@
 - url: https://github.com/derailed/k9s/releases/download/v0.50.7/k9s_Linux_armv7.tar.gz
   sha256: 66e5b5407c12db7d417cd51a9d17c17b55f31b83bc946bdd282b27b73fa887b2
   timestamp: 2025-07-05 18:08:27+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.9/k9s_Linux_amd64.tar.gz
+  sha256: ce5ca5132d882f46c88ab6f090f091a54425728b2009a46b176554506ac7e07e
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.9/k9s_Linux_arm64.tar.gz
+  sha256: 6943eb054196d0ed8b2a902bb271e0ce033e409de9f7331a69583ead3f6149b8
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/derailed/k9s/releases/download/v0.50.9/k9s_Linux_armv7.tar.gz
+  sha256: a56a0fb69f7a259aac7d6e835952e85225cfc0f0f20f0f5e469a5b2300e22bd6
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/k9s/ops2deb.yml
+++ b/blueprints/devops/k9s/ops2deb.yml
@@ -92,6 +92,7 @@
       - 0.50.5
       - 0.50.6
       - 0.50.7
+      - 0.50.9
   homepage: https://k9scli.io
   summary: manage your Kubernetes clusters with style
   description: |-

--- a/blueprints/devops/kubectl-oidc-login/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl-oidc-login/ops2deb.lock.yml
@@ -52,3 +52,9 @@
 - url: https://github.com/int128/kubelogin/releases/download/v1.33.0/kubelogin_linux_arm64.zip
   sha256: 2cfb36ca680d169bfbf831e3dbc4a7574d340a42be7b3b1b08f73f48b38f7437
   timestamp: 2025-06-16 06:11:11+00:00
+- url: https://github.com/int128/kubelogin/releases/download/v1.34.0/kubelogin_linux_amd64.zip
+  sha256: 9f68bd3fb1427fd12befe492a45a309bcb341d1bdff0d090052cfe3833291529
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/int128/kubelogin/releases/download/v1.34.0/kubelogin_linux_arm64.zip
+  sha256: 97a0d6884796f208bc408e39f0fdf72a9752490c3dd12194c24389775857564f
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/kubectl-oidc-login/ops2deb.yml
+++ b/blueprints/devops/kubectl-oidc-login/ops2deb.yml
@@ -13,6 +13,7 @@ matrix:
     - 1.32.3
     - 1.32.4
     - 1.33.0
+    - 1.34.0
 homepage: https://github.com/int128/kubelogin
 summary: Kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)
 description: |-

--- a/blueprints/devops/kubectl/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl/ops2deb.lock.yml
@@ -415,3 +415,12 @@
 - url: https://dl.k8s.io/release/v1.33.2/bin/linux/arm64/kubectl
   sha256: 54dc02c8365596eaa2b576fae4e3ac521db9130e26912385e1e431d156f8344d
   timestamp: 2025-06-18 18:09:36+00:00
+- url: https://dl.k8s.io/release/v1.33.3/bin/linux/amd64/kubectl
+  sha256: 2fcf65c64f352742dc253a25a7c95617c2aba79843d1b74e585c69fe4884afb0
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://dl.k8s.io/release/v1.33.3/bin/linux/arm/kubectl
+  sha256: 0124dba9e9091b872591cabcbaea7df07069cb132d38d95f3c7bc8d5b8b621a9
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://dl.k8s.io/release/v1.33.3/bin/linux/arm64/kubectl
+  sha256: 3d514dbae5dc8c09f773df0ef0f5d449dfad05b3aca5c96b13565f886df345fd
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/devops/kubectl/ops2deb.yml
+++ b/blueprints/devops/kubectl/ops2deb.yml
@@ -95,6 +95,7 @@
       - 1.33.0
       - 1.33.1
       - 1.33.2
+      - 1.33.3
   homepage: https://github.com/kubernetes/kubectl
   summary: command line client for controlling a Kubernetes cluster
   description: |-

--- a/blueprints/devops/kubelogin/ops2deb.lock.yml
+++ b/blueprints/devops/kubelogin/ops2deb.lock.yml
@@ -118,3 +118,9 @@
 - url: https://github.com/Azure/kubelogin/releases/download/v0.2.9/kubelogin-linux-arm64.zip
   sha256: eb5fda70613abdaf4023cac7efad113ab90f9b38922a1dd2f00ab903d0508e7d
   timestamp: 2025-06-25 00:33:16+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.10/kubelogin-linux-amd64.zip
+  sha256: d765147460b8719b34cb35e8bc6d9d7c3b8f53bd1a1b9f1e70069e22bd1b6c03
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.10/kubelogin-linux-arm64.zip
+  sha256: 470f56c8f1ef61a7d3fc949b27c4bf383f774c1953f975491f5fbde4b18955cf
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/devops/kubelogin/ops2deb.yml
+++ b/blueprints/devops/kubelogin/ops2deb.yml
@@ -24,6 +24,7 @@ matrix:
     - 0.2.7
     - 0.2.8
     - 0.2.9
+    - 0.2.10
 homepage: https://github.com/Azure/kubelogin
 summary: Kubernetes credential (exec) plugin implementing azure authentication
 description: |-

--- a/blueprints/devops/linkerd/ops2deb.lock.yml
+++ b/blueprints/devops/linkerd/ops2deb.lock.yml
@@ -1,15 +1,6 @@
 - url: https://github.com/linkerd/linkerd2/releases/download/edge-21.10.3/linkerd2-cli-edge-21.10.3-linux-amd64
   sha256: ad308ef6515e60f6be1ceec6212296c80108f625686736b1fbeaa4a1d3cb7d51
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/linkerd/linkerd2/releases/download/edge-22.10.2/linkerd2-cli-edge-22.10.2-linux-amd64
-  sha256: 65d6baf844de66755903ad55ce737b5fed2abe3d67d8ced2ce8cb5f2f7ba9316
-  timestamp: 2022-10-12 04:39:34+00:00
-- url: https://github.com/linkerd/linkerd2/releases/download/edge-22.10.2/linkerd2-cli-edge-22.10.2-linux-arm
-  sha256: 6dfacdd6060f9c9786a608f9fde3e4b98c8013675fa3f120c380c50cbc6c8c02
-  timestamp: 2022-10-12 04:39:34+00:00
-- url: https://github.com/linkerd/linkerd2/releases/download/edge-22.10.2/linkerd2-cli-edge-22.10.2-linux-arm64
-  sha256: 15608eb8b310fd8905a3e18e5f3771f9cc6b05a56f49616114c861779bf2bb67
-  timestamp: 2022-10-12 04:39:34+00:00
 - url: https://github.com/linkerd/linkerd2/releases/download/edge-22.10.3/linkerd2-cli-edge-22.10.3-linux-amd64
   sha256: 9a1b902ea0b95b6c6a145e144080bd299a8ef364057ccc17b6fc6b3b9458d453
   timestamp: 2022-10-28 06:06:14+00:00
@@ -451,3 +442,12 @@
 - url: https://github.com/linkerd/linkerd2/releases/download/edge-25.7.1/linkerd2-cli-edge-25.7.1-linux-arm64
   sha256: 70810fe9e17cea5804400a58b21b8e8ccafb924666941bddc72073851cde4eac
   timestamp: 2025-07-02 21:07:08+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.7.4/linkerd2-cli-edge-25.7.4-linux-amd64
+  sha256: b5c0c639c01f8e58ae88dbce1608d2af2c118405073e8e32187ad68a24ddbdf4
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.7.4/linkerd2-cli-edge-25.7.4-linux-arm
+  sha256: 440e06824f5ff64b2ac6c1484393af059b72410daf0bcf6abfda4a706e8e19cf
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.7.4/linkerd2-cli-edge-25.7.4-linux-arm64
+  sha256: 8ebd95b05898b23cff452c4a842c19e61755a0ff0290e4aa60f926703fb327a6
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/linkerd/ops2deb.yml
+++ b/blueprints/devops/linkerd/ops2deb.yml
@@ -18,7 +18,6 @@
       - arm64
       - armhf
     versions:
-      - 22.10.2
       - 22.10.3
       - 22.11.1
       - 22.11.2
@@ -68,6 +67,7 @@
       - 25.6.3
       - 25.6.4
       - 25.7.1
+      - 25.7.4
   homepage: https://linkerd.io
   summary: ultralight service mesh for Kubernetes
   description: |-

--- a/blueprints/devops/logcli/ops2deb.lock.yml
+++ b/blueprints/devops/logcli/ops2deb.lock.yml
@@ -322,3 +322,12 @@
 - url: https://github.com/grafana/loki/releases/download/v3.5.1/logcli-linux-arm64.zip
   sha256: d93268dc25e481c4407c968c631223eabd414327dbd622c78cede70668ec164e
   timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.5.2/logcli-linux-amd64.zip
+  sha256: de4db534ef20b942566a45f5185ea9d1ce48947e34fb0f91d382a406b8bd1737
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.5.2/logcli-linux-arm.zip
+  sha256: 38c566afece28cd8fefd57b580e16ee2ee951ac173d73c3b491ee1a889c4b88b
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.5.2/logcli-linux-arm64.zip
+  sha256: 29b18d062fc25d3a6c449ab12bcf7ff539f1878e4dedc155b97c9e964e6fb38e
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/devops/logcli/ops2deb.yml
+++ b/blueprints/devops/logcli/ops2deb.yml
@@ -41,6 +41,7 @@ matrix:
     - 3.4.3
     - 3.5.0
     - 3.5.1
+    - 3.5.2
 homepage: https://github.com/grafana/loki
 summary: command-line interface for loki
 description: It facilitates running LogQL queries against a Loki instance.

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.113.0/mirrord_linux_aarch64.zip
-  sha256: 4198c27b0fb3a0b77e63d167d6b36164238474b4c1fe3b3cb31195422e929d66
-  timestamp: 2024-08-14 12:09:35+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.113.0/mirrord_linux_x86_64.zip
-  sha256: 8456ed408f0d0b24811abd9df2ad079a462c236fadb8c57cac01f270a653e1b1
-  timestamp: 2024-08-14 12:09:35+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.113.1/mirrord_linux_aarch64.zip
   sha256: cc781af41ba515490025d6cbcdd6e8e7fdef7327b9f1c03c489fbb61507ab77a
   timestamp: 2024-08-15 21:05:51+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.148.0/mirrord_linux_x86_64.zip
   sha256: e1e6cde42ac6cc66ccd40659f21fd1609be972268d321b3a4b45430e9ad9cc8d
   timestamp: 2025-07-01 12:12:47+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.151.0/mirrord_linux_aarch64.zip
+  sha256: d310e939c08521e33cb21295f16bf71d8d58bd4c23d9dfb88a13a0a6b2425fcc
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.151.0/mirrord_linux_x86_64.zip
+  sha256: 34d960f6ecf845c2d3a9543c7310b941344d98b6284d1b35db0379ffd04face8
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.113.0
     - 3.113.1
     - 3.114.0
     - 3.114.1
@@ -54,6 +53,7 @@ matrix:
     - 3.146.0
     - 3.147.0
     - 3.148.0
+    - 3.151.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-

--- a/blueprints/devops/natscli/ops2deb.lock.yml
+++ b/blueprints/devops/natscli/ops2deb.lock.yml
@@ -112,3 +112,12 @@
 - url: https://github.com/nats-io/natscli/releases/download/v0.2.3/nats-0.2.3-linux-arm7.zip
   sha256: 4106d154abd19971a971c980d7284872b267ec49b989562c4c68fc2c7083bc42
   timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.4/nats-0.2.4-linux-amd64.zip
+  sha256: 79f8404ed49b24a9dfea0fb97bb2438cbbe419c5dc14f70ef7ed570ed14c8bcf
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.4/nats-0.2.4-linux-arm64.zip
+  sha256: c325fb03a802ebd94c6f24d274ece465a7a6abe40566174e208b0fe67e2d8af4
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.2.4/nats-0.2.4-linux-arm7.zip
+  sha256: 55f8b7778d0a7a5027157d392b35fc15705b29c6016685aa4f29fae51d6061b1
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/natscli/ops2deb.yml
+++ b/blueprints/devops/natscli/ops2deb.yml
@@ -44,6 +44,7 @@
       - 0.2.0
       - 0.2.2
       - 0.2.3
+      - 0.2.4
   homepage: https://github.com/nats-io/natscli
   summary: command-line interface for NATS
   description: |-

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -172,3 +172,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.19.3/openshift-client-linux.tar.gz
   sha256: 5c5848b6a9ae52e981050ef527930ebf8e9e9e021a1dd8c3b386904df389e3c3
   timestamp: 2025-07-04 06:10:40+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.19.5/openshift-client-linux-arm64.tar.gz
+  sha256: 3d34e1456b15303f497039a9c701629625290037e41f0d8f47bcdaefc5075a73
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.19.5/openshift-client-linux.tar.gz
+  sha256: f7dedf386815155f9ba6d8b7d583e075e1a1fe4bd0be769569352f069e34f7c4
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -32,6 +32,7 @@ matrix:
     - 4.19.1
     - 4.19.2
     - 4.19.3
+    - 4.19.5
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/olivetin/ops2deb.lock.yml
+++ b/blueprints/devops/olivetin/ops2deb.lock.yml
@@ -295,3 +295,12 @@
 - url: https://github.com/OliveTin/OliveTin/releases/download/2025.6.22/OliveTin_linux_armv7.deb
   sha256: b289a9298852671128cb6225e5cf7a2b10e39d826937ca61abaeff67ba890599
   timestamp: 2025-06-23 00:35:09+00:00
+- url: https://github.com/OliveTin/OliveTin/releases/download/2025.7.13/OliveTin_linux_amd64.deb
+  sha256: d3e5d2887c49f1799e329931be113553c8a7e980c0542852f720036bac3e6338
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/OliveTin/OliveTin/releases/download/2025.7.13/OliveTin_linux_arm64.deb
+  sha256: 32895b0f86e04c60d788da45f92d8b2a8b8ada34353032166c1e267e467f27d3
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/OliveTin/OliveTin/releases/download/2025.7.13/OliveTin_linux_armv7.deb
+  sha256: 90946feef7a61eda5ba31d425a1f5cb43529770ee6bb6a3e2af8dc5faac875d7
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/olivetin/ops2deb.yml
+++ b/blueprints/devops/olivetin/ops2deb.yml
@@ -38,6 +38,7 @@ matrix:
     - 2025.6.1
     - 2025.6.6
     - 2025.6.22
+    - 2025.7.13
 revision: "2"
 summary: safe and simple access to predefined shell commands from a web interface
 description: |-

--- a/blueprints/devops/opentofu/ops2deb.lock.yml
+++ b/blueprints/devops/opentofu/ops2deb.lock.yml
@@ -124,3 +124,9 @@
 - url: https://github.com/opentofu/opentofu/releases/download/v1.10.2/tofu_1.10.2_linux_arm64.zip
   sha256: f6e063fe2112d6c121f690c396d63949bef37142ba8b4c1f29b812771a7a7ee7
   timestamp: 2025-07-01 18:09:46+00:00
+- url: https://github.com/opentofu/opentofu/releases/download/v1.10.3/tofu_1.10.3_linux_amd64.zip
+  sha256: acf330602ec6ae29ba68dd5d8eb1f645811ae9809231ecdccd4774b21d5c79bc
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/opentofu/opentofu/releases/download/v1.10.3/tofu_1.10.3_linux_arm64.zip
+  sha256: 7011e9da95299dc8f8eaf4a54ebe066982ead04de778505dfbcaf406de25519a
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/opentofu/ops2deb.yml
+++ b/blueprints/devops/opentofu/ops2deb.yml
@@ -25,6 +25,7 @@ matrix:
     - 1.10.0
     - 1.10.1
     - 1.10.2
+    - 1.10.3
 homepage: https://opentofu.org
 summary: lets you declaratively manage your cloud infrastructure
 description: |-

--- a/blueprints/devops/operator-sdk/ops2deb.lock.yml
+++ b/blueprints/devops/operator-sdk/ops2deb.lock.yml
@@ -220,3 +220,9 @@
 - url: https://github.com/operator-framework/operator-sdk/releases/download/v1.40.0/operator-sdk_linux_arm64
   sha256: 2017fd31adbba6d7e0a3cd89a207906adb7f4cbb0c99fdf61759f95cd86c754d
   timestamp: 2025-06-02 21:06:47+00:00
+- url: https://github.com/operator-framework/operator-sdk/releases/download/v1.41.1/operator-sdk_linux_amd64
+  sha256: 348284cbd5298f70e2b0a01f9f86820a3149aa6e7e19272e886a9d5769c7fb69
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/operator-framework/operator-sdk/releases/download/v1.41.1/operator-sdk_linux_arm64
+  sha256: 719e5565cb11895995284d236e94bc14af0c9e7c96954ce4f30f450d8c86995e
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/operator-sdk/ops2deb.yml
+++ b/blueprints/devops/operator-sdk/ops2deb.yml
@@ -69,6 +69,7 @@
       - 1.39.1
       - 1.39.2
       - 1.40.0
+      - 1.41.1
   homepage: https://sdk.operatorframework.io
   summary: SDK for building Kubernetes applications
   description: |-

--- a/blueprints/devops/pluto/ops2deb.lock.yml
+++ b/blueprints/devops/pluto/ops2deb.lock.yml
@@ -166,3 +166,9 @@
 - url: https://github.com/FairwindsOps/pluto/releases/download/v5.21.8/pluto_5.21.8_linux_arm64.tar.gz
   sha256: 6a8a712c185f1c824d5701e253dc52d2be790acdd94830c55ca5d1c75a327604
   timestamp: 2025-06-17 18:09:42+00:00
+- url: https://github.com/FairwindsOps/pluto/releases/download/v5.22.0/pluto_5.22.0_linux_amd64.tar.gz
+  sha256: f12c29d3d18dbba21994371dcf9d1e6943c9bfc9be59c77db4d1b7fb855d6935
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/FairwindsOps/pluto/releases/download/v5.22.0/pluto_5.22.0_linux_arm64.tar.gz
+  sha256: 303255d5cd780ffbe6a1e9dfd118423dae84cf1cd6fcafdcc04eb361a48f778e
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/pluto/ops2deb.yml
+++ b/blueprints/devops/pluto/ops2deb.yml
@@ -32,6 +32,7 @@ matrix:
     - 5.21.6
     - 5.21.7
     - 5.21.8
+    - 5.22.0
 homepage: https://github.com/FairwindsOps/pluto/
 summary: discover deprecated apiversions in kubernetes
 description: |-

--- a/blueprints/devops/rancher/ops2deb.lock.yml
+++ b/blueprints/devops/rancher/ops2deb.lock.yml
@@ -100,3 +100,9 @@
 - url: https://github.com/rancher/cli/releases/download/v2.11.2/rancher-linux-arm-v2.11.2.tar.gz
   sha256: 979efc08e0f065cc960eedce1eb6c5ebaa4977d7e9df1386da4557245ace5294
   timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.11.3/rancher-linux-amd64-v2.11.3.tar.gz
+  sha256: 84e468005cb65066a4105ca30c67eade78ea2b18fa03977a89b364c694338010
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.11.3/rancher-linux-arm-v2.11.3.tar.gz
+  sha256: 57fcf72fff5e902cbc8ae3c857519750ed34b7a9954ccbf8e684f82d35e5f0b6
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/rancher/ops2deb.yml
+++ b/blueprints/devops/rancher/ops2deb.yml
@@ -47,6 +47,7 @@
       - 2.11.0
       - 2.11.1
       - 2.11.2
+      - 2.11.3
   homepage: https://github.com/rancher/cli
   summary: command-line interface for rancher
   description: |-

--- a/blueprints/devops/rclone/ops2deb.lock.yml
+++ b/blueprints/devops/rclone/ops2deb.lock.yml
@@ -295,3 +295,12 @@
 - url: https://github.com/rclone/rclone/releases/download/v1.70.2/rclone-v1.70.2-linux-arm64.zip
   sha256: f79595d23fe45bac9d2a159562ab5e22dcb8b057fa9c7a2248d3541573e9e0a7
   timestamp: 2025-06-27 15:07:34+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.70.3/rclone-v1.70.3-linux-amd64.zip
+  sha256: 7d69057e69385f6514a9684c7eaa424d972096b130284bb34dd967c4ed4f9dad
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.70.3/rclone-v1.70.3-linux-arm.zip
+  sha256: ca7d276ff2dfe27816d8c589fa2214f3c7b9ebbb3e459665febd9b27b8ad1f31
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.70.3/rclone-v1.70.3-linux-arm64.zip
+  sha256: 1b08be34622f1f9bb9b069a85d036bba822b690790215c18a9418dbaf19505fe
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/rclone/ops2deb.yml
+++ b/blueprints/devops/rclone/ops2deb.yml
@@ -70,6 +70,7 @@
       - 1.70.0
       - 1.70.1
       - 1.70.2
+      - 1.70.3
   revision: "2"
   homepage: https://rclone.org/
   summary: rsync for cloud storage

--- a/blueprints/devops/rpk/ops2deb.lock.yml
+++ b/blueprints/devops/rpk/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/redpanda-data/redpanda/releases/download/v23.3.2/rpk-linux-amd64.zip
-  sha256: d7595e59c43ad4f2b65bf646991ea1f2a3abf98bc503b71b503227dc6734ffc2
-  timestamp: 2024-01-13 01:16:45+00:00
-- url: https://github.com/redpanda-data/redpanda/releases/download/v23.3.2/rpk-linux-arm64.zip
-  sha256: 805cd7d67cb6d8da11075e52ef28143816ce1bfeeb1c6732b035ae709af990b6
-  timestamp: 2024-01-13 01:16:45+00:00
 - url: https://github.com/redpanda-data/redpanda/releases/download/v23.3.3/rpk-linux-amd64.zip
   sha256: d6503b323da7d31ec0e9b5f924189625bfe445d4f68733abe59bbbde5997f9a0
   timestamp: 2024-01-21 01:23:25+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.7/rpk-linux-arm64.zip
   sha256: 92ca0041aa62e4130d09f37af2e0f6dac092a2ec7693c94bbf45be009cd3ef4c
   timestamp: 2025-07-04 15:07:11+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.8/rpk-linux-amd64.zip
+  sha256: 342b99d0152e8073e6321291e1800c4c1273498701fb5db762b3f52a8cfe1d4e
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.8/rpk-linux-arm64.zip
+  sha256: 910f2b6ccf1900180d61f105476853d08b27b05c29d312800ec01bba6632168e
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/rpk/ops2deb.yml
+++ b/blueprints/devops/rpk/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 23.3.2
     - 23.3.3
     - 23.3.4
     - 23.3.5
@@ -54,6 +53,7 @@ matrix:
     - 25.1.5
     - 25.1.6
     - 25.1.7
+    - 25.1.8
 homepage: https://redpanda.com/
 summary: interact with your Redpanda clusters
 description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.69.13/terragrunt_linux_amd64
-  sha256: 6208c496f9bff82563b8b434e3040d7c8b9327a9cac6f3f9ea7ca5648aebeae5
-  timestamp: 2024-12-13 18:08:27+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.69.13/terragrunt_linux_arm64
-  sha256: 1e54b8e55af0bdd93ed631f8e6647963ffb18201661f5ed3ba3a2b766225e753
-  timestamp: 2024-12-13 18:08:27+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.70.0/terragrunt_linux_amd64
   sha256: 6ad5ec761e2db1c2a0eef3bb910df96c79c42a0efe0de9ab409fe83d71541c06
   timestamp: 2024-12-18 15:06:49+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.83.0/terragrunt_linux_arm64
   sha256: a24f1defb8f2d2493d2901739506fee0f08532e95df1a7625a63b9122be60e25
   timestamp: 2025-07-04 15:07:11+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.83.2/terragrunt_linux_amd64
+  sha256: db5ecb13589a6e666efe1dfcca8308a6cc623bba5b47b2e739391b7aab8ecbda
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.83.2/terragrunt_linux_arm64
+  sha256: 76117f43fc24a3e750afb0d0fedc6c4dba3760d2216f2b8eee2139deb41639f2
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.69.13
       - 0.70.0
       - 0.70.1
       - 0.70.2
@@ -75,6 +74,7 @@
       - 0.82.3
       - 0.82.4
       - 0.83.0
+      - 0.83.2
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/devops/tflint/ops2deb.lock.yml
+++ b/blueprints/devops/tflint/ops2deb.lock.yml
@@ -190,3 +190,9 @@
 - url: https://github.com/terraform-linters/tflint/releases/download/v0.58.0/tflint_linux_arm64.zip
   sha256: 7500c93e69ba0f37a4bb5f403cdbaec7230fa65044f39affa1939d8e0df01ad9
   timestamp: 2025-05-25 09:07:54+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.58.1/tflint_linux_amd64.zip
+  sha256: 2fea1af8e8602d4d9e4253a588ac66f17bf36152cafb51f4d929b8bc6335e740
+  timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.58.1/tflint_linux_arm64.zip
+  sha256: 5ddfd9948ba5ccbea3273cd99c5bc948fd8a0fbd36c593b3738191b3d0008dc3
+  timestamp: 2025-07-18 12:04:47+00:00

--- a/blueprints/devops/tflint/ops2deb.yml
+++ b/blueprints/devops/tflint/ops2deb.yml
@@ -36,6 +36,7 @@ matrix:
     - 0.56.0
     - 0.57.0
     - 0.58.0
+    - 0.58.1
 homepage: https://github.com/terraform-linters/tflint
 summary: pluggable Terraform linter
 description: |-

--- a/blueprints/secops/boundary/ops2deb.lock.yml
+++ b/blueprints/secops/boundary/ops2deb.lock.yml
@@ -367,3 +367,12 @@
 - url: https://releases.hashicorp.com/boundary/0.19.2/boundary_0.19.2_linux_arm64.zip
   sha256: 03db0cfe813df0c2d08ec23c8c2b03da5a9ae31bd38e695bf45fa6564d57add3
   timestamp: 2025-05-25 09:07:54+00:00
+- url: https://releases.hashicorp.com/boundary/0.19.3/boundary_0.19.3_linux_amd64.zip
+  sha256: 55e69a4a4b1b28e204d875ceb1979425151a0da409f781556c0387d77bb0ebdb
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://releases.hashicorp.com/boundary/0.19.3/boundary_0.19.3_linux_arm.zip
+  sha256: f056823ba63693f9aab041f7fe0fbfc3b57aab4e0f8baf1c6d77fc4b9297717b
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://releases.hashicorp.com/boundary/0.19.3/boundary_0.19.3_linux_arm64.zip
+  sha256: 957879fe6f38626114a895866dd4aef718c23b7dacc8b65e48b9c0d816296328
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/secops/boundary/ops2deb.yml
+++ b/blueprints/secops/boundary/ops2deb.yml
@@ -85,6 +85,7 @@
       - 0.19.0
       - 0.19.1
       - 0.19.2
+      - 0.19.3
   homepage: https://www.boundaryproject.io
   summary: provide simple and secure access to hosts and services
   description: |-

--- a/blueprints/secops/cosign/ops2deb.lock.yml
+++ b/blueprints/secops/cosign/ops2deb.lock.yml
@@ -34,3 +34,9 @@
 - url: https://github.com/sigstore/cosign/releases/download/v2.5.2/cosign-linux-arm64
   sha256: 2cbcea1873ad76274c3f241ef175d204654e3aac3e73e6ec4504e5227015cb0a
   timestamp: 2025-06-18 03:28:48+00:00
+- url: https://github.com/sigstore/cosign/releases/download/v2.5.3/cosign-linux-amd64
+  sha256: 783b5d6c74105401c63946c68d9b2a4e1aab3c8abce043e06b8510b02b623ec9
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/sigstore/cosign/releases/download/v2.5.3/cosign-linux-arm64
+  sha256: bffabe4cf183122b7de3111257a863c99e7dc6cf1093bfd7bf961de1795589b8
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/secops/cosign/ops2deb.yml
+++ b/blueprints/secops/cosign/ops2deb.yml
@@ -10,6 +10,7 @@ matrix:
     - 2.5.0
     - 2.5.1
     - 2.5.2
+    - 2.5.3
 homepage: https://www.sigstore.dev
 summary: code signing and transparency for containers and binaries
 description: |-

--- a/blueprints/secops/kubescape/ops2deb.lock.yml
+++ b/blueprints/secops/kubescape/ops2deb.lock.yml
@@ -124,3 +124,9 @@
 - url: https://github.com/kubescape/kubescape/releases/download/v3.0.34/kubescape-ubuntu-latest.tar.gz
   sha256: 598f6ac9d5e0fd5a38f4248b49f59ee549302da62957a89955760a9ac060a373
   timestamp: 2025-04-02 21:25:10+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.35/kubescape-arm64-ubuntu-latest.tar.gz
+  sha256: ea223c7a7195b3f929ce6b97353f766836664d649b055b9f12055bfda469277f
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/kubescape/kubescape/releases/download/v3.0.35/kubescape-ubuntu-latest.tar.gz
+  sha256: 106cba6f9988ba65b8523fb6dd013d37d0556de23f3b19063f6a6a2dc601f405
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/secops/kubescape/ops2deb.yml
+++ b/blueprints/secops/kubescape/ops2deb.yml
@@ -25,6 +25,7 @@ matrix:
     - 3.0.31
     - 3.0.32
     - 3.0.34
+    - 3.0.35
 homepage: https://kubescape.io
 summary: kubernetes security platform for your IDE, CI/CD pipelines, and clusters
 description: |-

--- a/blueprints/terminal/chezmoi/ops2deb.lock.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.39.1/chezmoi_2.39.1_linux_amd64.tar.gz
-  sha256: 88016c5284c5ad69ca3676de8c52a436cc2db75a995887e863a2fbcfc08795e8
-  timestamp: 2023-09-06 15:18:48+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.39.1/chezmoi_2.39.1_linux_arm.tar.gz
-  sha256: 724d17cf1441fd461afced5f575c7ab70297f3a6d2b0cd897a70ca584f87f676
-  timestamp: 2023-09-06 15:18:48+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.39.1/chezmoi_2.39.1_linux_arm64.tar.gz
-  sha256: b5398343440b3542fcca64d754ae6337b90fbf515ef34658a45bfe79cb749658
-  timestamp: 2023-09-06 15:18:48+00:00
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.40.0/chezmoi_2.40.0_linux_amd64.tar.gz
   sha256: 8467d0f33a14119511af50a11b3c1d0b7126e582e0a29d70bf43d4d841bf25c4
   timestamp: 2023-09-19 12:33:28+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.62.7/chezmoi_2.62.7_linux_arm64.tar.gz
   sha256: debcd4c3b4cb058973ee80e44763e71ea090e982026907231c5b770f2e732933
   timestamp: 2025-06-22 21:06:12+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.63.0/chezmoi_2.63.0_linux_amd64.tar.gz
+  sha256: 8e5bc70e1f421cfbabe6ef958ac82b1a0a6d3b128e3171582d9f92f039b6ee22
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.63.0/chezmoi_2.63.0_linux_arm.tar.gz
+  sha256: 5e6df860a8143c1f133528815a3a92a420f428ad7b29f597eab5ae6094b1c522
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.63.0/chezmoi_2.63.0_linux_arm64.tar.gz
+  sha256: 607e046be559cd0402d05c543f3d3fa0c35992430a68c564a9465d62d455740d
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/terminal/chezmoi/ops2deb.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 2.39.1
     - 2.40.0
     - 2.40.1
     - 2.40.2
@@ -55,6 +54,7 @@ matrix:
     - 2.62.5
     - 2.62.6
     - 2.62.7
+    - 2.63.0
 homepage: https://github.com/twpayne/chezmoi
 summary: manage your dotfiles across multiple diverse machines
 description: |-

--- a/blueprints/terminal/gomplate/ops2deb.lock.yml
+++ b/blueprints/terminal/gomplate/ops2deb.lock.yml
@@ -70,3 +70,9 @@
 - url: https://github.com/hairyhenderson/gomplate/releases/download/v4.3.2/gomplate_linux-arm64
   sha256: a1ac7569f8576ccb3c128488775a3f37265436a1fdd7c7912875738091022fb0
   timestamp: 2025-04-16 15:08:51+00:00
+- url: https://github.com/hairyhenderson/gomplate/releases/download/v4.3.3/gomplate_linux-amd64
+  sha256: ca281666e86f2f09218c1653e1908f572c0e349e9de64cb4ea93ade9333f0596
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/hairyhenderson/gomplate/releases/download/v4.3.3/gomplate_linux-arm64
+  sha256: 25bd73720ff470cec0dfaa31ca2c436b30f86142db9af68382ce64e0f3e7b9c5
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/terminal/gomplate/ops2deb.yml
+++ b/blueprints/terminal/gomplate/ops2deb.yml
@@ -16,6 +16,7 @@ matrix:
     - 4.3.0
     - 4.3.1
     - 4.3.2
+    - 4.3.3
 homepage: https://docs.gomplate.ca
 summary: flexible commandline tool for template rendering
 description: |-

--- a/blueprints/terminal/mdbook/ops2deb.lock.yml
+++ b/blueprints/terminal/mdbook/ops2deb.lock.yml
@@ -85,3 +85,6 @@
 - url: https://github.com/rust-lang/mdBook/releases/download/v0.4.51/mdbook-v0.4.51-x86_64-unknown-linux-gnu.tar.gz
   sha256: d611bcde080f1ab9932ca1724197ac2c23bb8c5d64581bb5da238bfbb4d39184
   timestamp: 2025-05-26 21:06:20+00:00
+- url: https://github.com/rust-lang/mdBook/releases/download/v0.4.52/mdbook-v0.4.52-x86_64-unknown-linux-gnu.tar.gz
+  sha256: c0b903f01dd8f4edc644372ad2b80b1fdddd12552d37b6a098657cbd8eddd768
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/terminal/mdbook/ops2deb.yml
+++ b/blueprints/terminal/mdbook/ops2deb.yml
@@ -30,6 +30,7 @@ matrix:
     - 0.4.49
     - 0.4.50
     - 0.4.51
+    - 0.4.52
 homepage: https://rust-lang.github.io/mdBook/
 summary: create book from markdown files
 description: |-

--- a/blueprints/terminal/neovim/ops2deb.lock.yml
+++ b/blueprints/terminal/neovim/ops2deb.lock.yml
@@ -10,3 +10,6 @@
 - url: https://github.com/neovim/neovim/releases/download/v0.11.2/nvim-linux-x86_64.tar.gz
   sha256: a9b24157672eb218ff3e33ef3f8c08db26f8931c5c04bdb0e471371dd1dfe63e
   timestamp: 2025-05-30 12:11:54+00:00
+- url: https://github.com/neovim/neovim/releases/download/v0.11.3/nvim-linux-x86_64.tar.gz
+  sha256: 02b808a3ee8fc30161e07fe3c3edfb24b28bd0295323ac5dbdd8ec7012cac67d
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/terminal/neovim/ops2deb.yml
+++ b/blueprints/terminal/neovim/ops2deb.yml
@@ -7,6 +7,7 @@ matrix:
     - 0.11.0
     - 0.11.1
     - 0.11.2
+    - 0.11.3
 homepage: https://github.com/neovim/neovim
 summary: heavily refactored vim fork
 description: |-

--- a/blueprints/terminal/yq/ops2deb.lock.yml
+++ b/blueprints/terminal/yq/ops2deb.lock.yml
@@ -376,3 +376,12 @@
 - url: https://github.com/mikefarah/yq/releases/download/v4.45.4/yq_linux_arm64
   sha256: a02cc637409db44a9f9cb55ea92c40019582ba88083c4d930a727ec4b59ed439
   timestamp: 2025-05-25 09:07:55+00:00
+- url: https://github.com/mikefarah/yq/releases/download/v4.46.1/yq_linux_amd64
+  sha256: c0eb42f6fbf928f0413422967983dcdf9806cc4dedc9394edc60c0dfb4a98529
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/mikefarah/yq/releases/download/v4.46.1/yq_linux_arm
+  sha256: 130b8714034feacde9269e3d8deb9fedfd92de247f24d1f7791bfe85cb98068d
+  timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/mikefarah/yq/releases/download/v4.46.1/yq_linux_arm64
+  sha256: 4ab0b301059348d671fc1833e99903c1fecc7ca287ac131f72dca0eb9a6ba87a
+  timestamp: 2025-07-18 12:04:46+00:00

--- a/blueprints/terminal/yq/ops2deb.yml
+++ b/blueprints/terminal/yq/ops2deb.yml
@@ -65,6 +65,7 @@
       - 4.45.1
       - 4.45.2
       - 4.45.4
+      - 4.46.1
   revision: "2"
   homepage: https://github.com/mikefarah/yq
   summary: portable command-line YAML processor


### PR DESCRIPTION
Add pyenv v2.6.4
Remove pyenv v2.3.18
Add hugo v0.148.1
Remove hugo v0.126.0
Add github-cli v2.76.0
Remove github-cli v2.38.0
Add kubebuilder v4.7.0
Add glab v1.63.0
Add scala-cli v1.8.4
Remove scala-cli v0.1.6
Add uv v0.8.0
Add gitoxide v0.45.0
Add teams-for-linux v2.1.0
Add signal-desktop v7.62.0
Remove signal-desktop v7.15.0
Add chezmoi v2.63.0
Remove chezmoi v2.39.1
Add neovim v0.11.3
Add yq v4.46.1
Add gomplate v4.3.3
Add mdbook v0.4.52
Add boundary v0.19.3
Add kubescape v3.0.35
Add cosign v2.5.3
Add clusterctl v1.10.4
Add oc v4.19.5
Add infracost v0.10.42
Add mirrord v3.151.0
Remove mirrord v3.113.0
Add kubectl v1.33.3
Add flux v2.6.4
Remove flux v0.29.2
Add logcli v3.5.2
Add kubelogin v0.2.10
Add argocd v3.0.11
Add helm v3.18.4
Add natscli v0.2.4
Add pluto v5.22.0
Add rancher v2.11.3
Add terragrunt v0.83.2
Remove terragrunt v0.69.13
Add rclone v1.70.3
Add olivetin v2025.7.13
Add rpk v25.1.8
Remove rpk v23.3.2
Add opentofu v1.10.3
Add docker-compose v2.38.2
Remove docker-compose v2.23.1
Add operator-sdk v1.41.1
Add k9s v0.50.9
Add helmfile v1.1.3
Add aws-iam-authenticator v0.7.4
Add tflint v0.58.1
Add linkerd v25.7.4
Remove linkerd v22.10.2
Add goreleaser v2.11.0
Add iamlive v1.1.26
Add kubectl-oidc-login v1.34.0