### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/dev/github-cli/ops2deb.lock.yml
+++ b/blueprints/dev/github-cli/ops2deb.lock.yml
@@ -10,15 +10,6 @@
 - url: https://github.com/cli/cli/releases/download/v2.5.0/gh_2.5.0_linux_armv6.tar.gz
   sha256: 44e44829a5361957217bfd7c2c8c6dc88fc5f56a72f2e4df772e0ea551a493bd
   timestamp: 2022-02-02 23:13:50+00:00
-- url: https://github.com/cli/cli/releases/download/v2.39.0/gh_2.39.0_linux_amd64.tar.gz
-  sha256: da8a96f8a5a8011a1d7f65ebefd57be4048b4bdb1c2059d7cb99bc82075d6d60
-  timestamp: 2023-11-14 09:16:47+00:00
-- url: https://github.com/cli/cli/releases/download/v2.39.0/gh_2.39.0_linux_arm64.tar.gz
-  sha256: d5ee90458f6cec5bde435f2ce94b7e9e5ec82ce0e635e3d28d666f065309efc1
-  timestamp: 2023-11-14 09:16:47+00:00
-- url: https://github.com/cli/cli/releases/download/v2.39.0/gh_2.39.0_linux_armv6.tar.gz
-  sha256: fb2426a216c64f9768137908e9d19c0717dfe6c8e3244e5529759f1e2fd44165
-  timestamp: 2023-11-14 09:16:47+00:00
 - url: https://github.com/cli/cli/releases/download/v2.39.1/gh_2.39.1_linux_amd64.tar.gz
   sha256: 18a1bc97eb72305ff20e965d3c67aee7e1ac607fabc6251c7374226d8c41422b
   timestamp: 2023-11-14 18:18:44+00:00
@@ -460,3 +451,12 @@
 - url: https://github.com/cli/cli/releases/download/v2.76.0/gh_2.76.0_linux_armv6.tar.gz
   sha256: 4b79eb0e54befd4412f6c6247e843b5e13790e95f466b3456b19b1f2bd1b4f24
   timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/cli/cli/releases/download/v2.76.1/gh_2.76.1_linux_amd64.tar.gz
+  sha256: 18367ca38b4462889ae38fba6a18c53a4c2818b6af309bbe53d0810bb06036e9
+  timestamp: 2025-07-24 00:08:49+00:00
+- url: https://github.com/cli/cli/releases/download/v2.76.1/gh_2.76.1_linux_arm64.tar.gz
+  sha256: fc6352cd6a710fb34e92f4771801a2f0a9e14b4e354645fb74e7453ef766e462
+  timestamp: 2025-07-24 00:08:49+00:00
+- url: https://github.com/cli/cli/releases/download/v2.76.1/gh_2.76.1_linux_armv6.tar.gz
+  sha256: c89ff132c6bdded348e4d2990f1e21ddb9d06443a2603b02b64264dfa203e89d
+  timestamp: 2025-07-24 00:08:49+00:00

--- a/blueprints/dev/github-cli/ops2deb.yml
+++ b/blueprints/dev/github-cli/ops2deb.yml
@@ -38,7 +38,6 @@
       - arm64
       - armhf
     versions:
-      - 2.39.0
       - 2.39.1
       - 2.39.2
       - 2.40.0
@@ -88,6 +87,7 @@
       - 2.74.1
       - 2.74.2
       - 2.76.0
+      - 2.76.1
   homepage: https://github.com/cli/cli
   summary: GitHub on the command line
   description: |-

--- a/blueprints/dev/go-task/ops2deb.lock.yml
+++ b/blueprints/dev/go-task/ops2deb.lock.yml
@@ -148,3 +148,9 @@
 - url: https://github.com/go-task/task/releases/download/v3.44.0/task_linux_arm64.tar.gz
   sha256: 3b2a79a5372e3806c4b345bdfb4a1a1a93a287a58804986bb57b16665db5db22
   timestamp: 2025-06-09 03:32:23+00:00
+- url: https://github.com/go-task/task/releases/download/v3.44.1/task_linux_amd64.tar.gz
+  sha256: 62969d22bee5ea8950cc64a30cc7eb278f89ad67683132e728841457aae523c1
+  timestamp: 2025-07-24 00:08:49+00:00
+- url: https://github.com/go-task/task/releases/download/v3.44.1/task_linux_arm64.tar.gz
+  sha256: 06f390bbc1545997bc08920b51741dd2142713cfdef748e5b17e9f68aa042bbd
+  timestamp: 2025-07-24 00:08:49+00:00

