### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -160,3 +160,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.89.0_amd64.deb
   sha256: 14c7916b35fd46ac2729726b0c36c45872094afcc4bf125618da0d31934ab235
   timestamp: 2026-02-12 00:10:47+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.90.0_amd64.deb
+  sha256: ed94d9b9ce37609449b32e1dcea88f11a1f5491e58d0c99b72f82fdb0f3b416d
+  timestamp: 2026-02-19 00:13:19+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -8,6 +8,7 @@ matrix:
     - 7.87.0
     - 7.88.0
     - 7.89.0
+    - 7.90.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -199,12 +199,6 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.46.1/downloads/glab_1.46.1_Linux_x86_64.deb
   sha256: bf8c53df12d23bf204cba7ae499c4721009e64b2a39277c814759000ac4d3fdd
   timestamp: 2024-09-10 21:06:11+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.47.0/downloads/glab_1.47.0_linux_amd64.deb
-  sha256: cbc09492b2b313b2457651f00ee62677ae11442279c4cc67377aeea66b260144
-  timestamp: 2024-10-11 13:51:49+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.47.0/downloads/glab_1.47.0_linux_arm64.deb
-  sha256: ab9de6ba9e4b8d8b6f9e3c11de138c1b9342e879ff07f9a502d49a7dae2244b9
-  timestamp: 2024-10-11 13:51:49+00:00
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.48.0/downloads/glab_1.48.0_linux_amd64.deb
   sha256: ddc82c30aec8620f762f705d37d217cc9283c14eb8f93d6e80f2f24126b4a2ab
   timestamp: 2024-10-17 15:06:16+00:00
@@ -499,3 +493,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.85.3/downloads/glab_1.85.3_linux_arm64.deb
   sha256: 8c1ab378e67b25c08394621a4b4e9f25eb97d2d482c70b1dddd96f6863531075
   timestamp: 2026-02-18 00:13:12+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.86.0/downloads/glab_1.86.0_linux_amd64.deb
+  sha256: 5eba9e5e513a0d9596c4cc355db7deeccf9215eda7a06e59c94374324bfa9888
+  timestamp: 2026-02-19 00:13:19+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.86.0/downloads/glab_1.86.0_linux_arm64.deb
+  sha256: 334a81bf1ceaec67d1f3395df60414bb4e92ea64a00988a7b24ac22c758a11b5
+  timestamp: 2026-02-19 00:13:19+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -56,7 +56,6 @@
       - amd64
       - arm64
     versions:
-      - 1.47.0
       - 1.48.0
       - 1.49.0
       - 1.50.0
@@ -106,6 +105,7 @@
       - 1.85.1
       - 1.85.2
       - 1.85.3
+      - 1.86.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.86.2/terragrunt_linux_amd64
-  sha256: de7a6dd7bc251e09d4fe0c7ebf3daefb2524846c123cf4d16f2dc1d9af326670
-  timestamp: 2025-08-25 18:03:32+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.86.2/terragrunt_linux_arm64
-  sha256: d75f93cba44c6ac687739e6be065c81ab237ba01a270cd9aa7fa4361870cde35
-  timestamp: 2025-08-25 18:03:32+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.87.0/terragrunt_linux_amd64
   sha256: cda1f8cabd840d45cdfceeb1e58ed2a153753911279edb7dfc62051d53875937
   timestamp: 2025-09-05 18:03:06+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.99.2/terragrunt_linux_arm64
   sha256: 939754dcdf024d5c322cdc4d03b496a82c527b1c4336281a18203052b4e02968
   timestamp: 2026-02-13 18:11:18+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.99.3/terragrunt_linux_amd64
+  sha256: 72660f61dfea1e1a2d4f0a642c1210c72bb504663d6d0b08efa0f1240236b5a7
+  timestamp: 2026-02-19 00:13:19+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.99.3/terragrunt_linux_arm64
+  sha256: 745201305fcca60c5fc8aa8a926e80e287488e54d4b9fcc81eabda4ff48fee95
+  timestamp: 2026-02-19 00:13:19+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.86.2
       - 0.87.0
       - 0.87.1
       - 0.87.2
@@ -75,6 +74,7 @@
       - 0.99.0
       - 0.99.1
       - 0.99.2
+      - 0.99.3
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-


### PR DESCRIPTION
Add terragrunt v0.99.3
Remove terragrunt v0.86.2
Add glab v1.86.0
Remove glab v1.47.0
Add signal-desktop v7.90.0