### PR TITLE
feat(devops): add cert-manager kubectl plugin 2.4.1

### DIFF
--- a/blueprints/devops/kubectl-cert-manager/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl-cert-manager/ops2deb.lock.yml
@@ -1,0 +1,6 @@
+- url: https://github.com/cert-manager/cmctl/releases/download/v2.4.1/cmctl_linux_amd64
+  sha256: 54098ba4d7b9a758d27e6a7538b906f59e64ffaa5a1f83ec7e4c4f9f107929ab
+  timestamp: 2026-03-17 13:06:29+00:00
+- url: https://github.com/cert-manager/cmctl/releases/download/v2.4.1/cmctl_linux_arm64
+  sha256: 10dcbe8831fbc4785ca0392e4560020fbd18b1088dfee5173579afe8f3064189
+  timestamp: 2026-03-17 13:06:29+00:00

--- a/blueprints/devops/kubectl-cert-manager/ops2deb.yml
+++ b/blueprints/devops/kubectl-cert-manager/ops2deb.yml
@@ -1,0 +1,15 @@
+name: kubectl-cert-manager
+matrix:
+  architectures:
+    - amd64
+    - arm64
+  versions:
+    - 2.4.1
+homepage: https://cert-manager.io/docs/reference/cmctl/
+summary: The cert-manager Command Line Tool (cmctl)
+description: |-
+  This is a kubectl plugin that can help you manage cert-manager and its
+  resources inside your cluster.
+fetch: https://github.com/cert-manager/cmctl/releases/download/v{{version}}/cmctl_linux_{{goarch}}
+install:
+  - cmctl_linux_{{goarch}}:/usr/bin/kubectl-cert_manager


### PR DESCRIPTION
The cert-manager kubectl plugin allows to manage and configure cert-manager resources for Kubernetes by CLI.