### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -166,3 +166,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_8.0.0_amd64.deb
   sha256: 508553086bb54c81db36130d6172c58977be343b889fdd67d81a4f8a4ebad254
   timestamp: 2026-02-26 00:11:21+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_8.1.0_amd64.deb
+  sha256: e17f14c6b28d95f1dfd1db980d591716435c2160c798d9470577ff5274020f03
+  timestamp: 2026-03-05 00:12:13+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -10,6 +10,7 @@ matrix:
     - 7.89.0
     - 7.90.0
     - 8.0.0
+    - 8.1.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -199,12 +199,6 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.46.1/downloads/glab_1.46.1_Linux_x86_64.deb
   sha256: bf8c53df12d23bf204cba7ae499c4721009e64b2a39277c814759000ac4d3fdd
   timestamp: 2024-09-10 21:06:11+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.49.0/downloads/glab_1.49.0_linux_amd64.deb
-  sha256: f42cc13a1ba6913bde8acd6b03bcd9a081199d9cbfff5fe152147e92ef433c6b
-  timestamp: 2024-11-15 03:16:02+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.49.0/downloads/glab_1.49.0_linux_arm64.deb
-  sha256: 136d7f0d65e402247f0f1aca420e60497fcd020c80f7e475235bf95ff3b467a0
-  timestamp: 2024-11-15 03:16:02+00:00
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.50.0/downloads/glab_1.50.0_linux_amd64.deb
   sha256: 15bd7b19ea416091dae4adc6578ef39df88020044136c0de23fc2315d3b0e9ee
   timestamp: 2024-11-28 18:08:03+00:00
@@ -499,3 +493,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.87.0/downloads/glab_1.87.0_linux_arm64.deb
   sha256: 094ce9e597feba7e844bc675786272e738b1ed49f30074f2bbcc545209bbcd4d
   timestamp: 2026-03-02 18:10:15+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.88.0/downloads/glab_1.88.0_linux_amd64.deb
+  sha256: a1b4629d9c8eefa64dfa30a3670590a5805e41d5ff4b59fa73777826c141d12d
+  timestamp: 2026-03-05 00:12:13+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.88.0/downloads/glab_1.88.0_linux_arm64.deb
+  sha256: 2390ae7fd2e45d720c63e1338a9ed4037e7b1867c8f4992494efe7717b5af57c
+  timestamp: 2026-03-05 00:12:13+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -56,7 +56,6 @@
       - amd64
       - arm64
     versions:
-      - 1.49.0
       - 1.50.0
       - 1.51.0
       - 1.52.0
@@ -106,6 +105,7 @@
       - 1.85.3
       - 1.86.0
       - 1.87.0
+      - 1.88.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-


### PR DESCRIPTION
Add glab v1.88.0
Remove glab v1.49.0
Add signal-desktop v8.1.0