--- a/blueprints/dev/go-task/ops2deb.yml
+++ b/blueprints/dev/go-task/ops2deb.yml
@@ -29,6 +29,7 @@ matrix:
     - 3.42.1
     - 3.43.3
     - 3.44.0
+    - 3.44.1
 homepage: https://taskfile.dev/
 summary: task runner / simpler Make alternative written in Go
 fetch: https://github.com/go-task/task/releases/download/v{{version}}/task_linux_{{arch}}.tar.gz

--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.19.zip
-  sha256: 1cc827f3b75ba6c4f3205652e7fdcb2a384724672e8fdd21028be25176d100d2
-  timestamp: 2023-06-08 12:32:39+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.20.zip
   sha256: de3f615e419482e320afea36de27d9e182dac0592fb9dc1e0f2e01a37cd83017
   timestamp: 2023-06-12 09:17:36+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.4.zip
   sha256: 9e30e095fd98599a010ef9f7ac931136c830f74a9abbac93e0eb6c73cf9fe67f
   timestamp: 2025-07-18 12:04:46+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.5.zip
+  sha256: b2bf496118657901d50cdf5e80245793eb6a172f27c0ee67cb1e3779a36ede61
+  timestamp: 2025-07-24 00:08:49+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.3.19
       - 2.3.20
       - 2.3.21
       - 2.3.22
@@ -73,6 +72,7 @@
       - 2.6.2
       - 2.6.3
       - 2.6.4
+      - 2.6.5
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/devops/linkerd/ops2deb.lock.yml
+++ b/blueprints/devops/linkerd/ops2deb.lock.yml
@@ -1,15 +1,6 @@
 - url: https://github.com/linkerd/linkerd2/releases/download/edge-21.10.3/linkerd2-cli-edge-21.10.3-linux-amd64
   sha256: ad308ef6515e60f6be1ceec6212296c80108f625686736b1fbeaa4a1d3cb7d51
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/linkerd/linkerd2/releases/download/edge-22.10.3/linkerd2-cli-edge-22.10.3-linux-amd64
-  sha256: 9a1b902ea0b95b6c6a145e144080bd299a8ef364057ccc17b6fc6b3b9458d453
-  timestamp: 2022-10-28 06:06:14+00:00
-- url: https://github.com/linkerd/linkerd2/releases/download/edge-22.10.3/linkerd2-cli-edge-22.10.3-linux-arm
-  sha256: 8b18e625e280380bc4997b8c5e1120d1705ea66a4626a8b72c6fc88340dfcab4
-  timestamp: 2022-10-28 06:06:14+00:00
-- url: https://github.com/linkerd/linkerd2/releases/download/edge-22.10.3/linkerd2-cli-edge-22.10.3-linux-arm64
-  sha256: b8f1db2676264f753450e0762262daaa864d53aa2cac697405b5cbf513234bf3
-  timestamp: 2022-10-28 06:06:14+00:00
 - url: https://github.com/linkerd/linkerd2/releases/download/edge-22.11.1/linkerd2-cli-edge-22.11.1-linux-amd64
   sha256: 5e559d370ccf21e4e4ce5ed85a58022f1ad64c86d32ffc32dc194fe74e6dd481
   timestamp: 2022-11-11 22:21:00+00:00
@@ -451,3 +442,12 @@
 - url: https://github.com/linkerd/linkerd2/releases/download/edge-25.7.4/linkerd2-cli-edge-25.7.4-linux-arm64
   sha256: 8ebd95b05898b23cff452c4a842c19e61755a0ff0290e4aa60f926703fb327a6
   timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.7.5/linkerd2-cli-edge-25.7.5-linux-amd64
+  sha256: d11f4e22402b7bc38c525aaa0cdf37cb3e0f8bc4f532262825331be145845f83
+  timestamp: 2025-07-24 00:08:49+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.7.5/linkerd2-cli-edge-25.7.5-linux-arm
+  sha256: 6501f11c9dba91420f3316a650e18549ebf1dd9cc8b9421220fead4afdf49aee
+  timestamp: 2025-07-24 00:08:49+00:00
+- url: https://github.com/linkerd/linkerd2/releases/download/edge-25.7.5/linkerd2-cli-edge-25.7.5-linux-arm64
+  sha256: 00129c1c2ed8ffd3d71803df67ac8366655b53901188d69e5819e71fdefed9d9
+  timestamp: 2025-07-24 00:08:49+00:00

