### PR TITLE
feat(dev): provide containerlab orchestration tool

### DIFF
--- a/blueprints/dev/containerlab/ops2deb.lock.yml
+++ b/blueprints/dev/containerlab/ops2deb.lock.yml
@@ -1,0 +1,6 @@
+- url: https://github.com/srl-labs/containerlab/releases/download/v0.72.0/containerlab_0.72.0_linux_amd64.pkg.tar.zst
+  sha256: 676c96f9cb907792e5cfd6b79bf7d355cd9d084947dfd131742128822969884f
+  timestamp: 2025-12-09 12:35:47+00:00
+- url: https://github.com/srl-labs/containerlab/releases/download/v0.72.0/containerlab_0.72.0_linux_arm64.pkg.tar.zst
+  sha256: 1be54df63a7ecf851e35f8da0f2c1de9db924dabe718e856bc31397724853574
+  timestamp: 2025-12-09 12:35:47+00:00

--- a/blueprints/dev/containerlab/ops2deb.yml
+++ b/blueprints/dev/containerlab/ops2deb.yml
@@ -1,0 +1,16 @@
+name: containerlab
+matrix:
+  architectures:
+    - amd64
+    - arm64
+  versions:
+    - 0.72.0
+homepage: https://containerlab.dev/
+summary: tool for orchestrating and managing container-based networking labs
+description: |-
+  Containerlab provides a CLI for orchestrating and managing container-based
+  networking labs. It starts the containers, builds a virtual wiring between them
+  to create lab topologies of users choice and manages labs lifecycle.
+fetch: https://github.com/srl-labs/containerlab/releases/download/v{{version}}/containerlab_{{version}}_linux_{{arch}}.pkg.tar.zst
+install:
+  - usr/bin/containerlab:/usr/bin/containerlab


### PR DESCRIPTION
While *containerlab* provides its own debian packages, using those would either imply a manual download or using yet another PPA.

The functionality of *containerlab* itself only needs the executable; integrating that into WakeMeOps makes it easily available in environments relying on WakeMeOps anyway.