### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.23.zip
-  sha256: 651660af2c01890be9b71206f7e316cdd54b740f8f51085dc48727a1d00267cb
-  timestamp: 2023-07-27 09:16:48+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.24.zip
   sha256: 5954c0f7db7675de84c458d1bbe8a43864509906cfe4b775e367c9a3faa38d19
   timestamp: 2023-08-11 12:30:26+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.8.zip
   sha256: d0e3ff533bcaf0d6cff72e1e5400f0b97c1d15833fd365a0acec2d4533f2ecef
   timestamp: 2025-09-19 06:03:04+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.9.zip
+  sha256: 65b05c1213ac8a4de45e5f85dcad17e986357da147b3d6f58c86d11340c48767
+  timestamp: 2025-10-08 00:07:59+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.3.23
       - 2.3.24
       - 2.3.25
       - 2.3.26
@@ -73,6 +72,7 @@
       - 2.6.6
       - 2.6.7
       - 2.6.8
+      - 2.6.9
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/dev/typos-cli/ops2deb.lock.yml
+++ b/blueprints/dev/typos-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/crate-ci/typos/releases/download/v1.23.7/typos-v1.23.7-x86_64-unknown-linux-musl.tar.gz
-  sha256: 3bb50a8e7c3e18750b6309ab34c63ec8ad63de80e50b44be3e8bf4166bf55fe0
-  timestamp: 2024-08-22 18:07:07+00:00
 - url: https://github.com/crate-ci/typos/releases/download/v1.24.1/typos-v1.24.1-x86_64-unknown-linux-musl.tar.gz
   sha256: 0b9b9effeaae48e040b7cdb704247e1f6a7f441872d631631651773af0f09fe0
   timestamp: 2024-08-23 21:05:47+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/crate-ci/typos/releases/download/v1.38.0/typos-v1.38.0-x86_64-unknown-linux-musl.tar.gz
   sha256: fa5e184d67f28af3c92cab732cf6c5b8b6ef2b367cf942369db8b5d6f5c6668a
   timestamp: 2025-10-07 00:08:03+00:00
+- url: https://github.com/crate-ci/typos/releases/download/v1.38.1/typos-v1.38.1-x86_64-unknown-linux-musl.tar.gz
+  sha256: 7432ad36fe4ef17a7c024b26c23c442ce8341455c7dee2c1efeb09ba69c0fef4
+  timestamp: 2025-10-08 00:07:59+00:00

--- a/blueprints/dev/typos-cli/ops2deb.yml
+++ b/blueprints/dev/typos-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: typos-cli
 matrix:
   versions:
-    - 1.23.7
     - 1.24.1
     - 1.24.2
     - 1.24.3
@@ -51,6 +50,7 @@ matrix:
     - 1.37.1
     - 1.37.2
     - 1.38.0
+    - 1.38.1
 homepage: https://github.com/crate-ci/typos/
 summary: source code spell checker
 description: |-

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -844,3 +844,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.8.24/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: db8179fffd97b7557b9a519bae82eaa4f499b02ef546f738a35e74e26c47e6b7
   timestamp: 2025-10-07 06:03:23+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.9.0/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: 041d8f56ffe82cbbc0f63f187f4e1935ac8b32531cf071bf5fa7abcb0441b147
+  timestamp: 2025-10-08 00:07:59+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.9.0/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: 3063c9adb4786ed49d699de9cf24c721ff2cb96bd2bb39465cab3e42d4e4efcc
+  timestamp: 2025-10-08 00:07:59+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.9.0/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 4dadaa5ff5009ccd6a0a43f6ccfa32bf36ed2eff18df7011275a9b1d81950e7b
+  timestamp: 2025-10-08 00:07:59+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -131,6 +131,7 @@
       - 0.8.22
       - 0.8.23
       - 0.8.24
