### PR TITLE
chore: migrate install_repository to deb822 format

### DIFF
--- a/assets/install_repository
+++ b/assets/install_repository
@@ -3,10 +3,10 @@
 set -e
 
 if ! which gpg; then
-  apt-get update -yq && apt-get install -yq --no-install-recommends gnupg2
+    apt-get update -yq && apt-get install -yq --no-install-recommends gnupg2
 fi
 
-cat << EOF | gpg --dearmor > /etc/apt/trusted.gpg.d/wakemeops-keyring.gpg
+cat >/etc/apt/keyrings/wakemeops-keyring.asc <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGGzicYBEADnBgApTxF3fFiAkSJuzfz2qKVXXSuouxCUkOV9owKqIWJ2pYoE
@@ -119,8 +119,19 @@ M1isGcqM+C+T2AMf+LSoI18ao7+aDUlvojZwJyVEwkiJ3SyoD5P/cBxVH5mVNXUS
 -----END PGP PUBLIC KEY BLOCK-----
 EOF
 
-cat <<EOF > /etc/apt/sources.list.d/wakemeops.list
-deb http://deb.wakemeops.com/wakemeops/ stable ${@-"dev devops secops terminal desktop"}
+cat >/etc/apt/sources.list.d/wakemeops.sources <<EOF
+Architectures: $(dpkg --print-architecture)
+Components: ${@-"dev devops secops terminal desktop"}
+Enabled: yes
+X-Repolib-Name: wakemeops
+Signed-By: /etc/apt/keyrings/wakemeops-keyring.asc
+Suites: stable
+Types: deb
+URIs: http://deb.wakemeops.com/wakemeops/
 EOF
+
+# delete old wakemeops-keyring.gpg and wakemeops.list files
+[[ -f /etc/apt/trusted.gpg.d/wakemeops-keyring.gpg ]] && rm -f /etc/apt/trusted.gpg.d/wakemeops-keyring.gpg
+[[ -f /etc/apt/sources.list.d/wakemeops.list ]] && rm -f /etc/apt/sources.list.d/wakemeops.list
 
 apt-get update -yq


### PR DESCRIPTION
## Summary

Migrate `assets/install_repository` from the legacy one-line format to the modern [deb822](https://manpages.debian.org/unstable/apt/sources.list.5.en.html#DEB822-STYLE_FORMAT) format for APT source configuration.

## Changes

### PGP keyring storage

- **Before**: The ASCII-armored key was piped through `gpg --dearmor` and stored as a binary `.gpg` file under `/etc/apt/trusted.gpg.d/`.
- **After**: The ASCII-armored key is stored directly as a `.asc` file under `/etc/apt/keyrings/`, which is the [recommended location](https://wiki.debian.org/DebianRepository/UseThirdParty) for third-party keyrings since Debian 12 / Ubuntu 22.04.

### APT sources configuration

- **Before**: A single-line `deb` entry written to `/etc/apt/sources.list.d/wakemeops.list`.
- **After**: A structured deb822 stanza written to `/etc/apt/sources.list.d/wakemeops.sources`, with explicit fields for `Architectures`, `Components`, `Signed-By`, `Suites`, `Types`, and `URIs`.

The new format offers better readability, supports architecture pinning via the `Architectures` field (auto-detected via `dpkg --print-architecture`), and properly scopes the signing key to this source only — avoiding the security pitfall of a globally trusted key.

### Backward compatibility

Old files (`/etc/apt/trusted.gpg.d/wakemeops-keyring.gpg` and `/etc/apt/sources.list.d/wakemeops.list`) are automatically removed when present, ensuring a clean migration for existing installations.