--- a/blueprints/devops/linkerd/ops2deb.yml
+++ b/blueprints/devops/linkerd/ops2deb.yml
@@ -18,7 +18,6 @@
       - arm64
       - armhf
     versions:
-      - 22.10.3
       - 22.11.1
       - 22.11.2
       - 22.11.3
@@ -68,6 +67,7 @@
       - 25.6.4
       - 25.7.1
       - 25.7.4
+      - 25.7.5
   homepage: https://linkerd.io
   summary: ultralight service mesh for Kubernetes
   description: |-

--- a/blueprints/devops/rpk/ops2deb.lock.yml
+++ b/blueprints/devops/rpk/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/redpanda-data/redpanda/releases/download/v23.3.3/rpk-linux-amd64.zip
-  sha256: d6503b323da7d31ec0e9b5f924189625bfe445d4f68733abe59bbbde5997f9a0
-  timestamp: 2024-01-21 01:23:25+00:00
-- url: https://github.com/redpanda-data/redpanda/releases/download/v23.3.3/rpk-linux-arm64.zip
-  sha256: 149d8456054a10ca1a236ca35f0d3c754f9cb05466aacbbf6affc5529f6b2730
-  timestamp: 2024-01-21 01:23:25+00:00
 - url: https://github.com/redpanda-data/redpanda/releases/download/v23.3.4/rpk-linux-amd64.zip
   sha256: 96fef6352defd454aa78991c1ab037e98ac4950f6e9beb31fb0359b036c9fdc2
   timestamp: 2024-01-26 03:18:14+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.8/rpk-linux-arm64.zip
   sha256: 910f2b6ccf1900180d61f105476853d08b27b05c29d312800ec01bba6632168e
   timestamp: 2025-07-18 12:04:47+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.9/rpk-linux-amd64.zip
+  sha256: c10022e9e3b5f34a3176de4887de9a192d68935ae1896186a2fc843175d1d166
+  timestamp: 2025-07-24 00:08:49+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v25.1.9/rpk-linux-arm64.zip
+  sha256: e66f4662c060eb93ddca5adab4704a9973d4e48523eac127d0b0d00def6d1c03
+  timestamp: 2025-07-24 00:08:49+00:00

--- a/blueprints/devops/rpk/ops2deb.yml
+++ b/blueprints/devops/rpk/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 23.3.3
     - 23.3.4
     - 23.3.5
     - 23.3.6
@@ -54,6 +53,7 @@ matrix:
     - 25.1.6
     - 25.1.7
     - 25.1.8
+    - 25.1.9
 homepage: https://redpanda.com/
 summary: interact with your Redpanda clusters
 description: |-

--- a/blueprints/terminal/nushell/ops2deb.lock.yml
+++ b/blueprints/terminal/nushell/ops2deb.lock.yml
@@ -316,3 +316,9 @@
 - url: https://github.com/nushell/nushell/releases/download/0.105.1/nu-0.105.1-x86_64-unknown-linux-gnu.tar.gz
   sha256: 6501bc346e2ad6eecae3bcf7eee78ac21b1a03bdc4fda879a4d24793c1f08db7
   timestamp: 2025-06-11 00:32:12+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.106.0/nu-0.106.0-aarch64-unknown-linux-gnu.tar.gz
+  sha256: a441dfbb4e69ef9eced4549f05b4f1a83ba9651f291c5d18b3a3f23b67884b6d
+  timestamp: 2025-07-24 00:08:49+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.106.0/nu-0.106.0-x86_64-unknown-linux-gnu.tar.gz
+  sha256: ba0969d7172fd5ed87204593c2688fbb1c27bfe1fb606e6d443dfd6c44ef98c6
+  timestamp: 2025-07-24 00:08:49+00:00

--- a/blueprints/terminal/nushell/ops2deb.yml
+++ b/blueprints/terminal/nushell/ops2deb.yml
@@ -119,6 +119,7 @@
       - 0.104.1
       - 0.105.0
       - 0.105.1
+      - 0.106.0
   homepage: https://www.nushell.sh/
   summary: new type of shell written in rust
   description: |-


### PR DESCRIPTION
Add pyenv v2.6.5
Remove pyenv v2.3.19
Add go-task v3.44.1
Add github-cli v2.76.1
Remove github-cli v2.39.0
Add nushell v0.106.0
Add rpk v25.1.9
Remove rpk v23.3.3
Add linkerd v25.7.5
Remove linkerd v22.10.3