+      - 0.9.0
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.73.3/terragrunt_linux_amd64
-  sha256: 40a9d35cdb820ea7d8fd19c3f642d2e58c6ef9282da8deb5d1ea2788e61dccbf
-  timestamp: 2025-02-14 18:08:09+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.73.3/terragrunt_linux_arm64
-  sha256: 1325fac8c73cb5fa83205bbfb87c34d9e7210a8f63ac2ba1a8ef1da1ee79e8f6
-  timestamp: 2025-02-14 18:08:09+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.73.5/terragrunt_linux_amd64
   sha256: d4639de8db007278a7f03b6e9d9fed63e1f2c79d2971b24e062c0b4d56224cbc
   timestamp: 2025-02-14 21:06:11+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.89.1/terragrunt_linux_arm64
   sha256: fb4515134c21601f21a4823e4331a53ed344baf68df41f039477a0678349ca79
   timestamp: 2025-10-07 18:03:28+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.89.2/terragrunt_linux_amd64
+  sha256: 6a1f5b06c5a0f66e93eafc0b0f70bf1f57b54c56a350815b0498eee8aa3a48fa
+  timestamp: 2025-10-08 00:07:59+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.89.2/terragrunt_linux_arm64
+  sha256: 48ec0e6d48dd246813730338e344fb9bc46525530068d658879a508e23abf357
+  timestamp: 2025-10-08 00:07:59+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.73.3
       - 0.73.5
       - 0.73.8
       - 0.75.6
@@ -75,6 +74,7 @@
       - 0.88.1
       - 0.89.0
       - 0.89.1
+      - 0.89.2
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/terminal/chezmoi/ops2deb.lock.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.41.0/chezmoi_2.41.0_linux_amd64.tar.gz
-  sha256: 75e10e67c0df54da8f6d804712da7195be57da9dbf40ae63b1510d5b84c8a47d
-  timestamp: 2023-11-14 03:17:25+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.41.0/chezmoi_2.41.0_linux_arm.tar.gz
-  sha256: 3786c601fbb445c535d0b14ce2b0c6d49d19eaf8156aa255840931acf7d905c3
-  timestamp: 2023-11-14 03:17:25+00:00
-- url: https://github.com/twpayne/chezmoi/releases/download/v2.41.0/chezmoi_2.41.0_linux_arm64.tar.gz
-  sha256: 3fe2526d198110ef5bb680aaa42ac76e1372008bc0cf3e28e9261964feb44c40
-  timestamp: 2023-11-14 03:17:25+00:00
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.42.0/chezmoi_2.42.0_linux_amd64.tar.gz
   sha256: 1ad2dac7cbbf7d7990d5deaa8800cea2821873aaf2ed7094b134e78981a7645c
   timestamp: 2023-11-26 21:14:35+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/twpayne/chezmoi/releases/download/v2.65.2/chezmoi_2.65.2_linux_arm64.tar.gz
   sha256: a88b026336c500b36208ff537ce99f8f937afa994ef362c0ac8142308c6a2616
   timestamp: 2025-09-24 00:08:07+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.66.0/chezmoi_2.66.0_linux_amd64.tar.gz
+  sha256: 980b9017404f94b7462f14fcf5a363526d314c0da698e97bed778a220a89d33f
+  timestamp: 2025-10-08 00:07:59+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.66.0/chezmoi_2.66.0_linux_arm.tar.gz
+  sha256: a2304832df25792c726ea6ae9c54010d79e5baca66c8a8d5ad083e4714c0a22c
+  timestamp: 2025-10-08 00:07:59+00:00
+- url: https://github.com/twpayne/chezmoi/releases/download/v2.66.0/chezmoi_2.66.0_linux_arm64.tar.gz
+  sha256: 4d77d1703448a352f07021a37fc8c7690ee5eae2f665904a65e83ec4f8818151
+  timestamp: 2025-10-08 00:07:59+00:00

--- a/blueprints/terminal/chezmoi/ops2deb.yml
+++ b/blueprints/terminal/chezmoi/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 2.41.0
     - 2.42.0
     - 2.42.1
     - 2.42.2
@@ -55,6 +54,7 @@ matrix:
     - 2.65.0
     - 2.65.1
     - 2.65.2
+    - 2.66.0
 homepage: https://github.com/twpayne/chezmoi
 summary: manage your dotfiles across multiple diverse machines
 description: |-


### PR DESCRIPTION
Add terragrunt v0.89.2
Remove terragrunt v0.73.3
Add chezmoi v2.66.0
Remove chezmoi v2.41.0
Add typos-cli v1.38.1
Remove typos-cli v1.23.7
Add pyenv v2.6.9
Remove pyenv v2.3.23
Add uv v0.9.0