### PR TITLE
feat: add cloud-provider-kind to provide load balancing on kind

### DIFF
--- a/blueprints/devops/cloud-provider-kind/ops2deb.lock.yml
+++ b/blueprints/devops/cloud-provider-kind/ops2deb.lock.yml
@@ -1,0 +1,3 @@
+- url: https://github.com/kubernetes-sigs/cloud-provider-kind/releases/download/v0.8.0/cloud-provider-kind_0.8.0_linux_amd64.tar.gz
+  sha256: 3c985ccd6bec27173c4aef1d623e08b98b5530124a0f331f738b5702d41214fd
+  timestamp: 2025-10-24 12:23:00+00:00

--- a/blueprints/devops/cloud-provider-kind/ops2deb.yml
+++ b/blueprints/devops/cloud-provider-kind/ops2deb.yml
@@ -1,0 +1,19 @@
+name: cloud-provider-kind
+version: 0.8.0
+homepage: https://github.com/kubernetes-sigs/cloud-provider-kind
+summary: Kubernetes Cloud Provider for KIND
+description: |-
+  KIND has demonstrated to be a very versatile, efficient, cheap and very useful
+  tool for Kubernetes testing.
+  However, KIND doesn't offer capabilities for testing all the features that
+  depend on cloud-providers,
+  specifically the Load Balancers, causing a gap on testing and a bad user
+  experience,
+  since is not easy to connect to the applications running on the cluster.
+
+  cloud-provider-kind aims to fill this gap and provide an agnostic and cheap
+  solution for all
+  the Kubernetes features that depend on a cloud-provider using KIND.
+fetch: https://github.com/kubernetes-sigs/cloud-provider-kind/releases/download/v{{version}}/cloud-provider-kind_{{version}}_linux_amd64.tar.gz
+install:
+  - cloud-provider-kind:/usr/bin/


### PR DESCRIPTION
KIND has demonstrated to be a very versatile, efficient, cheap and very useful tool for Kubernetes testing. However, KIND doesn't offer capabilities for testing all the features that depend on cloud-providers, specifically the Load Balancers, causing a gap on testing and a bad user experience, since is not easy to connect to the applications running on the cluster.

cloud-provider-kind aims to fill this gap and provide an agnostic and cheap solution for all the Kubernetes features that depend on a cloud-provider using KIND.