### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/mattermost-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/mattermost-desktop/ops2deb.lock.yml
@@ -58,3 +58,6 @@
 - url: https://releases.mattermost.com/desktop/6.1.0/mattermost-desktop-6.1.0-linux-x64.tar.gz
   sha256: 160d8e7654b621499cc45fd67dc134457eb6ab3f1e601a229c6aca10962938b6
   timestamp: 2026-03-02 12:07:27+00:00
+- url: https://releases.mattermost.com/desktop/6.1.2/mattermost-desktop-6.1.2-linux-x64.tar.gz
+  sha256: a4ad8ea37d4ffa26d972ee8b235592048cf904ff84f389304f9da16eb5e7bfbe
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/desktop/mattermost-desktop/ops2deb.yml
+++ b/blueprints/desktop/mattermost-desktop/ops2deb.yml
@@ -21,6 +21,7 @@ matrix:
     - 6.0.3
     - 6.0.4
     - 6.1.0
+    - 6.1.2
 homepage: https://mattermost.com
 summary: desktop application for Mattermost
 description: |-

--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -172,3 +172,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_8.3.0_amd64.deb
   sha256: 863bea0a12a145b11c151c9ae949b5c695d7cf92375324c3d5e88af847698fb5
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_8.7.0_amd64.deb
+  sha256: d40c7d6f339343656e277b17627c1bcf655cba2ca88d7bdd0f145f48d777cab1
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -12,6 +12,7 @@ matrix:
     - 8.0.0
     - 8.1.0
     - 8.3.0
+    - 8.7.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.10.1/teams-for-linux_1.10.1_amd64.deb
-  sha256: 9e57fb56272ea4e9447449622770dbac5c7afe2d272396670ff868ef522d3da3
-  timestamp: 2024-09-09 09:07:17+00:00
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.10.2/teams-for-linux_1.10.2_amd64.deb
   sha256: 5e99522b68446079d7d46bd979e46c9fc42dd98b2f2d1528a6249f88fd237cf5
   timestamp: 2024-09-10 21:06:11+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.7.12/teams-for-linux_2.7.12_amd64.deb
   sha256: bc6670fc517a0b80f2e029d8f837c4a756979a2968bacd78d73568f7a27ea472
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.8.0/teams-for-linux_2.8.0_amd64.deb
+  sha256: c3fafdc32f1d0fff5b40c47c06457e7edfb9c7936a7ce35ed9cf7824dab6c89f
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/desktop/teams-for-linux/ops2deb.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.yml
@@ -1,7 +1,6 @@
 name: teams-for-linux
 matrix:
   versions:
-    - 1.10.1
     - 1.10.2
     - 1.11.0
     - 1.11.1
@@ -51,6 +50,7 @@ matrix:
     - 2.7.8
     - 2.7.9
     - 2.7.12
+    - 2.8.0
 homepage: https://github.com/IsmaelMartinez/teams-for-linux/
 summary: unofficial Microsoft Teams for Linux client
 description: |-

--- a/blueprints/dev/atlas/ops2deb.lock.yml
+++ b/blueprints/dev/atlas/ops2deb.lock.yml
@@ -148,3 +148,9 @@
 - url: https://release.ariga.io/atlas/atlas-community-linux-arm64-v1.1.6
   sha256: 93a2db51f3d1280083dce66e7bb75f637ebeed401512788198d72c7920954b3d
   timestamp: 2026-03-06 18:08:59+00:00
+- url: https://release.ariga.io/atlas/atlas-community-linux-amd64-v1.2.0
+  sha256: 19a1f09eaa5469011d2cfb07cd8bdcaa5bb39fbf7c31bd63a60ba9d9aa7f562d
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://release.ariga.io/atlas/atlas-community-linux-arm64-v1.2.0
+  sha256: 8f7f89dd977a85ffe9be66fe157ce462a03036ef67a229ce8a39c3b1856e53f9
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/atlas/ops2deb.yml
+++ b/blueprints/dev/atlas/ops2deb.yml
@@ -29,6 +29,7 @@ matrix:
     - 1.1.3
     - 1.1.5
     - 1.1.6
+    - 1.2.0
 homepage: https://atlasgo.io
 summary: manage your database schema as code
 description: |-

--- a/blueprints/dev/bun/ops2deb.lock.yml
+++ b/blueprints/dev/bun/ops2deb.lock.yml
@@ -10,3 +10,9 @@
 - url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.11/bun-linux-x64.zip
   sha256: 8611ba935af886f05a6f38740a15160326c15e5d5d07adef966130b4493607ed
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-aarch64.zip
+  sha256: 70bae41b3908b0a120e1e58c5c8af30e74afae3b8d11b0d3fdd8e787ddfb4b22
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-x64.zip
+  sha256: 79c0771fa8b92c33aae41e15a0e0d307ea99d0e2f00317c71c6c53237a78e25a
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/bun/ops2deb.yml
+++ b/blueprints/dev/bun/ops2deb.yml
@@ -6,6 +6,7 @@ matrix:
   versions:
     - 1.3.10
     - 1.3.11
+    - 1.3.13
 homepage: https://bun.sh/
 summary: all-in-one JavaScript runtime, bundler, and package manager
 description: |-

--- a/blueprints/dev/containerlab/ops2deb.lock.yml
+++ b/blueprints/dev/containerlab/ops2deb.lock.yml
@@ -10,3 +10,9 @@
 - url: https://github.com/srl-labs/containerlab/releases/download/v0.74.2/containerlab_0.74.2_linux_arm64.pkg.tar.zst
   sha256: 6e06681f69f241f19f608d0e01a4b4e66e8dc581a6912889d8e531286c6c9fad
   timestamp: 2026-03-21 12:04:31+00:00
+- url: https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_amd64.pkg.tar.zst
+  sha256: c766fd2b61bf78ef913a8395f276fb37ce2f1f6e7dc55efe399cac45ad76694b
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/srl-labs/containerlab/releases/download/v0.74.3/containerlab_0.74.3_linux_arm64.pkg.tar.zst
+  sha256: b709b78546bfd4527c3c6bb0a943131cda046654dba57c95d0ad0a9d14bff445
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/containerlab/ops2deb.yml
+++ b/blueprints/dev/containerlab/ops2deb.yml
@@ -6,6 +6,7 @@ matrix:
   versions:
     - 0.74.1
     - 0.74.2
+    - 0.74.3
 homepage: https://containerlab.dev/
 summary: tool for orchestrating and managing container-based networking labs
 description: |-

--- a/blueprints/dev/github-cli/ops2deb.lock.yml
+++ b/blueprints/dev/github-cli/ops2deb.lock.yml
@@ -10,15 +10,6 @@
 - url: https://github.com/cli/cli/releases/download/v2.5.0/gh_2.5.0_linux_armv6.tar.gz
   sha256: 44e44829a5361957217bfd7c2c8c6dc88fc5f56a72f2e4df772e0ea551a493bd
   timestamp: 2022-02-02 23:13:50+00:00
-- url: https://github.com/cli/cli/releases/download/v2.50.0/gh_2.50.0_linux_amd64.tar.gz
-  sha256: 7f9795b3ce99351a1bfc6ea3b09b7363cb1eccca19978a046bcb477839efab82
-  timestamp: 2024-06-02 18:07:28+00:00
-- url: https://github.com/cli/cli/releases/download/v2.50.0/gh_2.50.0_linux_arm64.tar.gz
-  sha256: 115e1a18695fcc2e060711207f0c297f1cca8b76dd1d9cd0cf071f69ccac7422
-  timestamp: 2024-06-02 18:07:28+00:00
-- url: https://github.com/cli/cli/releases/download/v2.50.0/gh_2.50.0_linux_armv6.tar.gz
-  sha256: adc010fdc4139d12550f692b448232556b87dc35e16dea7bace5f7b6dab458e5
-  timestamp: 2024-06-02 18:07:28+00:00
 - url: https://github.com/cli/cli/releases/download/v2.51.0/gh_2.51.0_linux_amd64.tar.gz
   sha256: d7725fb2a643ca024edf5b4e2f2cca0431a404bbc2e251086ffca2b25e37be11
   timestamp: 2024-06-13 15:05:44+00:00
@@ -460,3 +451,12 @@
 - url: https://github.com/cli/cli/releases/download/v2.88.1/gh_2.88.1_linux_armv6.tar.gz
   sha256: 53eed76f45e4ab9d67e3937306477703a14e24d5e0c5a69d6e9bdeb0c5ba59f8
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/cli/cli/releases/download/v2.91.0/gh_2.91.0_linux_amd64.tar.gz
+  sha256: 304a0d2460f4a8847d2f192bad4e2a32cd9420d28716e7ae32198181b65b5f9c
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/cli/cli/releases/download/v2.91.0/gh_2.91.0_linux_arm64.tar.gz
+  sha256: ccbed39c472d3dc1c501d1e164a9cffd934c5f6fce1012811a1a59d24cb7d7c6
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/cli/cli/releases/download/v2.91.0/gh_2.91.0_linux_armv6.tar.gz
+  sha256: cfbe4e30bac224502d38be0e625d5956858560a67dc450f7a79f1c75a4d472e3
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/github-cli/ops2deb.yml
+++ b/blueprints/dev/github-cli/ops2deb.yml
@@ -38,7 +38,6 @@
       - arm64
       - armhf
     versions:
-      - 2.50.0
       - 2.51.0
       - 2.52.0
       - 2.53.0
@@ -88,6 +87,7 @@
       - 2.87.3
       - 2.88.0
       - 2.88.1
+      - 2.91.0
   homepage: https://github.com/cli/cli
   summary: GitHub on the command line
   description: |-

--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -199,12 +199,6 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.46.1/downloads/glab_1.46.1_Linux_x86_64.deb
   sha256: bf8c53df12d23bf204cba7ae499c4721009e64b2a39277c814759000ac4d3fdd
   timestamp: 2024-09-10 21:06:11+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.52.0/downloads/glab_1.52.0_linux_amd64.deb
-  sha256: 4963de777bdd5eeedd360bf670185b19aa03466bf4d64378052a374a09f77359
-  timestamp: 2025-01-28 09:07:23+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.52.0/downloads/glab_1.52.0_linux_arm64.deb
-  sha256: 161e429d017a434ca1dc8e35a6dd3862439c95c34253e3d4a2a93d871cc9bee6
-  timestamp: 2025-01-28 09:07:23+00:00
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.53.0/downloads/glab_1.53.0_linux_amd64.deb
   sha256: 633fa8eea4c4f081b0fa8a602dd10a9885ee08bb5391fdefc9dcaa1dbb110531
   timestamp: 2025-02-14 15:06:26+00:00
@@ -499,3 +493,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.90.0/downloads/glab_1.90.0_linux_arm64.deb
   sha256: 9ba8431991dc4b4ad78c3c6e0b6341076d0d7063ca81ed370bcd1378665a4370
   timestamp: 2026-03-23 18:14:20+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.93.0/downloads/glab_1.93.0_linux_amd64.deb
+  sha256: e5df04d929fad92ed4cc6ba8762fe7325afaafe3cd861b7fef02f3b7e933a678
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.93.0/downloads/glab_1.93.0_linux_arm64.deb
+  sha256: 91341e72f41aa19d005cf0a0cf97029810909c0bb6381072f86c1ee8d41b327a
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -56,7 +56,6 @@
       - amd64
       - arm64
     versions:
-      - 1.52.0
       - 1.53.0
       - 1.54.0
       - 1.55.0
@@ -106,6 +105,7 @@
       - 1.88.0
       - 1.89.0
       - 1.90.0
+      - 1.93.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-

--- a/blueprints/dev/go-task/ops2deb.lock.yml
+++ b/blueprints/dev/go-task/ops2deb.lock.yml
@@ -220,3 +220,9 @@
 - url: https://github.com/go-task/task/releases/download/v3.49.1/task_linux_arm64.tar.gz
   sha256: aa6732c9c66397c5380ec2b60c070fd599075b2a8538dba03f3a21edc99ab0cb
   timestamp: 2026-03-09 00:11:22+00:00
+- url: https://github.com/go-task/task/releases/download/v3.50.0/task_linux_amd64.tar.gz
+  sha256: d449ba85ab85a0769989d78f8b9872938e4ba9347f7f4f925f73d98272a0a655
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/go-task/task/releases/download/v3.50.0/task_linux_arm64.tar.gz
+  sha256: ee67e7d999a4a70711bff1946c70bf76628012c91d9be55626ee90ba976897da
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/go-task/ops2deb.yml
+++ b/blueprints/dev/go-task/ops2deb.yml
@@ -41,6 +41,7 @@ matrix:
     - 3.48.0
     - 3.49.0
     - 3.49.1
+    - 3.50.0
 homepage: https://taskfile.dev/
 summary: task runner / simpler Make alternative written in Go
 fetch: https://github.com/go-task/task/releases/download/v{{version}}/task_linux_{{arch}}.tar.gz

--- a/blueprints/dev/hugo/ops2deb.lock.yml
+++ b/blueprints/dev/hugo/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/gohugoio/hugo/releases/download/v0.139.4/hugo_extended_0.139.4_linux-amd64.tar.gz
-  sha256: 2b2405f9e1e4e0827a9d7d3c3d76dbcc8559aa6d9ba2f710f5335e9356172613
-  timestamp: 2024-12-09 21:06:26+00:00
-- url: https://github.com/gohugoio/hugo/releases/download/v0.139.4/hugo_extended_0.139.4_linux-arm64.tar.gz
-  sha256: d03f41c43e8d4bea5af11eb2cca8129c049d099b6bf05c555ae1eb97a781feed
-  timestamp: 2024-12-09 21:06:26+00:00
 - url: https://github.com/gohugoio/hugo/releases/download/v0.140.0/hugo_extended_0.140.0_linux-amd64.tar.gz
   sha256: 32c4d831b54d18915324308c58fd4faf7e96052b92633ed66d4a474efb6d122f
   timestamp: 2024-12-17 15:06:51+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/gohugoio/hugo/releases/download/v0.159.0/hugo_extended_0.159.0_linux-arm64.tar.gz
   sha256: bec48a1ac9ab89d58fc4311b5945294af49683659714ac18043bc65abcde933e
   timestamp: 2026-03-24 00:11:54+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.160.1/hugo_extended_0.160.1_linux-amd64.tar.gz
+  sha256: 133adf4932c1b626b6fe6aa28d56791555abe3ceff167e03be534e8324c9ed39
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.160.1/hugo_extended_0.160.1_linux-arm64.tar.gz
+  sha256: be4203d99a5b91446cd89af1e788aeb3c6210cbe78fab380a26be135a3f4ec59
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/hugo/ops2deb.yml
+++ b/blueprints/dev/hugo/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 0.139.4
     - 0.140.0
     - 0.140.1
     - 0.140.2
@@ -54,6 +53,7 @@ matrix:
     - 0.157.0
     - 0.158.0
     - 0.159.0
+    - 0.160.1
 revision: "2"
 homepage: https://gohugo.io/
 summary: fast and flexible Static Site Generator

--- a/blueprints/dev/influx-cli/ops2deb.lock.yml
+++ b/blueprints/dev/influx-cli/ops2deb.lock.yml
@@ -34,3 +34,9 @@
 - url: https://dl.influxdata.com/influxdb/releases/influxdb2-client-2.7.1-linux-arm64.tar.gz
   sha256: a27c0e6c0ecc053a648bcc1ba7af57ceff83de9ef01970692ad9ff360b5e6fd2
   timestamp: 2023-04-05 21:16:33+00:00
+- url: https://dl.influxdata.com/influxdb/releases/influxdb2-client-2.8.0-linux-amd64.tar.gz
+  sha256: feaa32e02c99815414574265d5471c4f2550b07aef6f8b19907d8a1af98e5d61
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://dl.influxdata.com/influxdb/releases/influxdb2-client-2.8.0-linux-arm64.tar.gz
+  sha256: 95cda9399dcda3c704dd8ab929c2c08f20e55cab7273dd1f3d305be942530232
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/influx-cli/ops2deb.yml
+++ b/blueprints/dev/influx-cli/ops2deb.yml
@@ -25,6 +25,7 @@
       - arm64
     versions:
       - 2.7.1
+      - 2.8.0
   homepage: https://docs.influxdata.com/influxdb/latest/tools/influx-cli/?t=Linux
   summary: command line client for influxdb
   description: |-

--- a/blueprints/dev/k6/ops2deb.lock.yml
+++ b/blueprints/dev/k6/ops2deb.lock.yml
@@ -124,3 +124,9 @@
 - url: https://github.com/grafana/k6/releases/download/v1.6.1/k6-v1.6.1-linux-arm64.tar.gz
   sha256: 698e47804a8cf679237dc7f19813e2967e0a892d4b9387f6f6de46da259069f9
   timestamp: 2026-02-16 12:09:16+00:00
+- url: https://github.com/grafana/k6/releases/download/v1.7.1/k6-v1.7.1-linux-amd64.tar.gz
+  sha256: cc127a656f734f8ea1e89f8a417777905ae6a93d42f3e763e95313518180655b
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/grafana/k6/releases/download/v1.7.1/k6-v1.7.1-linux-arm64.tar.gz
+  sha256: 5a91fa37d89d1fe776aea590d689029ffc2d2f2634a6c61eb51c982ff50700d7
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/k6/ops2deb.yml
+++ b/blueprints/dev/k6/ops2deb.yml
@@ -25,6 +25,7 @@ matrix:
     - 1.5.0
     - 1.6.0
     - 1.6.1
+    - 1.7.1
 homepage: https://k6.io
 summary: modern load testing tool, using Go and JavaScript
 description: |-

--- a/blueprints/dev/kubebuilder/ops2deb.lock.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.lock.yml
@@ -256,3 +256,9 @@
 - url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.13.0/kubebuilder_linux_arm64
   sha256: ef720de120277319af8f298f321bc9a5a2e34f1be6d6aa4f29e42102744db834
   timestamp: 2026-02-27 18:08:56+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.13.1/kubebuilder_linux_amd64
+  sha256: c91a214f3cada120cd7468ee4633621da963e997cf19a1cf320ebd36e6324fd6
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.13.1/kubebuilder_linux_arm64
+  sha256: 7d39d8c2ed3f0bde122b5ba4ee5106d07da3a920b6865a8be4a56e689f8a0a56
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/kubebuilder/ops2deb.yml
+++ b/blueprints/dev/kubebuilder/ops2deb.yml
@@ -47,6 +47,7 @@ matrix:
     - 4.11.1
     - 4.12.0
     - 4.13.0
+    - 4.13.1
 homepage: https://book.kubebuilder.io
 summary: SDK for building Kubernetes APIs using CRDs
 description: |-

--- a/blueprints/dev/lazygit/ops2deb.lock.yml
+++ b/blueprints/dev/lazygit/ops2deb.lock.yml
@@ -130,3 +130,9 @@
 - url: https://github.com/jesseduffield/lazygit/releases/download/v0.60.0/lazygit_0.60.0_Linux_x86_64.tar.gz
   sha256: 6252ca6cf98bc4fd3e0d927b54225910cfa57b065d0ad88263f14592f7f9ab15
   timestamp: 2026-03-10 00:12:50+00:00
+- url: https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_Linux_arm64.tar.gz
+  sha256: 20b1abb2bee5dfd46173b9047353eb678bc51a23839e821958d0b1863ab1655e
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_Linux_x86_64.tar.gz
+  sha256: 1b91e660700f2332696726b635202576b543e2bc49b639830dccd26bc5160d5d
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/lazygit/ops2deb.yml
+++ b/blueprints/dev/lazygit/ops2deb.yml
@@ -26,6 +26,7 @@ matrix:
     - 0.58.1
     - 0.59.0
     - 0.60.0
+    - 0.61.1
 homepage: https://github.com/jesseduffield/lazygit
 summary: a lazier way to manage everything git
 description: A simple terminal UI for git, written in Go with the gocui library.

--- a/blueprints/dev/pdm/ops2deb.lock.yml
+++ b/blueprints/dev/pdm/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.13.2.tar.gz
-  sha256: 2615bc2def05111059af191f9c63d4853addcdebf9e0b44885869cd47b446222
-  timestamp: 2024-03-30 12:06:58+00:00
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.13.3.tar.gz
   sha256: fef20178ae809c36379464946e97f069b83ce41997bf43edee34141acdf18468
   timestamp: 2024-04-08 12:08:11+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.26.6.tar.gz
   sha256: aa1f5e8f2633b61658d7adf82de21226e84925fe4303f7c6e6c9fff5eb8c8998
   timestamp: 2026-01-22 12:04:38+00:00
+- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.26.8.tar.gz
+  sha256: 0820b1d0a8ee64a4bb7f8a5c20a70e323c99d413b8583c0f0957d99e0212aae5
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/pdm/ops2deb.yml
+++ b/blueprints/dev/pdm/ops2deb.yml
@@ -1,7 +1,6 @@
 name: pdm
 matrix:
   versions:
-    - 2.13.2
     - 2.13.3
     - 2.14.0
     - 2.15.0
@@ -51,6 +50,7 @@ matrix:
     - 2.26.4
     - 2.26.5
     - 2.26.6
+    - 2.26.8
 homepage: https://pdm.fming.dev/
 summary: modern Python package and dependency manager supporting the latest PEP standards
 description: |-

--- a/blueprints/dev/pipx/ops2deb.lock.yml
+++ b/blueprints/dev/pipx/ops2deb.lock.yml
@@ -49,3 +49,6 @@
 - url: https://github.com/pypa/pipx/releases/download/1.11.0/pipx.pyz
   sha256: 088012ed44db557464e48721275b62b2c2a9a943f444cde05f82cf7a23e63dbc
   timestamp: 2026-03-24 00:11:54+00:00
+- url: https://github.com/pypa/pipx/releases/download/1.11.1/pipx.pyz
+  sha256: 60c947d2449af642c17079a2119ef87e426ad83967b8bb223bb27c802fc29ccd
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/pipx/ops2deb.yml
+++ b/blueprints/dev/pipx/ops2deb.yml
@@ -18,6 +18,7 @@ matrix:
     - 1.10.0
     - 1.10.1
     - 1.11.0
+    - 1.11.1
 architecture: all
 homepage: https://github.com/pypa/pipx
 summary: execute binaries from Python packages in isolated environments

--- a/blueprints/dev/poetry/ops2deb.lock.yml
+++ b/blueprints/dev/poetry/ops2deb.lock.yml
@@ -88,3 +88,6 @@
 - url: https://github.com/python-poetry/poetry/archive/refs/tags/2.3.2.tar.gz
   sha256: 7a0ca140271797449b8ce789955cdaf1fd66c7783ebb4b62989957041a02b550
   timestamp: 2026-02-01 18:04:20+00:00
+- url: https://github.com/python-poetry/poetry/archive/refs/tags/2.3.4.tar.gz
+  sha256: b43c5875b583769636f336725aebf8d423c991841546c60c40ef536d468423c8
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/poetry/ops2deb.yml
+++ b/blueprints/dev/poetry/ops2deb.yml
@@ -122,6 +122,7 @@
       - 2.3.0
       - 2.3.1
       - 2.3.2
+      - 2.3.4
   homepage: https://python-poetry.org
   summary: tool for dependency management and packaging in Python
   description: |-

--- a/blueprints/dev/pre-commit/ops2deb.lock.yml
+++ b/blueprints/dev/pre-commit/ops2deb.lock.yml
@@ -91,3 +91,6 @@
 - url: https://github.com/pre-commit/pre-commit/releases/download/v4.5.1/pre-commit-4.5.1.pyz
   sha256: 19d00ba35cbf9c04dc3736cd8bb641e8633f3eddd4cedde71809574ae68a2cd1
   timestamp: 2025-12-17 00:07:38+00:00
+- url: https://github.com/pre-commit/pre-commit/releases/download/v4.6.0/pre-commit-4.6.0.pyz
+  sha256: ea8a0c84902e48c1875558f2f362ed8476773aa5fc8c16c5d8f2acc2a2830a65
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/pre-commit/ops2deb.yml
+++ b/blueprints/dev/pre-commit/ops2deb.yml
@@ -32,6 +32,7 @@ matrix:
     - 4.4.0
     - 4.5.0
     - 4.5.1
+    - 4.6.0
 revision: "2"
 architecture: all
 homepage: https://pre-commit.com/

--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.8.zip
-  sha256: 7175ed14a33b76047f8b99bdd54925bf7619261ccbaab111445b5fae133024ae
-  timestamp: 2024-07-21 06:06:58+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.9.zip
   sha256: 215ba6b3859975fd70e2a27480156a4a30c927c5b2cb431dbda131c53b595a01
   timestamp: 2024-08-05 00:24:46+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.26.zip
   sha256: 215ab5d643158873dca667f1af600fc8d0d331b74424567e57e690437b19025e
   timestamp: 2026-03-11 00:08:21+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.27.zip
+  sha256: 2584c2b094efc2bd1de47664c190d9b08329bf928f406f01cd49e3b82c7262bf
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.4.8
       - 2.4.9
       - 2.4.10
       - 2.4.11
@@ -73,6 +72,7 @@
       - 2.6.24
       - 2.6.25
       - 2.6.26
+      - 2.6.27
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/dev/scala-cli/ops2deb.lock.yml
+++ b/blueprints/dev/scala-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/VirtusLab/scala-cli/releases/download/v0.1.18/scala-cli-x86_64-pc-linux.deb
-  sha256: c12d19ad02453fe88e845941e04470887b60c600b71420a6c6687990dfe5ca53
-  timestamp: 2022-11-30 16:22:33+00:00
 - url: https://github.com/VirtusLab/scala-cli/releases/download/v0.1.19/scala-cli-x86_64-pc-linux.deb
   sha256: 2d2e7834a5a5e2a1a0ec1958401abda3b9d5839c4900ef201616213e565e0c31
   timestamp: 2022-12-20 02:35:03+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/VirtusLab/scala-cli/releases/download/v1.12.5/scala-cli-x86_64-pc-linux.deb
   sha256: 6e7d6e3a56a1b0c91188d53615ac37fd6a72f4ab33ffc159da180b8ca22e5bad
   timestamp: 2026-03-20 12:07:23+00:00
+- url: https://github.com/VirtusLab/scala-cli/releases/download/v1.13.0/scala-cli-x86_64-pc-linux.deb
+  sha256: 8700a0656f605064be6cda6b27c9a23248c566b7a42a147d86f5083ab3b0b1b2
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/scala-cli/ops2deb.yml
+++ b/blueprints/dev/scala-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: scala-cli
 matrix:
   versions:
-    - 0.1.18
     - 0.1.19
     - 0.1.20
     - 0.2.0
@@ -51,6 +50,7 @@ matrix:
     - 1.12.3
     - 1.12.4
     - 1.12.5
+    - 1.13.0
 homepage: https://scala-cli.virtuslab.org/
 summary: command-line tool to interact with the Scala language
 description: |-

--- a/blueprints/dev/typos-cli/ops2deb.lock.yml
+++ b/blueprints/dev/typos-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/crate-ci/typos/releases/download/v1.28.2/typos-v1.28.2-x86_64-unknown-linux-musl.tar.gz
-  sha256: d06f2be394a828e2b9e429c6053b943974e2a7134ec8cbac3ad1f65c18c75970
-  timestamp: 2024-12-02 18:08:33+00:00
 - url: https://github.com/crate-ci/typos/releases/download/v1.28.3/typos-v1.28.3-x86_64-unknown-linux-musl.tar.gz
   sha256: 5aadc7aa163b99f040bcce246172e8c1dda0b6139b2d67d00894b3884233bbfb
   timestamp: 2024-12-13 00:30:02+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/crate-ci/typos/releases/download/v1.44.0/typos-v1.44.0-x86_64-unknown-linux-musl.tar.gz
   sha256: 1b788b7d764e2f20fe089487428a3944ed218d1fb6fcd8eac4230b5893a38779
   timestamp: 2026-02-27 18:08:56+00:00
+- url: https://github.com/crate-ci/typos/releases/download/v1.45.1/typos-v1.45.1-x86_64-unknown-linux-musl.tar.gz
+  sha256: 33447531a0eff29796d6fb9b555b4628723db72c6bad129e168d97ac86ceb0f1
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/typos-cli/ops2deb.yml
+++ b/blueprints/dev/typos-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: typos-cli
 matrix:
   versions:
-    - 1.28.2
     - 1.28.3
     - 1.28.4
     - 1.29.0
@@ -51,6 +50,7 @@ matrix:
     - 1.43.4
     - 1.43.5
     - 1.44.0
+    - 1.45.1
 homepage: https://github.com/crate-ci/typos/
 summary: source code spell checker
 description: |-

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -448,15 +448,6 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.6.7/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 601c2b1147117c4471a154b4cebbdb31c818105f796d5f8115fe42d2526689c8
   timestamp: 2025-03-18 03:17:18+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.8.16/uv-aarch64-unknown-linux-musl.tar.gz
-  sha256: 6bd6a11c384f07353c3c7eec9bde094f89b92a12dc09caea9df40c424afebea5
-  timestamp: 2025-09-10 06:03:31+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.8.16/uv-armv7-unknown-linux-gnueabihf.tar.gz
-  sha256: ada6f393d5e5d9cba5445832ba61e8222859e915e5d77a37f5dd35979f3f18e4
-  timestamp: 2025-09-10 06:03:31+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.8.16/uv-x86_64-unknown-linux-gnu.tar.gz
-  sha256: fc94e50e8ef93a97d723b83faa42888e7710c4443a5b8a1af3aac2cda5390f3a
-  timestamp: 2025-09-10 06:03:31+00:00
 - url: https://github.com/astral-sh/uv/releases/download/0.8.17/uv-aarch64-unknown-linux-musl.tar.gz
   sha256: bd141b7e263935d14f5725f2a5c1c942fd89642e37683cb904f1984ce7e365f4
   timestamp: 2025-09-11 00:07:57+00:00
@@ -898,3 +889,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.11.0/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: cc0fbb42b3642125f600a55b0b095bea65cddaadb94c6ea2b6ba5d79c5825089
   timestamp: 2026-03-24 00:11:54+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.11.7/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: 46647dc16cbb7d6700f762fdd7a67d220abe18570914732bc310adc91308d272
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.11.7/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: 7aa9ddc128f58c0e667227feb84e0aac3bb65301604c5f6f2ab0f442aaaafd99
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.11.7/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 6681d691eb7f9c00ac6a3af54252f7ab29ae72f0c8f95bdc7f9d1401c23ea868
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -87,7 +87,6 @@
       - arm64
       - armhf
     versions:
-      - 0.8.16
       - 0.8.17
       - 0.8.18
       - 0.8.19
@@ -137,6 +136,7 @@
       - 0.10.9
       - 0.10.12
       - 0.11.0
+      - 0.11.7
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/devops/act/ops2deb.lock.yml
+++ b/blueprints/devops/act/ops2deb.lock.yml
@@ -376,3 +376,12 @@
 - url: https://github.com/nektos/act/releases/download/v0.2.85/act_Linux_x86_64.tar.gz
   sha256: fbf411fb5a47bff407d3be1f320f3314af050d92b0e7e9615075222ba0c22947
   timestamp: 2026-03-23 18:14:20+00:00
+- url: https://github.com/nektos/act/releases/download/v0.2.87/act_Linux_arm64.tar.gz
+  sha256: c17a9fe2428a4824f61248ceb8e93db8de95d9163b0f2651ec5ccea0e6f4edc8
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/nektos/act/releases/download/v0.2.87/act_Linux_armv7.tar.gz
+  sha256: 65e59643a65cd02ec1957967e1f98222e15af0d8c714a4954a63785909b4495e
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/nektos/act/releases/download/v0.2.87/act_Linux_x86_64.tar.gz
+  sha256: 9bbfca7d779f71746233ec65e47fdcb12c4c976c1c97ec085956976fcabee866
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/act/ops2deb.yml
+++ b/blueprints/devops/act/ops2deb.yml
@@ -74,6 +74,7 @@
       - 0.2.83
       - 0.2.84
       - 0.2.85
+      - 0.2.87
   homepage: https://github.com/nektos/act/
   summary: run your GitHub Actions locally
   description: |-

--- a/blueprints/devops/argo/ops2deb.lock.yml
+++ b/blueprints/devops/argo/ops2deb.lock.yml
@@ -208,3 +208,9 @@
 - url: https://github.com/argoproj/argo-workflows/releases/download/v4.0.3/argo-linux-arm64.gz
   sha256: b20b03ca71906e4ac8d35972671f9429219dc6e419ea7bb6a9b35f4628a727d5
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v4.0.5/argo-linux-amd64.gz
+  sha256: 8732418f3bc930e9ea0e2be497270cf245b55c7ac9ae116856743f6bc32733c0
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v4.0.5/argo-linux-arm64.gz
+  sha256: 280683f4d29c433c614bbc47d8638d2ca095a98e150f821b71a40732606e34cb
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/argo/ops2deb.yml
+++ b/blueprints/devops/argo/ops2deb.yml
@@ -39,6 +39,7 @@ matrix:
     - 4.0.1
     - 4.0.2
     - 4.0.3
+    - 4.0.5
 homepage: https://argo-workflows.readthedocs.io
 summary: Workflow Engine for Kubernetes
 description: |-

--- a/blueprints/devops/argocd/ops2deb.lock.yml
+++ b/blueprints/devops/argocd/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/argoproj/argo-cd/releases/download/v2.11.6/argocd-linux-amd64
-  sha256: d645ffd8c70fe8bb51c0c9a2cc639275f8ea1c2cba24de032341d3deecd5fc85
-  timestamp: 2024-07-23 18:07:18+00:00
-- url: https://github.com/argoproj/argo-cd/releases/download/v2.11.6/argocd-linux-arm64
-  sha256: ba7b71f7bfeae68d72f57ed4bb354227e2f441a5a20b721e218df32bf9916e66
-  timestamp: 2024-07-23 18:07:18+00:00
 - url: https://github.com/argoproj/argo-cd/releases/download/v2.11.7/argocd-linux-amd64
   sha256: 64db335c5b1b6b63ab5d6530894429a803897d2ab8293272ad6e8e166e677b35
   timestamp: 2024-07-24 21:06:29+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/argoproj/argo-cd/releases/download/v3.3.4/argocd-linux-arm64
   sha256: 040a82303ba4049423283605bc0d5d437dff702fa862763bf445aab0f2f4f0ff
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v3.3.8/argocd-linux-amd64
+  sha256: 11070d2502c5a51523f78388e23ddefb9151bd33f2faab955cde78a9c0d492e6
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v3.3.8/argocd-linux-arm64
+  sha256: cec49dcb3a3b9e7f4b78390af52e6890689d02c9f0a3b9a61ecd5b2edf38d49b
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/argocd/ops2deb.yml
+++ b/blueprints/devops/argocd/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 2.11.6
     - 2.11.7
     - 2.12.0
     - 2.12.1
@@ -54,6 +53,7 @@ matrix:
     - 3.3.2
     - 3.3.3
     - 3.3.4
+    - 3.3.8
 homepage: https://github.com/argoproj/argo-cd
 summary: continuous delivery tool for Kubernetes
 description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.

--- a/blueprints/devops/aws-iam-authenticator/ops2deb.lock.yml
+++ b/blueprints/devops/aws-iam-authenticator/ops2deb.lock.yml
@@ -184,3 +184,9 @@
 - url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.12/aws-iam-authenticator_0.7.12_linux_arm64
   sha256: 916c4a74372b6901ea1937bfb95127d71c4c7155cbd1b757b85b4497c0f9beba
   timestamp: 2026-03-21 06:10:21+00:00
+- url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.13/aws-iam-authenticator_0.7.13_linux_amd64
+  sha256: 53e0cd1fba499ec70c9d1aee69b0beb281c298e7deda67b4191c3e1ad183b638
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.13/aws-iam-authenticator_0.7.13_linux_arm64
+  sha256: 9ad3cb19a3f3fcd32edacaa7199174560c85a95c41e0c451a587cb514b633012
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/aws-iam-authenticator/ops2deb.yml
+++ b/blueprints/devops/aws-iam-authenticator/ops2deb.yml
@@ -35,6 +35,7 @@ matrix:
     - 0.7.10
     - 0.7.11
     - 0.7.12
+    - 0.7.13
 homepage: https://github.com/kubernetes-sigs/aws-iam-authenticator
 summary: Kubernetes authentication using AWS IAM
 description: A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster.

--- a/blueprints/devops/clusterctl/ops2deb.lock.yml
+++ b/blueprints/devops/clusterctl/ops2deb.lock.yml
@@ -166,3 +166,9 @@
 - url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.4/clusterctl-linux-arm64
   sha256: 1260f75a3e936057b94a561c8b21ac6cba2ae75d9f1c2c25ea3ecc876017fbd6
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0/clusterctl-linux-amd64
+  sha256: 8641af6b79f156cf48d2ce9b1179f114e94d5ca9a2adfba6f2bd78ce59f7a5f8
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0/clusterctl-linux-arm64
+  sha256: 72fcf8a08e47a3c5d9ea338a3867be82ed4bc1da2c7e8dac989c9d9353e9044d
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/clusterctl/ops2deb.yml
+++ b/blueprints/devops/clusterctl/ops2deb.yml
@@ -32,6 +32,7 @@ matrix:
     - 1.12.2
     - 1.12.3
     - 1.12.4
+    - 1.13.0
 homepage: https://cluster-api.sigs.k8s.io/
 summary: Kubernetes project offering declarative APIs for managing multiple clusters
 description: |-

--- a/blueprints/devops/dapr/ops2deb.lock.yml
+++ b/blueprints/devops/dapr/ops2deb.lock.yml
@@ -76,3 +76,9 @@
 - url: https://github.com/dapr/cli/releases/download/v1.17.0/dapr_linux_arm64.tar.gz
   sha256: 09b1e2fbc1e1c977d16077e04b92070cbae97b4539fd07085fcf3644575faa8c
   timestamp: 2026-02-28 00:10:00+00:00
+- url: https://github.com/dapr/cli/releases/download/v1.17.1/dapr_linux_amd64.tar.gz
+  sha256: a2ce17223d23e1a3651b8ccd9d0e619638db5b760b52fbc4e4d21e8571c6999e
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/dapr/cli/releases/download/v1.17.1/dapr_linux_arm64.tar.gz
+  sha256: 1ec4dd07c3f70810931ce140d67ad0d28261a508c6c5474fcc381001ae392b88
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/dapr/ops2deb.yml
+++ b/blueprints/devops/dapr/ops2deb.yml
@@ -17,6 +17,7 @@ matrix:
     - 1.16.3
     - 1.16.5
     - 1.17.0
+    - 1.17.1
 homepage: https://dapr.io/
 summary: command-line tools for Dapr.
 description: |-

--- a/blueprints/devops/devspace/ops2deb.lock.yml
+++ b/blueprints/devops/devspace/ops2deb.lock.yml
@@ -202,3 +202,9 @@
 - url: https://github.com/devspace-sh/devspace/releases/download/v6.3.20/devspace-linux-arm64
   sha256: 0f40e0a6bd8a754a07a1bced2f6d3e07e6be2bb64cdcf4e19887979566461c11
   timestamp: 2026-02-24 18:19:34+00:00
+- url: https://github.com/devspace-sh/devspace/releases/download/v6.3.21/devspace-linux-amd64
+  sha256: 9720a6c87a2465f6d73b4db5a908e15e1971158443b5de9162d94aa5f87f79f0
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/devspace-sh/devspace/releases/download/v6.3.21/devspace-linux-arm64
+  sha256: 8652285a22f079d4bfeda37a2f1089d56e64a34a76d32537dfb20a7cd6e69fcb
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/devops/devspace/ops2deb.yml
+++ b/blueprints/devops/devspace/ops2deb.yml
@@ -75,6 +75,7 @@
       - 6.3.17
       - 6.3.18
       - 6.3.20
+      - 6.3.21
   homepage: https://devspace.sh
   summary: developer tool for Kubernetes
   description: |-

--- a/blueprints/devops/docker-compose/ops2deb.lock.yml
+++ b/blueprints/devops/docker-compose/ops2deb.lock.yml
@@ -1,15 +1,6 @@
 - url: https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64
   sha256: f3f10cf3dbb8107e9ba2ea5f23c1d2159ff7321d16f0a23051d68d8e2547b323
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/docker/compose/releases/download/v2.27.1/docker-compose-linux-aarch64
-  sha256: 16e93b9c2fc147d29ca1acbb8ceab6a50a0e26af777f43dc7a753cb883142617
-  timestamp: 2024-05-24 15:06:05+00:00
-- url: https://github.com/docker/compose/releases/download/v2.27.1/docker-compose-linux-armv7
-  sha256: 9dcfa9523dc912370417b7ccc3d81900bbb98dd9addbff0d218398bbe9078bbd
-  timestamp: 2024-05-24 15:06:05+00:00
-- url: https://github.com/docker/compose/releases/download/v2.27.1/docker-compose-linux-x86_64
-  sha256: ddc876fe2a89d5b7ea455146b0975bfe52904eecba9b192193377d6f99d69ad9
-  timestamp: 2024-05-24 15:06:05+00:00
 - url: https://github.com/docker/compose/releases/download/v2.27.2/docker-compose-linux-aarch64
   sha256: de8c48203f4876fe3ae8bf27081a9aa69dc87de67a705f9d76c3a3ad776ed0c2
   timestamp: 2024-06-20 12:09:56+00:00
@@ -451,3 +442,12 @@
 - url: https://github.com/docker/compose/releases/download/v5.1.1/docker-compose-linux-x86_64
   sha256: 2ac954c9d506b912a12477d72f01601dc72ec918c429c7bae48fd707bdf0f3e5
   timestamp: 2026-03-20 06:16:04+00:00
+- url: https://github.com/docker/compose/releases/download/v5.1.3/docker-compose-linux-aarch64
+  sha256: e8105a3e687ea7e0b0f81abe4bf9269c8a2801fb72c2b498b5ff2472bc54145f
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/docker/compose/releases/download/v5.1.3/docker-compose-linux-armv7
+  sha256: 4c1ce6ad43c184934a1f76cd55d7231192492c487acbd13e96258ed10fd9e468
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/docker/compose/releases/download/v5.1.3/docker-compose-linux-x86_64
+  sha256: a0298760c9772d2c06888fc8703a487c94c3c3b0134adeef830742a2fc7647b4
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/devops/docker-compose/ops2deb.yml
+++ b/blueprints/devops/docker-compose/ops2deb.yml
@@ -18,7 +18,6 @@
       - arm64
       - armhf
     versions:
-      - 2.27.1
       - 2.27.2
       - 2.27.3
       - 2.28.0
@@ -68,6 +67,7 @@
       - 5.0.2
       - 5.1.0
       - 5.1.1
+      - 5.1.3
   homepage: https://docs.docker.com/compose
   summary: lightweight development environments using Docker
   description: |-

--- a/blueprints/devops/flux/ops2deb.lock.yml
+++ b/blueprints/devops/flux/ops2deb.lock.yml
@@ -16,15 +16,6 @@
 - url: https://github.com/fluxcd/flux2/releases/download/v0.24.1/flux_0.24.1_linux_amd64.tar.gz
   sha256: 3373a272ff888772e40647e90ba41dfa232e7482df62b10735cdd86a25e42178
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/fluxcd/flux2/releases/download/v0.31.5/flux_0.31.5_linux_amd64.tar.gz
-  sha256: b2f9ccec32cb3ddc701e47792f62e7a5f739346b6ad31f168570b8a8b5fe2f85
-  timestamp: 2022-07-27 20:27:05+00:00
-- url: https://github.com/fluxcd/flux2/releases/download/v0.31.5/flux_0.31.5_linux_arm.tar.gz
-  sha256: f38f5420957d8e86d863c64d880d948fe38dbbfa48f7fa287977b385b6175ffc
-  timestamp: 2022-07-27 20:27:05+00:00
-- url: https://github.com/fluxcd/flux2/releases/download/v0.31.5/flux_0.31.5_linux_arm64.tar.gz
-  sha256: 1a6ee419981f91b58ea8ec4169f284f650ce1e01081afd15421da44be226b452
-  timestamp: 2022-07-27 20:27:05+00:00
 - url: https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_linux_amd64.tar.gz
   sha256: c94a42e96620848f9aed69a130c01b7d740412f6f2b3ad3c95fe23471f2b8e4e
   timestamp: 2022-08-11 17:24:09+00:00
@@ -466,3 +457,12 @@
 - url: https://github.com/fluxcd/flux2/releases/download/v2.8.3/flux_2.8.3_linux_arm64.tar.gz
   sha256: 8f02cd3c2f058434b40cb264d4f3d961a3d5bc7c4985cc4544946f9b8224632b
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_linux_amd64.tar.gz
+  sha256: c53cc990ae266f7840f64c81515d701d8821d558a9062aa4211d71b38cf044be
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_linux_arm.tar.gz
+  sha256: be062d350dbecdcb089556f21cf397e5bd3bdd0732b0e261436b8cea6f20530c
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_linux_arm64.tar.gz
+  sha256: bc460320c2d33ad833791277896dd1aaf1cff6b3e64ba397c44238f00d4ae5bc
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/flux/ops2deb.yml
+++ b/blueprints/devops/flux/ops2deb.yml
@@ -36,7 +36,6 @@
       - arm64
       - armhf
     versions:
-      - 0.31.5
       - 0.32.0
       - 0.33.0
       - 0.34.0
@@ -86,6 +85,7 @@
       - 2.8.0
       - 2.8.1
       - 2.8.3
+      - 2.8.6
   homepage: https://fluxcd.io
   summary: open and extensible continuous delivery solution for Kubernetes
   description: |-

--- a/blueprints/devops/goreleaser/ops2deb.lock.yml
+++ b/blueprints/devops/goreleaser/ops2deb.lock.yml
@@ -256,3 +256,9 @@
 - url: https://github.com/goreleaser/goreleaser/releases/download/v2.14.3/goreleaser_Linux_x86_64.tar.gz
   sha256: dc7faeeeb6da8bdfda788626263a4ae725892a8c7504b975c3234127d4a44579
   timestamp: 2026-03-09 18:13:35+00:00
+- url: https://github.com/goreleaser/goreleaser/releases/download/v2.15.4/goreleaser_Linux_arm64.tar.gz
+  sha256: de01ca1497571e9b348413cd2e7f74be49b8d57696ae386f7eedd06176544a88
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/goreleaser/goreleaser/releases/download/v2.15.4/goreleaser_Linux_x86_64.tar.gz
+  sha256: aae00c71a4a6d55e08cce9273a1516bdce33c1e07cffb7e502fa6fec4377dede
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/goreleaser/ops2deb.yml
+++ b/blueprints/devops/goreleaser/ops2deb.yml
@@ -47,6 +47,7 @@ matrix:
     - 2.14.1
     - 2.14.2
     - 2.14.3
+    - 2.15.4
 homepage: https://goreleaser.com
 summary: release Go projects as fast and easily as possible
 description: |-

--- a/blueprints/devops/helm/ops2deb.lock.yml
+++ b/blueprints/devops/helm/ops2deb.lock.yml
@@ -52,12 +52,6 @@
 - url: https://get.helm.sh/helm-v3.9.1-linux-arm64.tar.gz
   sha256: 655dbceb4ab4b246af2214e669b9d44e3a35f170f39df8eebdb8d87619c585d1
   timestamp: 2022-07-13 20:26:10+00:00
-- url: https://get.helm.sh/helm-v3.10.3-linux-amd64.tar.gz
-  sha256: 950439759ece902157cf915b209b8d694e6f675eaab5099fb7894f30eeaee9a2
-  timestamp: 2022-12-14 19:23:42+00:00
-- url: https://get.helm.sh/helm-v3.10.3-linux-arm.tar.gz
-  sha256: dca718eb68c72c51fc7157c4c2ebc8ce7ac79b95fc9355c5427ded99e913ec4c
-  timestamp: 2022-12-14 19:23:42+00:00
 - url: https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz
   sha256: 6c3440d829a56071a4386dd3ce6254eab113bc9b1fe924a6ee99f7ff869b9e0b
   timestamp: 2023-01-18 19:22:55+00:00
@@ -352,3 +346,9 @@
 - url: https://get.helm.sh/helm-v4.1.3-linux-arm.tar.gz
   sha256: 5ea614cd1562e682e213e07f3632b76f9d7b4b0917918e820c515a9030a59951
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://get.helm.sh/helm-v4.1.4-linux-amd64.tar.gz
+  sha256: 70b2c30a19da4db264dfd68c8a3664e05093a361cefd89572ffb36f8abfa3d09
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://get.helm.sh/helm-v4.1.4-linux-arm.tar.gz
+  sha256: c4a7d37032379cc7e82c9c76487d1041b193c9a0fbb4b8f3790230899b830a4f
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/helm/ops2deb.yml
+++ b/blueprints/devops/helm/ops2deb.yml
@@ -42,7 +42,6 @@
       - amd64
       - armhf
     versions:
-      - 3.10.3
       - 3.11.0
       - 3.11.1
       - 3.11.2
@@ -92,6 +91,7 @@
       - 4.1.0
       - 4.1.1
       - 4.1.3
+      - 4.1.4
   homepage: https://helm.sh
   summary: Kubernetes package manager
   description: |-

--- a/blueprints/devops/helmfile/ops2deb.lock.yml
+++ b/blueprints/devops/helmfile/ops2deb.lock.yml
@@ -40,12 +40,6 @@
 - url: https://github.com/roboll/helmfile/releases/download/v0.144.0/helmfile_linux_arm64
   sha256: 8461bbb13ba23f4333dc99d96bf7a24c283cd7683e746acf639d80bbd828926a
   timestamp: 2022-03-31 05:32:30+00:00
-- url: https://github.com/helmfile/helmfile/releases/download/v0.145.0/helmfile_0.145.0_linux_amd64.tar.gz
-  sha256: 2a5d10adce4a9735ac44a9548797f62739e187acc251c284dbd5ce8e6f0f3410
-  timestamp: 2022-08-22 10:57:25+00:00
-- url: https://github.com/helmfile/helmfile/releases/download/v0.145.0/helmfile_0.145.0_linux_arm64.tar.gz
-  sha256: 4553acf0101fd0ddc9d3ca19c003eded55b97f42e1002ffa1e7cc0636834f54d
-  timestamp: 2022-08-22 10:57:25+00:00
 - url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_linux_amd64.tar.gz
   sha256: 7ec58255927eb5dcd18d9361de52ed548b84f657356dc5f9e88ecfb4af1d2279
   timestamp: 2022-08-22 11:18:51+00:00
@@ -340,3 +334,9 @@
 - url: https://github.com/helmfile/helmfile/releases/download/v1.4.2/helmfile_1.4.2_linux_arm64.tar.gz
   sha256: 5aa3c417cf192803797e2921d6d87fb323cd99ef85b4db5ea1598bca093d43a6
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.4.4/helmfile_1.4.4_linux_amd64.tar.gz
+  sha256: 3c35a7d7f65e900fa770cc27c119b1f48d458cd5755b4103e679ba5eb029ec91
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.4.4/helmfile_1.4.4_linux_arm64.tar.gz
+  sha256: 9ed46e06d7ec19bf1fb78f6e2995214112be9e10934a20576a52df5f4bfa6da2
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/helmfile/ops2deb.yml
+++ b/blueprints/devops/helmfile/ops2deb.yml
@@ -79,7 +79,6 @@
       - amd64
       - arm64
     versions:
-      - 0.145.0
       - 0.145.3
       - 0.145.4
       - 0.145.5
@@ -129,6 +128,7 @@
       - 1.4.0
       - 1.4.1
       - 1.4.2
+      - 1.4.4
   homepage: https://helmfile.readthedocs.io/
   summary: deploy Kubernetes Helm Charts
   description: |-

--- a/blueprints/devops/hubble/ops2deb.lock.yml
+++ b/blueprints/devops/hubble/ops2deb.lock.yml
@@ -46,3 +46,6 @@
 - url: https://github.com/cilium/hubble/releases/download/v1.18.6/hubble-linux-amd64.tar.gz
   sha256: 93080f029b96ddf9c3513dc74b15b578190e206410f8f596ae404474f2ff2168
   timestamp: 2026-02-10 00:16:19+00:00
+- url: https://github.com/cilium/hubble/releases/download/v1.19.3/hubble-linux-amd64.tar.gz
+  sha256: e0e555001a46921ff2501ddc874ed1f4c68ba20cdb00cf4ea8263be4395eb008
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/hubble/ops2deb.yml
+++ b/blueprints/devops/hubble/ops2deb.yml
@@ -19,6 +19,7 @@ matrix:
     - 1.18.3
     - 1.18.5
     - 1.18.6
+    - 1.19.3
 homepage: https://github.com/cilium/hubble
 summary: Network, Service & Security Observability for Kubernetes using eBPF
 description: |-

--- a/blueprints/devops/infracost/ops2deb.lock.yml
+++ b/blueprints/devops/infracost/ops2deb.lock.yml
@@ -214,3 +214,9 @@
 - url: https://github.com/infracost/infracost/releases/download/v0.10.43/infracost-linux-arm64.tar.gz
   sha256: c79e4e822b6e241aa2548e9b860b77ce86e99acbc79d8954e2b14f174c55bd62
   timestamp: 2025-12-03 12:04:23+00:00
+- url: https://github.com/infracost/infracost/releases/download/v0.10.44/infracost-linux-amd64.tar.gz
+  sha256: a85bf52b6abcc0a101e9c0c36ae7d0274c542346b36948710a89676e51e7da8e
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/infracost/infracost/releases/download/v0.10.44/infracost-linux-arm64.tar.gz
+  sha256: 0691b749c1136bed2497a896396b1ded2a774c885ee5236889f6938e53e18020
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/infracost/ops2deb.yml
+++ b/blueprints/devops/infracost/ops2deb.yml
@@ -40,6 +40,7 @@ matrix:
     - 0.10.41
     - 0.10.42
     - 0.10.43
+    - 0.10.44
 homepage: https://www.infracost.io
 summary: cloud cost estimates for Terraform in pull requests
 description: |-

--- a/blueprints/devops/istioctl/ops2deb.lock.yml
+++ b/blueprints/devops/istioctl/ops2deb.lock.yml
@@ -52,15 +52,6 @@
 - url: https://github.com/istio/istio/releases/download/1.13.2/istio-1.13.2-linux-armv7.tar.gz
   sha256: 7fcbc2514c9cad3756557bb49015707f9ede72478980aa79ddaf22090d507929
   timestamp: 2022-03-24 01:26:26+00:00
-- url: https://github.com/istio/istio/releases/download/1.16.0/istio-1.16.0-linux-amd64.tar.gz
-  sha256: aed8d55b59d52989e8f4c3c25cd1ea2c9d27e6a1dd0165f85388d62e53a6ef54
-  timestamp: 2022-11-16 02:57:51+00:00
-- url: https://github.com/istio/istio/releases/download/1.16.0/istio-1.16.0-linux-arm64.tar.gz
-  sha256: 2e58cd7a06f57e8652a7735a1caf9d35fbe41fbcc20e64d474d07a4655bea937
-  timestamp: 2022-11-16 02:57:51+00:00
-- url: https://github.com/istio/istio/releases/download/1.16.0/istio-1.16.0-linux-armv7.tar.gz
-  sha256: 7467c34b4219fe9ded25efb6a4a3d25ed9b560651f1750a8851ce44ff58e990a
-  timestamp: 2022-11-16 02:57:51+00:00
 - url: https://github.com/istio/istio/releases/download/1.16.1/istio-1.16.1-linux-amd64.tar.gz
   sha256: e5f6efc11c5dde58592478e1976b3c8e7bb9993cf22c57ac8a63003288baafdf
   timestamp: 2022-12-13 19:23:59+00:00
@@ -502,3 +493,12 @@
 - url: https://github.com/istio/istio/releases/download/1.29.1/istio-1.29.1-linux-armv7.tar.gz
   sha256: b13ff98f4bcf47aa56daa6c038dc529784756948e99b278e60aa1eadbd4db981
   timestamp: 2026-03-11 00:08:21+00:00
+- url: https://github.com/istio/istio/releases/download/1.29.2/istio-1.29.2-linux-amd64.tar.gz
+  sha256: 904bbf1b917dd0135aa55b99cbfa34edd0a188fdeeeef09bb995d8e8e3165112
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/istio/istio/releases/download/1.29.2/istio-1.29.2-linux-arm64.tar.gz
+  sha256: c4130d32359446fa5e4820c0543d06e2e424883c6890f0f8c59f3ac69dd4b44e
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/istio/istio/releases/download/1.29.2/istio-1.29.2-linux-armv7.tar.gz
+  sha256: 74e7f29064eb4b3904362bd539cf0fa26405edbdc98bf07d23a882c8388afb8e
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/istioctl/ops2deb.yml
+++ b/blueprints/devops/istioctl/ops2deb.yml
@@ -79,7 +79,6 @@
       - arm64
       - armhf
     versions:
-      - 1.16.0
       - 1.16.1
       - 1.16.2
       - 1.17.0
@@ -129,6 +128,7 @@
       - 1.28.3
       - 1.29.0
       - 1.29.1
+      - 1.29.2
   homepage: https://istio.io
   summary: command-line interface for Istio
   description: Istio is an open platform to connect, manage, and secure microservices.

--- a/blueprints/devops/jfrog-cli/ops2deb.lock.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.71.3/jfrog-cli-linux-amd64/jf
-  sha256: 3eaffc28189b7e05ce457654e519354db0574df165dc6334597ee420bc2c7160
-  timestamp: 2024-11-04 15:06:54+00:00
-- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.71.3/jfrog-cli-linux-arm64/jf
-  sha256: e3bda33146d2a27b94a7a3978671cc91fa40123ca0db2a143acf9bc59226f36b
-  timestamp: 2024-11-04 15:06:54+00:00
 - url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.71.4/jfrog-cli-linux-amd64/jf
   sha256: ec578e7c579cd9c5c901dd495852bb0a1715ea3b3de8bb06629491265b2e39b1
   timestamp: 2024-11-13 18:08:11+00:00
@@ -298,3 +292,9 @@
 - url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.96.0/jfrog-cli-linux-arm64/jf
   sha256: 0991e0c46a7aea2fd5d905d1894e57826726e42089fc745982a2ca28750a6ac0
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.102.0/jfrog-cli-linux-amd64/jf
+  sha256: e1134c1f26c9fa5fbc524dd062bf829c11a487ced2facc59065adfc584b7594a
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.102.0/jfrog-cli-linux-arm64/jf
+  sha256: a4d968e8eb82b85e8a4003b0714fac6cd00db0cbed5ece06e464b5a58aa786e1
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/devops/jfrog-cli/ops2deb.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 2.71.3
     - 2.71.4
     - 2.71.5
     - 2.72.0
@@ -54,6 +53,7 @@ matrix:
     - 2.94.0
     - 2.95.0
     - 2.96.0
+    - 2.102.0
 homepage: https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli
 summary: client that provides a simple interface that automates access to the JFrog
   products

--- a/blueprints/devops/kubectl-oidc-login/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl-oidc-login/ops2deb.lock.yml
@@ -88,3 +88,9 @@
 - url: https://github.com/int128/kubelogin/releases/download/v1.36.0/kubelogin_linux_arm64.zip
   sha256: a0cb7ab0e67e5cc4acdcc4db31bd2e93f7f6831a3bd5da6143e3174c610852df
   timestamp: 2026-03-01 06:12:20+00:00
+- url: https://github.com/int128/kubelogin/releases/download/v1.36.1/kubelogin_linux_amd64.zip
+  sha256: a6dae91dfedd564906d892b1bdb1b74d821808802263b95751ca8e95cb1c0936
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/int128/kubelogin/releases/download/v1.36.1/kubelogin_linux_arm64.zip
+  sha256: b6790c4991d9ec13fca3c9375635608874434da4a5476b8567e65302c852690e
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/kubectl-oidc-login/ops2deb.yml
+++ b/blueprints/devops/kubectl-oidc-login/ops2deb.yml
@@ -19,6 +19,7 @@ matrix:
     - 1.35.0
     - 1.35.2
     - 1.36.0
+    - 1.36.1
 homepage: https://github.com/int128/kubelogin
 summary: Kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)
 description: |-

--- a/blueprints/devops/kubectl/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl/ops2deb.lock.yml
@@ -505,3 +505,12 @@
 - url: https://dl.k8s.io/release/v1.35.3/bin/linux/arm64/kubectl
   sha256: 6f0cd088a82dde5d5807122056069e2fac4ed447cc518efc055547ae46525f14
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
+  sha256: 123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://dl.k8s.io/release/v1.36.0/bin/linux/arm/kubectl
+  sha256: bd1ab1f3d3cb7dec7c46799355e82717a6519fa83708752c2be88fe5c378681f
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
+  sha256: 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/kubectl/ops2deb.yml
+++ b/blueprints/devops/kubectl/ops2deb.yml
@@ -105,6 +105,7 @@
       - 1.35.1
       - 1.35.2
       - 1.35.3
+      - 1.36.0
   homepage: https://github.com/kubernetes/kubectl
   summary: command line client for controlling a Kubernetes cluster
   description: |-

--- a/blueprints/devops/kubectx/ops2deb.lock.yml
+++ b/blueprints/devops/kubectx/ops2deb.lock.yml
@@ -25,3 +25,9 @@
 - url: https://github.com/ahmetb/kubectx/releases/download/v0.10.2/kubectx_v0.10.2_linux_armhf.tar.gz
   sha256: 943ad6beefbd2551ff71bafa0ecf5c6fd16a3a1b6cbb2e20e2f2e07e2a8b06c6
   timestamp: 2026-03-24 00:11:54+00:00
+- url: https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubectx_v0.11.0_linux_arm64.tar.gz
+  sha256: 1dac2072216689e773325cb7587b858ea7415706ebcf04e23bf80e7e70555340
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubectx_v0.11.0_linux_armhf.tar.gz
+  sha256: f0ce8e365bfd04ee62f16a35d7001d4f9c49223206d249c5ecb691d83fea09a7
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/kubectx/ops2deb.yml
+++ b/blueprints/devops/kubectx/ops2deb.yml
@@ -19,6 +19,7 @@
       - 0.9.5
       - 0.10.0
       - 0.10.2
+      - 0.11.0
   revision: "3"
   homepage: https://github.com/ahmetb/kubectx
   summary: kubectl plugin that helps you switch between clusters

--- a/blueprints/devops/kubelogin/ops2deb.lock.yml
+++ b/blueprints/devops/kubelogin/ops2deb.lock.yml
@@ -160,3 +160,9 @@
 - url: https://github.com/Azure/kubelogin/releases/download/v0.2.16/kubelogin-linux-arm64.zip
   sha256: 5716aa7f62275cd6393215cbcfa80baf5e79f105dc286043631845c60cd021ec
   timestamp: 2026-03-10 18:13:14+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.17/kubelogin-linux-amd64.zip
+  sha256: 9a5484504ab1c91cdafdcd55a9e439bb3f55a0fe29fe253a169df5538c0a2c86
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/Azure/kubelogin/releases/download/v0.2.17/kubelogin-linux-arm64.zip
+  sha256: 39608e328d87a98f84c7f5af780d9303ac8eda7a27a6d463f43cc2ae85196184
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/devops/kubelogin/ops2deb.yml
+++ b/blueprints/devops/kubelogin/ops2deb.yml
@@ -31,6 +31,7 @@ matrix:
     - 0.2.14
     - 0.2.15
     - 0.2.16
+    - 0.2.17
 homepage: https://github.com/Azure/kubelogin
 summary: Kubernetes credential (exec) plugin implementing azure authentication
 description: |-

--- a/blueprints/devops/kubens/ops2deb.lock.yml
+++ b/blueprints/devops/kubens/ops2deb.lock.yml
@@ -25,3 +25,9 @@
 - url: https://github.com/ahmetb/kubectx/releases/download/v0.10.2/kubens_v0.10.2_linux_armhf.tar.gz
   sha256: d0148fe606abf29416d1454768da0e74a7ed327be0728be7a198f1861f49f7c2
   timestamp: 2026-03-24 00:11:54+00:00
+- url: https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubens_v0.11.0_linux_arm64.tar.gz
+  sha256: 37058abe82ef20c93b44f3dc8ca2382dbb95d416cec958fbf7b8f79f011be86c
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/ahmetb/kubectx/releases/download/v0.11.0/kubens_v0.11.0_linux_armhf.tar.gz
+  sha256: a30a6551a3a0cfc98faf32225ed5e7526286faef798ce5b3346e4c202f9d87c7
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/kubens/ops2deb.yml
+++ b/blueprints/devops/kubens/ops2deb.yml
@@ -19,6 +19,7 @@
       - 0.9.5
       - 0.10.0
       - 0.10.2
+      - 0.11.0
   revision: "3"
   homepage: https://github.com/ahmetb/kubectx
   summary: kubectl plugin that helps you switch between namespaces

--- a/blueprints/devops/kubeseal/ops2deb.lock.yml
+++ b/blueprints/devops/kubeseal/ops2deb.lock.yml
@@ -19,15 +19,6 @@
 - url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-linux-arm64.tar.gz
   sha256: 600b3eabaf2fd47b204c6d46ac10141381c6f98e0b6d0f95f2aab0338f3fff63
   timestamp: 2022-03-31 17:23:25+00:00
-- url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.5/kubeseal-0.17.5-linux-amd64.tar.gz
-  sha256: 7a832db451c09a8bb2c49930b9248c23ddf151f30ff579615e4996317dac9d61
-  timestamp: 2022-04-20 23:19:30+00:00
-- url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.5/kubeseal-0.17.5-linux-arm.tar.gz
-  sha256: be0aeab42f312ae67c02ee963c0a5f617f7e3a180555a0c2252c722ffa9371d1
-  timestamp: 2022-04-20 23:19:30+00:00
-- url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.5/kubeseal-0.17.5-linux-arm64.tar.gz
-  sha256: fb328aa09ff7f94130699ff5759a30a44975343ed1eba0a400da431fa335300e
-  timestamp: 2022-04-20 23:19:30+00:00
 - url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.18.0/kubeseal-0.18.0-linux-amd64.tar.gz
   sha256: 51f3180d0e61d6b51b95f3c99f31d77f4417eb4945a03884afa55c20ce01c19a
   timestamp: 2022-06-02 23:19:33+00:00
@@ -469,3 +460,12 @@
 - url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.36.1/kubeseal-0.36.1-linux-arm64.tar.gz
   sha256: 568094081b77b14db9990c681e7fd78ed51eecf0d16274a6bf6c2fb3f76f64e9
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.36.6/kubeseal-0.36.6-linux-amd64.tar.gz
+  sha256: 9a091f92d56ae90e6df269294c556cf75b48fe50ebc09541a1e85732373a9893
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.36.6/kubeseal-0.36.6-linux-arm.tar.gz
+  sha256: daacf4b0c12a7c4c4dcd0c9b222d96518fb5c3c4869611b142aa9b7d4b06a96c
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.36.6/kubeseal-0.36.6-linux-arm64.tar.gz
+  sha256: cd5fda90f545e2f0d256646552c6138d4abec1face3b2decd473f844eeb451c7
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/kubeseal/ops2deb.yml
+++ b/blueprints/devops/kubeseal/ops2deb.yml
@@ -35,7 +35,6 @@
       - arm64
       - armhf
     versions:
-      - 0.17.5
       - 0.18.0
       - 0.18.1
       - 0.18.2
@@ -85,6 +84,7 @@
       - 0.35.0
       - 0.36.0
       - 0.36.1
+      - 0.36.6
   homepage: https://github.com/bitnami-labs/sealed-secrets
   summary: secret management solution for Kubernetes
   description: |-

--- a/blueprints/devops/lazydocker/ops2deb.lock.yml
+++ b/blueprints/devops/lazydocker/ops2deb.lock.yml
@@ -124,3 +124,12 @@
 - url: https://github.com/jesseduffield/lazydocker/releases/download/v0.25.0/lazydocker_0.25.0_Linux_x86_64.tar.gz
   sha256: 9c17b1458b214af50168f5f5e981f1f9c4b34d13a22734b7318bf9a05132ff3d
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Linux_arm64.tar.gz
+  sha256: 005c38b685aaa557e7d646d83a3dadb5024340eeed8c6a2e1949eee6f530de23
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Linux_armv7.tar.gz
+  sha256: 7a12a63fd39fdbb84b41db14824822f2ce38a549b744ddb5647587ec3aa4cf2e
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/jesseduffield/lazydocker/releases/download/v0.25.2/lazydocker_0.25.2_Linux_x86_64.tar.gz
+  sha256: 0d9dbfc26068b218e7ed84b104748cadc6e3cf733c0afd35465306fb39b9523c
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/lazydocker/ops2deb.yml
+++ b/blueprints/devops/lazydocker/ops2deb.yml
@@ -19,6 +19,7 @@ matrix:
     - 0.24.3
     - 0.24.4
     - 0.25.0
+    - 0.25.2
 homepage: https://github.com/jesseduffield/lazydocker
 summary: a lazier way to manage everything docker
 description: |-

--- a/blueprints/devops/logcli/ops2deb.lock.yml
+++ b/blueprints/devops/logcli/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/grafana/loki/releases/download/v2.4.2/logcli-linux-amd64.zip
-  sha256: 68e5e281b4488ad49303cce972e194fe4e186cd519ed8a14db0c28316ad01e05
-  timestamp: 2022-01-12 19:25:43+00:00
-- url: https://github.com/grafana/loki/releases/download/v2.4.2/logcli-linux-arm.zip
-  sha256: 362eb654400e33024c40d1a8f4595241f206fbcb39b8767fe7104cf301f8d325
-  timestamp: 2022-01-30 16:22:16+00:00
-- url: https://github.com/grafana/loki/releases/download/v2.4.2/logcli-linux-arm64.zip
-  sha256: 38003a38b3ffab792fc1f00d68bf48fe440ec48ff0eb13206c37805e18d19eac
-  timestamp: 2022-01-30 16:22:16+00:00
 - url: https://github.com/grafana/loki/releases/download/v2.5.0/logcli-linux-amd64.zip
   sha256: ba034c3c56e121697a6bcec7a51b012e946a4f449a757a0ce594cd689c3e6648
   timestamp: 2022-04-11 20:28:57+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/grafana/loki/releases/download/v3.6.7/logcli-linux-arm64.zip
   sha256: 88eb1939c1a45f72ae31e65124317c77d4f84b371d3fd27db1ba782c33542bcd
   timestamp: 2026-02-23 12:09:32+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.7.1/logcli-linux-amd64.zip
+  sha256: 26aee3878f09ec453df1a4bb84c34a8345072e6e36fdaff539f397c263cddf18
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.7.1/logcli-linux-arm.zip
+  sha256: c5727549491308b13d88f135e3599d09ca0dd556368f61d8a4bb9bf9bf6266e1
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.7.1/logcli-linux-arm64.zip
+  sha256: b3cf8e9b842c406b93cb8c1788bbfeee68ccb449d8c24e86c71469009266e870
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/logcli/ops2deb.yml
+++ b/blueprints/devops/logcli/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 2.4.2
     - 2.5.0
     - 2.6.0
     - 2.6.1
@@ -55,6 +54,7 @@ matrix:
     - 3.6.5
     - 3.6.6
     - 3.6.7
+    - 3.7.1
 homepage: https://github.com/grafana/loki
 summary: command-line interface for loki
 description: It facilitates running LogQL queries against a Loki instance.

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.154.1/mirrord_linux_aarch64.zip
-  sha256: 09c2cd23a23420c1089311751916b412747e084fb108e6b30f694b3bb56bf7c8
-  timestamp: 2025-08-04 12:03:51+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.154.1/mirrord_linux_x86_64.zip
-  sha256: 4b0412782d164bf1379f9ab766ecaad5b58b53197b1e2e8a33c728635baa776d
-  timestamp: 2025-08-04 12:03:51+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.155.0/mirrord_linux_aarch64.zip
   sha256: 2a8d690ecd2ec588e93290e5e29157af8aa9f790e6d2f186f88900ef7a2e6780
   timestamp: 2025-08-06 00:08:55+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.194.0/mirrord_linux_x86_64.zip
   sha256: 0eb15fb27264d08a234219cb11d57ea074099448aa3474171d4c3057c63dc1f8
   timestamp: 2026-03-20 06:16:04+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.204.1/mirrord_linux_aarch64.zip
+  sha256: 2f6d343d7ce8e7e3c1204add492eff802b667ecf6e76e7387aafa028a679f696
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.204.1/mirrord_linux_x86_64.zip
+  sha256: 07606c8989f843d58a003502a77cb5469d10e222bb3c0a091ba298e8163b5bb5
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.154.1
     - 3.155.0
     - 3.156.0
     - 3.157.0
@@ -54,6 +53,7 @@ matrix:
     - 3.192.1
     - 3.193.0
     - 3.194.0
+    - 3.204.1
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-

--- a/blueprints/devops/nats-server/ops2deb.lock.yml
+++ b/blueprints/devops/nats-server/ops2deb.lock.yml
@@ -88,3 +88,12 @@
 - url: https://github.com/nats-io/nats-server/releases/download/v2.12.5/nats-server-v2.12.5-linux-arm7.tar.gz
   sha256: 72f0084970ca9605b83db78806717403e1f676a587a4a07bb28a4b86ae201bc6
   timestamp: 2026-03-09 18:13:35+00:00
+- url: https://github.com/nats-io/nats-server/releases/download/v2.12.7/nats-server-v2.12.7-linux-amd64.tar.gz
+  sha256: 570d2d627db111e679cc1e6bc57ba78f373ed1769acd8dc9c21c8f62d15b3c52
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/nats-io/nats-server/releases/download/v2.12.7/nats-server-v2.12.7-linux-arm64.tar.gz
+  sha256: 3b9a79986778285c0e5acaba0b1218b72f6159db68fe5b8916a7d846240f9f22
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/nats-io/nats-server/releases/download/v2.12.7/nats-server-v2.12.7-linux-arm7.tar.gz
+  sha256: c6a2563489aa54ecb2f5ff73d24fc5f9052ef70c4bf179b10ea322811cd42a0b
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/nats-server/ops2deb.yml
+++ b/blueprints/devops/nats-server/ops2deb.yml
@@ -15,6 +15,7 @@ matrix:
     - 2.12.3
     - 2.12.4
     - 2.12.5
+    - 2.12.7
 homepage: https://github.com/nats-io/nats-server
 summary: NATS server implementation
 description: |-

--- a/blueprints/devops/natscli/ops2deb.lock.yml
+++ b/blueprints/devops/natscli/ops2deb.lock.yml
@@ -139,3 +139,12 @@
 - url: https://github.com/nats-io/natscli/releases/download/v0.3.1/nats-0.3.1-linux-arm7.zip
   sha256: ccac3c9e4e6b621a354d9cf9dadbcfb3518f92445c4366ed38c42dc46cc0ec68
   timestamp: 2026-01-28 12:04:34+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.3.2/nats-0.3.2-linux-amd64.zip
+  sha256: be942b5c3815d572b0836b1656e6c27e6306cf5633e439fbba8dd19c77288ba7
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.3.2/nats-0.3.2-linux-arm64.zip
+  sha256: c3861ac1a654768ddf50c6936714686211a99eb76cc7166518cd9066cefb89b1
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/nats-io/natscli/releases/download/v0.3.2/nats-0.3.2-linux-arm7.zip
+  sha256: 1474e5af3b80fe713f20ce7a0bf31136f6df04f62e02f04c918d939c733226e9
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/natscli/ops2deb.yml
+++ b/blueprints/devops/natscli/ops2deb.yml
@@ -47,6 +47,7 @@
       - 0.2.4
       - 0.3.0
       - 0.3.1
+      - 0.3.2
   homepage: https://github.com/nats-io/natscli
   summary: command-line interface for NATS
   description: |-

--- a/blueprints/devops/nsc/ops2deb.lock.yml
+++ b/blueprints/devops/nsc/ops2deb.lock.yml
@@ -25,3 +25,12 @@
 - url: https://github.com/nats-io/nsc/releases/download/v2.12.0/nsc-linux-armv7.zip
   sha256: 56d708096a0ba62a6f009363a7b985264db5fd19cade6c35d5e57dcc61c0ef9f
   timestamp: 2025-09-23 00:08:17+00:00
+- url: https://github.com/nats-io/nsc/releases/download/v2.12.2/nsc-linux-amd64.zip
+  sha256: 8414c04db40a7ee18c3ce389604230c2f327c0093fd1c84cb237dfe94480af5f
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/nats-io/nsc/releases/download/v2.12.2/nsc-linux-arm64.zip
+  sha256: c9d0c45ddfce5107df2a53d5fd061c4e94ba1e3b703c4879f1ab4cbf1ac630bc
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/nats-io/nsc/releases/download/v2.12.2/nsc-linux-armv7.zip
+  sha256: a050066e2b50fce468377175c62d0229a382c5a107332ef393275f7071f28f4c
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/nsc/ops2deb.yml
+++ b/blueprints/devops/nsc/ops2deb.yml
@@ -8,6 +8,7 @@ matrix:
     - 2.11.0
     - 2.11.1
     - 2.12.0
+    - 2.12.2
 homepage: https://github.com/nats-io/nsc
 summary: tool for creating nkey/jwt based configurations
 description: |-

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -4,12 +4,6 @@
 - url: https://github.com/okd-project/okd/releases/download/4.15.0-0.okd-2024-03-10-010116/openshift-client-linux-4.15.0-0.okd-2024-03-10-010116.tar.gz
   sha256: 90a357d420008494e0ea898801ddf39da11cab4270b778ee01a72bda7835a3a9
   timestamp: 2024-11-25 11:13:58+00:00
-- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.17.10/openshift-client-linux-arm64.tar.gz
-  sha256: 1cdfefda501895ab24d88b574e861dbb6c8f01b5526509c53fd0c77ef2b8d862
-  timestamp: 2024-12-20 15:06:24+00:00
-- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.17.10/openshift-client-linux.tar.gz
-  sha256: d826c272dff763ffe9f3162f149cc9cb09b8a486c55e6c59cb987b0501218974
-  timestamp: 2024-12-20 15:06:24+00:00
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.17.11/openshift-client-linux-arm64.tar.gz
   sha256: da6980eb93e6520d323009a25540242e946ec92d4ee13b11ee21f13d14bf261f
   timestamp: 2025-01-03 00:27:11+00:00
@@ -304,3 +298,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.7/openshift-client-linux.tar.gz
   sha256: d50da222b02816bf7df8c910586f8d7fbedef0a34d41f18230d9efe4b330a154
   timestamp: 2026-03-21 00:11:40+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.12/openshift-client-linux-arm64.tar.gz
+  sha256: 02e15c5ef87ca1e35412d3b79861e535a5e5c02bcd16076de6b6c227022bd11a
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.12/openshift-client-linux.tar.gz
+  sha256: 9cc0f0de303bc21fb1cc8cb43e12f78aa2471e53547534c7335bc6bb25be4d6b
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 4.17.10
     - 4.17.11
     - 4.17.12
     - 4.17.14
@@ -54,6 +53,7 @@ matrix:
     - 4.21.5
     - 4.21.6
     - 4.21.7
+    - 4.21.12
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/opentofu/ops2deb.lock.yml
+++ b/blueprints/devops/opentofu/ops2deb.lock.yml
@@ -196,3 +196,9 @@
 - url: https://github.com/opentofu/opentofu/releases/download/v1.11.5/tofu_1.11.5_linux_arm64.zip
   sha256: 1b79f8fe3cbf7ac0540507bb6bd0ecab1675c78393bbf492867eaabb79840eec
   timestamp: 2026-02-12 18:16:43+00:00
+- url: https://github.com/opentofu/opentofu/releases/download/v1.11.6/tofu_1.11.6_linux_amd64.zip
+  sha256: 68026be376f8910a318645acc65f21da8b39ab86946cb0dd6cd16ef1705f34b3
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/opentofu/opentofu/releases/download/v1.11.6/tofu_1.11.6_linux_arm64.zip
+  sha256: 273f107f1f64734fcae4753796803a24b86ae0c383e433ab64bd5542ccd18772
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/opentofu/ops2deb.yml
+++ b/blueprints/devops/opentofu/ops2deb.yml
@@ -37,6 +37,7 @@ matrix:
     - 1.11.3
     - 1.11.4
     - 1.11.5
+    - 1.11.6
 homepage: https://opentofu.org
 summary: lets you declaratively manage your cloud infrastructure
 description: |-

--- a/blueprints/devops/packer/ops2deb.lock.yml
+++ b/blueprints/devops/packer/ops2deb.lock.yml
@@ -268,3 +268,12 @@
 - url: https://releases.hashicorp.com/packer/1.15.0/packer_1.15.0_linux_arm64.zip
   sha256: 1687f43bd120601f62e54b970b1cc06f83e95897357dc5c679b57ec9d2fb40a7
   timestamp: 2026-02-04 12:07:17+00:00
+- url: https://releases.hashicorp.com/packer/1.15.1/packer_1.15.1_linux_amd64.zip
+  sha256: 648d704bec73805a5508ed612185a9e5858ca7d57b730b88b1a54c3af3a91f5f
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://releases.hashicorp.com/packer/1.15.1/packer_1.15.1_linux_arm.zip
+  sha256: b2f3b0d138f78c4ced18f63e92e78944f71466b2c23ee2c082d2dacf1f76391f
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://releases.hashicorp.com/packer/1.15.1/packer_1.15.1_linux_arm64.zip
+  sha256: a8d68f1746ecacaf8fa9d364aa086249958a0a1f67c90b8a4f165ff024c0e58e
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/packer/ops2deb.yml
+++ b/blueprints/devops/packer/ops2deb.yml
@@ -53,6 +53,7 @@
       - 1.14.2
       - 1.14.3
       - 1.15.0
+      - 1.15.1
   homepage: https://www.packer.io
   summary: create multi-platform machine images from a single source configuration
   description: |-

--- a/blueprints/devops/rancher/ops2deb.lock.yml
+++ b/blueprints/devops/rancher/ops2deb.lock.yml
@@ -154,3 +154,9 @@
 - url: https://github.com/rancher/cli/releases/download/v2.13.3/rancher-linux-arm-v2.13.3.tar.gz
   sha256: 1b26e4a8bfa570413d812e36f32ac84058c8209d9caf0e19f48634571312fde5
   timestamp: 2026-02-26 00:11:21+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.14.0/rancher-linux-amd64-v2.14.0.tar.gz
+  sha256: d05e207d9830f22171e62801dc51a32417125ecb7aaf50c073bf423e7da36a94
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/rancher/cli/releases/download/v2.14.0/rancher-linux-arm-v2.14.0.tar.gz
+  sha256: 87f9484cd8be594340071a5ed60e3a6b1b8c703394bdaceae8fe430d593d1219
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/devops/rancher/ops2deb.yml
+++ b/blueprints/devops/rancher/ops2deb.yml
@@ -56,6 +56,7 @@
       - 2.13.1
       - 2.13.2
       - 2.13.3
+      - 2.14.0
   homepage: https://github.com/rancher/cli
   summary: command-line interface for rancher
   description: |-

--- a/blueprints/devops/rclone/ops2deb.lock.yml
+++ b/blueprints/devops/rclone/ops2deb.lock.yml
@@ -385,3 +385,12 @@
 - url: https://github.com/rclone/rclone/releases/download/v1.73.3/rclone-v1.73.3-linux-arm64.zip
   sha256: ed2a638b4cb15abe4f01d6d9c015f3a1cb41aa7a17c96db2725542c61f353b8e
   timestamp: 2026-03-24 00:11:54+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.73.5/rclone-v1.73.5-linux-amd64.zip
+  sha256: 932cf4b7484de74d82b4875488e0009469fd21f9904673385184520fe11a1bf0
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.73.5/rclone-v1.73.5-linux-arm.zip
+  sha256: a2e66e11bae19573f8feece3f639f5a33c14502567d403e74c8d4df294e1b843
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.73.5/rclone-v1.73.5-linux-arm64.zip
+  sha256: 8d465c921d95b2f54c5f2e79b24c97742ebc2082a0b8709a686361bed5ba7932
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/devops/rclone/ops2deb.yml
+++ b/blueprints/devops/rclone/ops2deb.yml
@@ -80,6 +80,7 @@
       - 1.73.1
       - 1.73.2
       - 1.73.3
+      - 1.73.5
   revision: "2"
   homepage: https://rclone.org/
   summary: rsync for cloud storage

--- a/blueprints/devops/resticprofile/ops2deb.lock.yml
+++ b/blueprints/devops/resticprofile/ops2deb.lock.yml
@@ -97,3 +97,12 @@
 - url: https://github.com/creativeprojects/resticprofile/releases/download/v0.32.0/resticprofile_0.32.0_linux_armv7.tar.gz
   sha256: 6c3dbea32216175353307eadaf21e712ed3ba767384ed8e862a1c2937ff73689
   timestamp: 2025-09-26 12:03:31+00:00
+- url: https://github.com/creativeprojects/resticprofile/releases/download/v0.33.1/resticprofile_0.33.1_linux_amd64.tar.gz
+  sha256: 5fecd20de21811a750a4d61e841b2258fdf018bbfffad136c96078df27b452df
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/creativeprojects/resticprofile/releases/download/v0.33.1/resticprofile_0.33.1_linux_arm64.tar.gz
+  sha256: 0d547cc0c34a83a8c1d884271a70340da90fe8750ac4a2d7de8ed7aa1d9bb9c7
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/creativeprojects/resticprofile/releases/download/v0.33.1/resticprofile_0.33.1_linux_armv7.tar.gz
+  sha256: 9b53976f2468e04866317b25af5f63020f014e149e7b3f011fde51a9ca49a8b4
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/devops/resticprofile/ops2deb.yml
+++ b/blueprints/devops/resticprofile/ops2deb.yml
@@ -16,6 +16,7 @@ matrix:
     - 0.30.1
     - 0.31.0
     - 0.32.0
+    - 0.33.1
 homepage: https://creativeprojects.github.io/resticprofile/
 summary: configuration profiles manager for restic backup
 description: |-

--- a/blueprints/devops/rpk/ops2deb.lock.yml
+++ b/blueprints/devops/rpk/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/redpanda-data/redpanda/releases/download/v24.1.13/rpk-linux-amd64.zip
-  sha256: a228c59e9bf3fcc51bc481c9576bba8269367944583110a4a5390a243233d52d
-  timestamp: 2024-07-27 00:22:57+00:00
-- url: https://github.com/redpanda-data/redpanda/releases/download/v24.1.13/rpk-linux-arm64.zip
-  sha256: 5e91a7e76ee1ca8cbc327aa59a84a906ce1be0faa44124edc4daed1ea22b4fc6
-  timestamp: 2024-07-27 00:22:57+00:00
 - url: https://github.com/redpanda-data/redpanda/releases/download/v24.2.1/rpk-linux-amd64.zip
   sha256: be211696e9e62d50ba74f61c6176624473389bfb1a37ef6ec9ad47264ddde845
   timestamp: 2024-07-31 21:05:56+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/redpanda-data/redpanda/releases/download/v25.3.10/rpk-linux-arm64.zip
   sha256: 5b8a1f28ae781803d414fbc20542096bdce44a4afbc58a3fef723505067b1f96
   timestamp: 2026-03-06 00:17:08+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v26.1.6/rpk-linux-amd64.zip
+  sha256: bd018d75c6ba99f40d54086279b719d7c6101c734a01bdd14815e8c8c7b7dd8c
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v26.1.6/rpk-linux-arm64.zip
+  sha256: 325a62c10e104f9b26190f3a87346a799eb79d4d1c33ec54b0b95210fbb564f3
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/devops/rpk/ops2deb.yml
+++ b/blueprints/devops/rpk/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 24.1.13
     - 24.2.1
     - 24.2.2
     - 24.2.3
@@ -54,6 +53,7 @@ matrix:
     - 25.3.8
     - 25.3.9
     - 25.3.10
+    - 26.1.6
 homepage: https://redpanda.com/
 summary: interact with your Redpanda clusters
 description: |-

--- a/blueprints/devops/rustic/ops2deb.lock.yml
+++ b/blueprints/devops/rustic/ops2deb.lock.yml
@@ -25,3 +25,12 @@
 - url: https://github.com/rustic-rs/rustic/releases/download/v0.11.1/rustic-v0.11.1-x86_64-unknown-linux-gnu.tar.gz
   sha256: 9d7227ce72eb171eabcbb09938fec15df93bea95d058f93531cf372449bc8c93
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/rustic-rs/rustic/releases/download/v0.11.2/rustic-v0.11.2-aarch64-unknown-linux-gnu.tar.gz
+  sha256: 7aba94732fefd4597f28bb4c5d5373117e9de25a1992e853113e805f98d54998
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/rustic-rs/rustic/releases/download/v0.11.2/rustic-v0.11.2-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: ed8803f0a290eb6a5b290e12ffa614c8be710ef28db3e6fb24e661c636762ff3
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/rustic-rs/rustic/releases/download/v0.11.2/rustic-v0.11.2-x86_64-unknown-linux-gnu.tar.gz
+  sha256: fb7b74a14418b2dd070360c9abb22607f8559bdd344a0adf1b33bc2e31f83f5f
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/rustic/ops2deb.yml
+++ b/blueprints/devops/rustic/ops2deb.yml
@@ -8,6 +8,7 @@ matrix:
     - 0.10.3
     - 0.11.0
     - 0.11.1
+    - 0.11.2
 homepage: https://github.com/rustic-rs/rustic
 summary: fast, encrypted, and deduplicated backup tool
 description: |-

--- a/blueprints/devops/scw/ops2deb.lock.yml
+++ b/blueprints/devops/scw/ops2deb.lock.yml
@@ -4,12 +4,6 @@
 - url: https://github.com/scaleway/scaleway-cli/releases/download/v2.4.0/scw-2.4.0-linux-x86_64
   sha256: 5e5f28412fa57f445f13c8b88ab488a948bba7c68b5da853c645f3716d5307d1
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/scaleway/scaleway-cli/releases/download/v2.6.1/scaleway-cli_2.6.1_linux_amd64
-  sha256: 5ef8b494e93420672f6ec875d342839dfe1050a415ae665640b5976c835c2b36
-  timestamp: 2022-10-20 23:26:18+00:00
-- url: https://github.com/scaleway/scaleway-cli/releases/download/v2.6.1/scaleway-cli_2.6.1_linux_arm64
-  sha256: df7548d960a7c0eaa4947906cabede124362be868569ea44c691727ea71df4ba
-  timestamp: 2022-10-20 23:26:18+00:00
 - url: https://github.com/scaleway/scaleway-cli/releases/download/v2.6.2/scaleway-cli_2.6.2_linux_amd64
   sha256: 22fbfd6cc6881d31b594ef67eec07dbc2b9f194ad4f6a25adfadf3f5a4bfc97f
   timestamp: 2022-11-07 16:24:33+00:00
@@ -304,3 +298,9 @@
 - url: https://github.com/scaleway/scaleway-cli/releases/download/v2.53.0/scaleway-cli_2.53.0_linux_arm64
   sha256: a08264489cc3fafbdbb5fc45d861c38d84e5802ede26a3bf9595bec9f566306f
   timestamp: 2026-03-11 18:14:43+00:00
+- url: https://github.com/scaleway/scaleway-cli/releases/download/v2.55.0/scaleway-cli_2.55.0_linux_amd64
+  sha256: 01f6be578bdcc8fd6e4a3656694cda87e0bd9859cf05460ed2e1afc0723d69e9
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/scaleway/scaleway-cli/releases/download/v2.55.0/scaleway-cli_2.55.0_linux_arm64
+  sha256: b4aa69faeeae2d21e6c182f3a254e6181be8b77b2ec54ad422e9ac0195e7e6e4
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/scw/ops2deb.yml
+++ b/blueprints/devops/scw/ops2deb.yml
@@ -27,7 +27,6 @@
       - amd64
       - arm64
     versions:
-      - 2.6.1
       - 2.6.2
       - 2.7.0
       - 2.8.0
@@ -77,6 +76,7 @@
       - 2.51.0
       - 2.52.0
       - 2.53.0
+      - 2.55.0
   homepage: https://github.com/scaleway/scaleway-cli
   summary: command-line interface for Scaleway
   description: |-

--- a/blueprints/devops/skaffold/ops2deb.lock.yml
+++ b/blueprints/devops/skaffold/ops2deb.lock.yml
@@ -298,3 +298,9 @@
 - url: https://github.com/GoogleContainerTools/skaffold/releases/download/v2.18.1/skaffold-linux-arm64
   sha256: c01dbdf4fc9a342295bf07438b2ec74c32901646f2a03dc6fb0f751063af66c2
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/GoogleContainerTools/skaffold/releases/download/v2.19.0/skaffold-linux-amd64
+  sha256: 8794026e7f0c2fb04c44ebc6a8f4f446a7a68dde8f8868ac5b701903b7973e19
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/GoogleContainerTools/skaffold/releases/download/v2.19.0/skaffold-linux-arm64
+  sha256: 206b35b063aa327966048c1637e5380c11db38cf30019e01cc93f2aa8097c049
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/devops/skaffold/ops2deb.yml
+++ b/blueprints/devops/skaffold/ops2deb.yml
@@ -91,6 +91,7 @@
       - 2.17.2
       - 2.17.3
       - 2.18.1
+      - 2.19.0
   homepage: https://skaffold.dev/
   summary: easy and repeatable Kubernetes development
   description: |-

--- a/blueprints/devops/terraform-docs/ops2deb.lock.yml
+++ b/blueprints/devops/terraform-docs/ops2deb.lock.yml
@@ -37,3 +37,9 @@
 - url: https://github.com/terraform-docs/terraform-docs/releases/download/v0.21.0/terraform-docs-v0.21.0-linux-arm64.tar.gz
   sha256: 35b2e6846268841484e6eea7d00d7dfe2c94b4725e52cfe19aa6c26a86c32edc
   timestamp: 2025-12-12 18:03:18+00:00
+- url: https://github.com/terraform-docs/terraform-docs/releases/download/v0.22.0/terraform-docs-v0.22.0-linux-arm.tar.gz
+  sha256: 2a58762c7e64ff8cd347fcacff09396505509ac256899aaf2dad3287de471d78
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/terraform-docs/terraform-docs/releases/download/v0.22.0/terraform-docs-v0.22.0-linux-arm64.tar.gz
+  sha256: 4feccd471e0595546271bde7aabd275a5c1a5b055d6cd89c2678b38ced1376f6
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/terraform-docs/ops2deb.yml
+++ b/blueprints/devops/terraform-docs/ops2deb.yml
@@ -21,6 +21,7 @@
       - 0.19.0
       - 0.20.0
       - 0.21.0
+      - 0.22.0
   homepage: https://terraform-docs.io
   summary: generate documentation from Terraform modules in various output formats
   description: |-

--- a/blueprints/devops/terraform/ops2deb.lock.yml
+++ b/blueprints/devops/terraform/ops2deb.lock.yml
@@ -28,15 +28,6 @@
 - url: https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_arm64.zip
   sha256: 2f72982008c52d2d57294ea50794d7c6ae45d2948e08598bfec3e492bce8d96e
   timestamp: 2022-03-02 22:16:55+00:00
-- url: https://releases.hashicorp.com/terraform/1.6.3/terraform_1.6.3_linux_amd64.zip
-  sha256: caa432f110db519bf9b7c84df23ead398e59b6cc3da2938f010200f1ee8f2ae4
-  timestamp: 2023-11-01 18:21:50+00:00
-- url: https://releases.hashicorp.com/terraform/1.6.3/terraform_1.6.3_linux_arm.zip
-  sha256: e180ff62badecbf4e0a4f71d628812d73981bab650533b0c2facb2bc10d9ccac
-  timestamp: 2023-11-01 18:21:50+00:00
-- url: https://releases.hashicorp.com/terraform/1.6.3/terraform_1.6.3_linux_arm64.zip
-  sha256: 01d8dc9bda3d4de585d5901c5099d9155faeb0730fbd9dc6c6e13735cba76700
-  timestamp: 2023-11-01 18:21:50+00:00
 - url: https://releases.hashicorp.com/terraform/1.6.4/terraform_1.6.4_linux_amd64.zip
   sha256: 569fc3d526dcf57eb5af4764843b87b36a7cb590fc50f94a07757c1189256775
   timestamp: 2023-11-15 18:20:25+00:00
@@ -478,3 +469,12 @@
 - url: https://releases.hashicorp.com/terraform/1.14.7/terraform_1.14.7_linux_arm64.zip
   sha256: 04f88ee8924db27c0e26c379721965273c80c9b6a94bc5d8d8048a69163952ba
   timestamp: 2026-03-11 18:14:43+00:00
+- url: https://releases.hashicorp.com/terraform/1.14.9/terraform_1.14.9_linux_amd64.zip
+  sha256: 2e5cffc20a0b48a67a76268723bd5a10b8666f69b2aa4f04906e206726bedd63
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://releases.hashicorp.com/terraform/1.14.9/terraform_1.14.9_linux_arm.zip
+  sha256: 0086d4f9b58a83e37b2e6754f7a90139c643991e5674ed766b2be0e497c2a0f8
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://releases.hashicorp.com/terraform/1.14.9/terraform_1.14.9_linux_arm64.zip
+  sha256: 863002085b886453795d9ff4b8989b8468784478150b70ba8a1df3e3ad66da99
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/terraform/ops2deb.yml
+++ b/blueprints/devops/terraform/ops2deb.yml
@@ -40,7 +40,6 @@
       - arm64
       - armhf
     versions:
-      - 1.6.3
       - 1.6.4
       - 1.6.5
       - 1.6.6
@@ -90,6 +89,7 @@
       - 1.14.5
       - 1.14.6
       - 1.14.7
+      - 1.14.9
   homepage: https://www.terraform.io
   summary: tool for building, changing, and versioning infrastructure safely
   description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.87.1/terragrunt_linux_amd64
-  sha256: 7b22b88407068619304fed0af9f1a8ee929771cedf6387f10ac72ffe8b99e36c
-  timestamp: 2025-09-11 00:07:57+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.87.1/terragrunt_linux_arm64
-  sha256: 0c819346bd6b19bac2c9f6ad41129cdd7c3318b9be4ad2e674a739fc16901cf5
-  timestamp: 2025-09-11 00:07:57+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.87.2/terragrunt_linux_amd64
   sha256: 95f38eac5b879315e63b020c945c0318d85d83dc07f2c3751f97b224c6f463e6
   timestamp: 2025-09-13 00:07:32+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.99.4/terragrunt_linux_arm64
   sha256: 96d17d9b0acd8db97ca65c381b1922376e875aee7ea56534692a25b239b62bea
   timestamp: 2026-02-20 00:10:52+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.0.2/terragrunt_linux_amd64
+  sha256: 4a0e327ec20c7af2c680142c5143ece3236fc3fd6c9de772bd0444a9b95abec2
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.0.2/terragrunt_linux_arm64
+  sha256: 4511f2c9a8f06dbefc17a1cdc29ea00dc467d0f608e473242c2a3c75d387df72
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.87.1
       - 0.87.2
       - 0.87.3
       - 0.87.4
@@ -75,6 +74,7 @@
       - 0.99.2
       - 0.99.3
       - 0.99.4
+      - 1.0.2
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/devops/tflint/ops2deb.lock.yml
+++ b/blueprints/devops/tflint/ops2deb.lock.yml
@@ -214,3 +214,9 @@
 - url: https://github.com/terraform-linters/tflint/releases/download/v0.61.0/tflint_linux_arm64.zip
   sha256: 999c25cfdb5208fe1133dec6b219e666a39fc2a7a0786a781dc9924ea5945ebf
   timestamp: 2026-02-07 12:04:28+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_linux_amd64.zip
+  sha256: 000400d7f4c2236d9ed4b35fec3ee95617c3747571593cc6138169fc78cc226a
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_linux_arm64.zip
+  sha256: 064206ec85adaf90f637c880eb3cd5a8e07ddce09e4da7c813eb362cb794f95f
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/tflint/ops2deb.yml
+++ b/blueprints/devops/tflint/ops2deb.yml
@@ -40,6 +40,7 @@ matrix:
     - 0.59.1
     - 0.60.0
     - 0.61.0
+    - 0.62.0
 homepage: https://github.com/terraform-linters/tflint
 summary: pluggable Terraform linter
 description: |-

--- a/blueprints/devops/undock/ops2deb.lock.yml
+++ b/blueprints/devops/undock/ops2deb.lock.yml
@@ -13,3 +13,6 @@
 - url: https://github.com/crazy-max/undock/releases/download/v0.11.0/undock_0.11.0_linux_amd64.tar.gz
   sha256: 288cb0ab9fa1237ba8389e3116645fb83963998fffc260df736d114be7e9068f
   timestamp: 2025-12-30 18:03:11+00:00
+- url: https://github.com/crazy-max/undock/releases/download/v0.12.0/undock_0.12.0_linux_amd64.tar.gz
+  sha256: 6e1e20f2599d28ab59edb67a2ad5211277bf33e3a32cbaa9a2d5fe288f0f0fb2
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/undock/ops2deb.yml
+++ b/blueprints/devops/undock/ops2deb.yml
@@ -8,6 +8,7 @@ matrix:
     - 0.9.0
     - 0.10.0
     - 0.11.0
+    - 0.12.0
 homepage: https://crazymax.dev/undock/
 summary: extracting files from container images
 description: |-

--- a/blueprints/devops/zli/ops2deb.lock.yml
+++ b/blueprints/devops/zli/ops2deb.lock.yml
@@ -94,3 +94,9 @@
 - url: https://github.com/project-zot/zot/releases/download/v2.1.15/zli-linux-arm64
   sha256: d223ec5cf4dc819bd9b836ad32bf03dd2063276a2c28567766bdaa2d1ab89e70
   timestamp: 2026-03-09 00:11:22+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.16/zli-linux-amd64
+  sha256: fe31caf80ebc49438685543602b13b06679310424c8086e3d2c070de7ad567e4
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.16/zli-linux-arm64
+  sha256: cdc9fd9114eb8b032a72beff13ea7557d9516c95ad9b236c6f846434df3419b9
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/zli/ops2deb.yml
+++ b/blueprints/devops/zli/ops2deb.yml
@@ -20,6 +20,7 @@ matrix:
     - 2.1.13
     - 2.1.14
     - 2.1.15
+    - 2.1.16
 homepage: https://zotregistry.dev
 summary: tool for OCI-native container image registry, simplified
 description: |-

--- a/blueprints/devops/zot/ops2deb.lock.yml
+++ b/blueprints/devops/zot/ops2deb.lock.yml
@@ -94,3 +94,9 @@
 - url: https://github.com/project-zot/zot/releases/download/v2.1.15/zot-linux-arm64
   sha256: e18e713c14f4c431f768f9f32b1c63310ce574b9924bc2b3546562d4a513edb1
   timestamp: 2026-03-09 00:11:22+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.16/zot-linux-amd64
+  sha256: f9b7e805056db94c97d34bcff4eab77ec8e7cdc2cb76fd6db3d7ad7143605dba
+  timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/project-zot/zot/releases/download/v2.1.16/zot-linux-arm64
+  sha256: 43ccc539feb4be3f86bdca1c16b3d2df3bba7cea475930c4293339851d55b089
+  timestamp: 2026-04-24 06:37:37+00:00

--- a/blueprints/devops/zot/ops2deb.yml
+++ b/blueprints/devops/zot/ops2deb.yml
@@ -19,6 +19,7 @@ matrix:
     - 2.1.13
     - 2.1.14
     - 2.1.15
+    - 2.1.16
 homepage: https://zotregistry.dev
 summary: OCI-native container image registry, simplified
 description: |-

--- a/blueprints/secops/bitwarden-cli/ops2deb.lock.yml
+++ b/blueprints/secops/bitwarden-cli/ops2deb.lock.yml
@@ -43,3 +43,6 @@
 - url: https://github.com/bitwarden/clients/releases/download/cli-v2026.2.0/bw-linux-2026.2.0.zip
   sha256: 8d73e2a471993db8b2e6e4f69293a71e28e9b4c2cb4b696665f5f396126e1850
   timestamp: 2026-03-05 18:33:39+00:00
+- url: https://github.com/bitwarden/clients/releases/download/cli-v2026.4.1/bw-linux-2026.4.1.zip
+  sha256: 2172dc63f821fcbd4b4ce65e7106f1ebab26b6cb16c9c8a5b28230dcc6f8a774
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/secops/bitwarden-cli/ops2deb.yml
+++ b/blueprints/secops/bitwarden-cli/ops2deb.yml
@@ -16,6 +16,7 @@ matrix:
     - 2025.12.1
     - 2026.1.0
     - 2026.2.0
+    - 2026.4.1
 homepage: https://bitwarden.com/help/cli/
 summary: CLI to access and manage a bitwarden vault
 description: |-

--- a/blueprints/secops/boundary/ops2deb.lock.yml
+++ b/blueprints/secops/boundary/ops2deb.lock.yml
@@ -412,3 +412,12 @@
 - url: https://releases.hashicorp.com/boundary/0.21.1/boundary_0.21.1_linux_arm64.zip
   sha256: 623c773b71a086ca728d20a19e4ce5386c5a0b1d1ef95af97da49a7965c47696
   timestamp: 2026-02-13 18:11:18+00:00
+- url: https://releases.hashicorp.com/boundary/0.21.2/boundary_0.21.2_linux_amd64.zip
+  sha256: a52aaa65de6de280ae3bbcb24a567766236b3b5e5736aa6556dd77c594e8b18d
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://releases.hashicorp.com/boundary/0.21.2/boundary_0.21.2_linux_arm.zip
+  sha256: 5dd1105d7769bfa9051f9968147bd10fe4b347529d5a2d78d4cbb7809ddfc377
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://releases.hashicorp.com/boundary/0.21.2/boundary_0.21.2_linux_arm64.zip
+  sha256: b20983aed20b09e3031ed7912cd478020b34863f24f1bd7ec2ae7b96470c2968
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/secops/boundary/ops2deb.yml
+++ b/blueprints/secops/boundary/ops2deb.yml
@@ -90,6 +90,7 @@
       - 0.20.1
       - 0.21.0
       - 0.21.1
+      - 0.21.2
   homepage: https://www.boundaryproject.io
   summary: provide simple and secure access to hosts and services
   description: |-

--- a/blueprints/secops/cosign/ops2deb.lock.yml
+++ b/blueprints/secops/cosign/ops2deb.lock.yml
@@ -82,3 +82,9 @@
 - url: https://github.com/sigstore/cosign/releases/download/v3.0.5/cosign-linux-arm64
   sha256: d098f3168ae4b3aa70b4ca78947329b953272b487727d1722cb3cb098a1a20ab
   timestamp: 2026-02-20 00:10:52+00:00
+- url: https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-amd64
+  sha256: c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-arm64
+  sha256: bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/secops/cosign/ops2deb.yml
+++ b/blueprints/secops/cosign/ops2deb.yml
@@ -18,6 +18,7 @@ matrix:
     - 3.0.3
     - 3.0.4
     - 3.0.5
+    - 3.0.6
 homepage: https://www.sigstore.dev
 summary: code signing and transparency for containers and binaries
 description: |-

--- a/blueprints/secops/trivy/ops2deb.lock.yml
+++ b/blueprints/secops/trivy/ops2deb.lock.yml
@@ -412,12 +412,6 @@
 - url: https://github.com/aquasecurity/trivy/releases/download/v0.42.1/trivy_0.42.1_Linux-ARM64.tar.gz
   sha256: cad74fc7c0a6a96ad0721987acda2e529b0b77db754c67e65bec8667b50d9ca5
   timestamp: 2023-06-08 15:17:30+00:00
-- url: https://github.com/aquasecurity/trivy/releases/download/v0.48.2/trivy_0.48.2_Linux-64bit.tar.gz
-  sha256: 2820ce6c8314ac39d3d9f470322506d029fe5cb5cbce12a826968f9bcc68c783
-  timestamp: 2024-01-05 09:17:01+00:00
-- url: https://github.com/aquasecurity/trivy/releases/download/v0.48.2/trivy_0.48.2_Linux-ARM64.tar.gz
-  sha256: 3a04f78d66d0920a28af17673dd9d993decfc6186a64c3d4385ef40dcc58c360
-  timestamp: 2024-01-05 09:17:01+00:00
 - url: https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_Linux-64bit.tar.gz
   sha256: 61f6d5c0fb6ed451c8bab8b13acb5d701f1b532bd6b629f3163f8f57bb10e564
   timestamp: 2024-01-11 12:33:27+00:00
@@ -712,3 +706,9 @@
 - url: https://github.com/aquasecurity/trivy/releases/download/v0.69.3/trivy_0.69.3_Linux-ARM64.tar.gz
   sha256: 7e3924a974e912e57b4a99f65ece7931f8079584dae12eb7845024f97087bdfd
   timestamp: 2026-03-03 18:12:24+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_Linux-64bit.tar.gz
+  sha256: 8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_Linux-ARM64.tar.gz
+  sha256: 2f6bb988b553a1bbac6bdd1ce890f5e412439564e17522b88a4541b4f364fc8d
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/secops/trivy/ops2deb.yml
+++ b/blueprints/secops/trivy/ops2deb.yml
@@ -70,7 +70,6 @@
       - amd64
       - arm64
     versions:
-      - 0.48.2
       - 0.48.3
       - 0.49.0
       - 0.49.1
@@ -120,6 +119,7 @@
       - 0.69.1
       - 0.69.2
       - 0.69.3
+      - 0.70.0
   homepage: https://www.aquasec.com/products/trivy/
   summary: vulnerability and misconfiguration scanner
   description: |-

--- a/blueprints/terminal/dasel/ops2deb.lock.yml
+++ b/blueprints/terminal/dasel/ops2deb.lock.yml
@@ -142,3 +142,12 @@
 - url: https://github.com/TomWright/dasel/releases/download/v3.4.0/dasel_linux_arm64
   sha256: 248d12881184f8aa21360511773c231b934deccae5a0b2318e346b56166eec67
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/TomWright/dasel/releases/download/v3.4.1/dasel_linux_amd64
+  sha256: 3c947a8dcd88856a32c172081db091c38059394fb57a15fa43871f6d046427e1
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/TomWright/dasel/releases/download/v3.4.1/dasel_linux_arm32
+  sha256: 20c29248df118154fba247ab624876e37a4f1da5751e195f36bc49f5e903c249
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/TomWright/dasel/releases/download/v3.4.1/dasel_linux_arm64
+  sha256: a128c5554c53e6e4af880700adba1d212ce651db208da1592fb1cae0e959cbc6
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/terminal/dasel/ops2deb.yml
+++ b/blueprints/terminal/dasel/ops2deb.yml
@@ -21,6 +21,7 @@ matrix:
     - 3.3.0
     - 3.3.1
     - 3.4.0
+    - 3.4.1
 homepage: https://daseldocs.tomwright.me
 summary: allows to query and modify data structures using selector strings
 description: |-

--- a/blueprints/terminal/fzf/ops2deb.lock.yml
+++ b/blueprints/terminal/fzf/ops2deb.lock.yml
@@ -112,3 +112,9 @@
 - url: https://github.com/junegunn/fzf/releases/download/v0.70.0/fzf-0.70.0-linux_arm64.tar.gz
   sha256: 90a07a13b61f56dd59ccfd0f0bf05070e9cec067713d313fa2607aab2dc0e422
   timestamp: 2026-03-02 12:07:27+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.71.0/fzf-0.71.0-linux_amd64.tar.gz
+  sha256: 22639bb38489dbca8acef57850cbb50231ab714d0e8e855ac52fae8b41233df4
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.71.0/fzf-0.71.0-linux_arm64.tar.gz
+  sha256: 98b7d322efae9c37e4bfbbab1cbcd8722eb742d9399511f96375feb40cc35d1d
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/terminal/fzf/ops2deb.yml
+++ b/blueprints/terminal/fzf/ops2deb.yml
@@ -23,6 +23,7 @@ matrix:
     - 0.67.0
     - 0.68.0
     - 0.70.0
+    - 0.71.0
 homepage: https://junegunn.github.io/fzf/
 summary: A command-line fuzzy finder in Go
 description: |-

--- a/blueprints/terminal/ghorg/ops2deb.lock.yml
+++ b/blueprints/terminal/ghorg/ops2deb.lock.yml
@@ -214,3 +214,9 @@
 - url: https://github.com/gabrie30/ghorg/releases/download/v1.11.9/ghorg_1.11.9_Linux_x86_64.tar.gz
   sha256: 730f161e886cb074d140d174d1031210b444c5bb902866873c988cb0978eb59d
   timestamp: 2026-02-08 00:16:01+00:00
+- url: https://github.com/gabrie30/ghorg/releases/download/v1.11.10/ghorg_1.11.10_Linux_arm64.tar.gz
+  sha256: ad807fa207a85a1ba373a25509d0c33a7ce6ac7bc4adb8d094f19df142a40f0f
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/gabrie30/ghorg/releases/download/v1.11.10/ghorg_1.11.10_Linux_x86_64.tar.gz
+  sha256: 28ccf93b5a320ec31589e1b84d3e58fc5661fbbeb1b6e892ca59346790c96850
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/terminal/ghorg/ops2deb.yml
+++ b/blueprints/terminal/ghorg/ops2deb.yml
@@ -40,6 +40,7 @@ matrix:
     - 1.11.7
     - 1.11.8
     - 1.11.9
+    - 1.11.10
 homepage: https://github.com/gabrie30/ghorg
 summary: quickly clone an entire org/users repositories into one directory
 description: |-

--- a/blueprints/terminal/git-delta/ops2deb.lock.yml
+++ b/blueprints/terminal/git-delta/ops2deb.lock.yml
@@ -97,3 +97,12 @@
 - url: https://github.com/dandavison/delta/releases/download/0.19.1/delta-0.19.1-x86_64-unknown-linux-gnu.tar.gz
   sha256: b21fd5c32da694085f1bc1ab2daa81c01c48efaf5ce3137ba23102b824304c71
   timestamp: 2026-03-22 18:05:02+00:00
+- url: https://github.com/dandavison/delta/releases/download/0.19.2/delta-0.19.2-aarch64-unknown-linux-gnu.tar.gz
+  sha256: 0bfce159a5cddd5feb3d6db4a616d883ff51253ce08ac7ec11cb1d208cfaab9e
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/dandavison/delta/releases/download/0.19.2/delta-0.19.2-arm-unknown-linux-gnueabihf.tar.gz
+  sha256: 4ef68854d15bf92f0ff0e132bb8cfc738b9c0693d359c6bea7fb90e0d3a8afa6
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/dandavison/delta/releases/download/0.19.2/delta-0.19.2-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 8e695c5f586a8c53d6c3b01be0b4a422ed218bfed2a56191caebe373a1c18ab2
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/terminal/git-delta/ops2deb.yml
+++ b/blueprints/terminal/git-delta/ops2deb.yml
@@ -39,6 +39,7 @@
       - 0.18.1
       - 0.18.2
       - 0.19.1
+      - 0.19.2
   homepage: https://dandavison.github.io/delta/
   summary: syntax-highlighting pager for git, diff, and grep output
   description: |-

--- a/blueprints/terminal/glow/ops2deb.lock.yml
+++ b/blueprints/terminal/glow/ops2deb.lock.yml
@@ -16,3 +16,9 @@
 - url: https://github.com/charmbracelet/glow/releases/download/v2.1.1/glow_2.1.1_Linux_x86_64.tar.gz
   sha256: 59106b08be69b2a0bda1178327bbb7accd584e7c113ba3d2f5ef6e48ff3ac27f
   timestamp: 2025-05-30 15:07:11+00:00
+- url: https://github.com/charmbracelet/glow/releases/download/v2.1.2/glow_2.1.2_Linux_arm64.tar.gz
+  sha256: cf63abebcb50b72909db965d78290e7cecbf17a900e84705dc84addbb6952099
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/charmbracelet/glow/releases/download/v2.1.2/glow_2.1.2_Linux_x86_64.tar.gz
+  sha256: 6063d4f2af8a82a5f4bba0831e165de9381660aa8b41df4816d0106a265b07d5
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/terminal/glow/ops2deb.yml
+++ b/blueprints/terminal/glow/ops2deb.yml
@@ -7,6 +7,7 @@ matrix:
     - 2.0.0
     - 2.1.0
     - 2.1.1
+    - 2.1.2
 homepage: https://github.com/charmbracelet/glow
 summary: render markdown on the CLI
 description: |-

--- a/blueprints/terminal/neovim/ops2deb.lock.yml
+++ b/blueprints/terminal/neovim/ops2deb.lock.yml
@@ -22,3 +22,6 @@
 - url: https://github.com/neovim/neovim/releases/download/v0.11.6/nvim-linux-x86_64.tar.gz
   sha256: 2fc90b962327f73a78afbfb8203fd19db8db9cdf4ee5e2bef84704339add89cc
   timestamp: 2026-01-26 18:04:36+00:00
+- url: https://github.com/neovim/neovim/releases/download/v0.12.2/nvim-linux-x86_64.tar.gz
+  sha256: 31cf85945cb600d96cdf69f88bc68bec814acbff50863c5546adef3a1bcef260
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/terminal/neovim/ops2deb.yml
+++ b/blueprints/terminal/neovim/ops2deb.yml
@@ -11,6 +11,7 @@ matrix:
     - 0.11.4
     - 0.11.5
     - 0.11.6
+    - 0.12.2
 homepage: https://github.com/neovim/neovim
 summary: heavily refactored vim fork
 description: |-

--- a/blueprints/terminal/nushell/ops2deb.lock.yml
+++ b/blueprints/terminal/nushell/ops2deb.lock.yml
@@ -34,12 +34,6 @@
 - url: https://github.com/nushell/nushell/releases/download/0.70.0/nu-0.70.0-x86_64-unknown-linux-gnu.tar.gz
   sha256: 97c4ec8f7167fe13411556e38533cdb72e76fd5858ee49d7772728e9f6b8dcc7
   timestamp: 2022-10-19 04:33:25+00:00
-- url: https://github.com/nushell/nushell/releases/download/0.75.0/nu-0.75.0-aarch64-unknown-linux-gnu.tar.gz
-  sha256: 5d952fe49ed3641375201161e04fc0015737aa5c93755ab8ae903811a7ce0247
-  timestamp: 2023-02-01 04:27:41+00:00
-- url: https://github.com/nushell/nushell/releases/download/0.75.0/nu-0.75.0-x86_64-unknown-linux-gnu.tar.gz
-  sha256: 8344ff30be0527a18df957e52c48d9a07dffdc8fd1c810a0bafc1f67a151df4d
-  timestamp: 2023-02-01 04:27:41+00:00
 - url: https://github.com/nushell/nushell/releases/download/0.76.0/nu-0.76.0-aarch64-unknown-linux-gnu.tar.gz
   sha256: d27c5b550982cd083d633f703a31f5292d3892cc65361efc2ef085ed0fd34d1a
   timestamp: 2023-02-22 02:40:49+00:00
@@ -334,3 +328,9 @@
 - url: https://github.com/nushell/nushell/releases/download/0.111.0/nu-0.111.0-x86_64-unknown-linux-gnu.tar.gz
   sha256: aa5376efaa5f2da98ebae884b901af6504dc8291acf5f4147ac994e9d03cd1ba
   timestamp: 2026-03-01 06:12:20+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.112.2/nu-0.112.2-aarch64-unknown-linux-gnu.tar.gz
+  sha256: c25a713f4c10bd886162c62c278db6cf8a657754be53d33379af70fbadab07b8
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.112.2/nu-0.112.2-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 4038c171dd2618f2413a2aa615b8dab7e9d04852be8200f1755df3e422328395
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/terminal/nushell/ops2deb.yml
+++ b/blueprints/terminal/nushell/ops2deb.yml
@@ -72,7 +72,6 @@
       - amd64
       - arm64
     versions:
-      - 0.75.0
       - 0.76.0
       - 0.77.0
       - 0.77.1
@@ -122,6 +121,7 @@
       - 0.109.1
       - 0.110.0
       - 0.111.0
+      - 0.112.2
   homepage: https://www.nushell.sh/
   summary: new type of shell written in rust
   description: |-

--- a/blueprints/terminal/yq/ops2deb.lock.yml
+++ b/blueprints/terminal/yq/ops2deb.lock.yml
@@ -475,3 +475,12 @@
 - url: https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_arm64
   sha256: 4c2cc022a129be5cc1187959bb4b09bebc7fb543c5837b93001c68f97ce39a5d
   timestamp: 2026-02-14 12:04:31+00:00
+- url: https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
+  sha256: d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_arm
+  sha256: 0d1dd54d8ab6240b404c8a438c52751c91df6c5d82593701d625dc97e421e19e
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_arm64
+  sha256: 03061b2a50c7a498de2bbb92d7cb078ce433011f085a4994117c2726be4106ea
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/terminal/yq/ops2deb.yml
+++ b/blueprints/terminal/yq/ops2deb.yml
@@ -76,6 +76,7 @@
       - 4.52.1
       - 4.52.2
       - 4.52.4
+      - 4.53.2
   revision: "2"
   homepage: https://github.com/mikefarah/yq
   summary: portable command-line YAML processor

--- a/blueprints/terminal/zellij/ops2deb.lock.yml
+++ b/blueprints/terminal/zellij/ops2deb.lock.yml
@@ -142,3 +142,9 @@
 - url: https://github.com/zellij-org/zellij/releases/download/v0.44.0/zellij-x86_64-unknown-linux-musl.tar.gz
   sha256: 7e981d50c98ec13ad6cc882e8ca4da32544dd6b69fd0d1b2b753eb597847adb3
   timestamp: 2026-03-23 12:12:14+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.44.1/zellij-aarch64-unknown-linux-musl.tar.gz
+  sha256: 6f028bb569d29be968c961249c5f80d5336ad4ad4b3cd79af8e32afab57b0948
+  timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.44.1/zellij-x86_64-unknown-linux-musl.tar.gz
+  sha256: 669825021d529fca5d939888263c9d2a90762145191fa07581a15250e8af2b49
+  timestamp: 2026-04-24 06:37:36+00:00

--- a/blueprints/terminal/zellij/ops2deb.yml
+++ b/blueprints/terminal/zellij/ops2deb.yml
@@ -28,6 +28,7 @@ matrix:
     - 0.43.0
     - 0.43.1
     - 0.44.0
+    - 0.44.1
 homepage: https://zellij.dev
 summary: terminal workspace with batteries included
 description: |-


### PR DESCRIPTION
Add trivy v0.70.0
Remove trivy v0.48.2
Add boundary v0.21.2
Add cosign v3.0.6
Add bitwarden-cli v2026.4.1
Add mattermost-desktop v6.1.2
Add teams-for-linux v2.8.0
Remove teams-for-linux v1.10.1
Add signal-desktop v8.7.0
Add zellij v0.44.1
Add ghorg v1.11.10
Add fzf v0.71.0
Add glow v2.1.2
Add neovim v0.12.2
Add git-delta v0.19.2
Add yq v4.53.2
Add nushell v0.112.2
Remove nushell v0.75.0
Add dasel v3.4.1
Add devspace v6.3.21
Add skaffold v2.19.0
Add kubelogin v0.2.17
Add rclone v1.73.5
Add rpk v26.1.6
Remove rpk v24.1.13
Add jfrog-cli v2.102.0
Remove jfrog-cli v2.71.3
Add rancher v2.14.0
Add resticprofile v0.33.1
Add docker-compose v5.1.3
Remove docker-compose v2.27.1
Add hubble v1.19.3
Add natscli v0.3.2
Add terraform v1.14.9
Remove terraform v1.6.3
Add terraform-docs v0.22.0
Add aws-iam-authenticator v0.7.13
Add kubectx v0.11.0
Add helm v4.1.4
Remove helm v3.10.3
Add nsc v2.12.2
Add goreleaser v2.15.4
Add zli v2.1.16
Add kubectl-oidc-login v1.36.1
Add lazydocker v0.25.2
Add helmfile v1.4.4
Remove helmfile v0.145.0
Add scw v2.55.0
Remove scw v2.6.1
Add infracost v0.10.44
Add terragrunt v1.0.2
Remove terragrunt v0.87.1
Add dapr v1.17.1
Add tflint v0.62.0
Add nats-server v2.12.7
Add kubectl v1.36.0
Add rustic v0.11.2
Add argo v4.0.5
Add zot v2.1.16
Add argocd v3.3.8
Remove argocd v2.11.6
Add opentofu v1.11.6
Add logcli v3.7.1
Remove logcli v2.4.2
Add flux v2.8.6
Remove flux v0.31.5
Add act v0.2.87
Add istioctl v1.29.2
Remove istioctl v1.16.0
Add oc v4.21.12
Remove oc v4.17.10
Add packer v1.15.1
Add clusterctl v1.13.0
Add mirrord v3.204.1
Remove mirrord v3.154.1
Add kubens v0.11.0
Add kubeseal v0.36.6
Remove kubeseal v0.17.5
Add undock v0.12.0
Add k6 v1.7.1
Add typos-cli v1.45.1
Remove typos-cli v1.28.2
Add bun v1.3.13
Add pyenv v2.6.27
Remove pyenv v2.4.8
Add github-cli v2.91.0
Remove github-cli v2.50.0
Add scala-cli v1.13.0
Remove scala-cli v0.1.18
Add go-task v3.50.0
Add pre-commit v4.6.0
Add containerlab v0.74.3
Add lazygit v0.61.1
Add pdm v2.26.8
Remove pdm v2.13.2
Add poetry v2.3.4
Add atlas v1.2.0
Add pipx v1.11.1
Add glab v1.93.0
Remove glab v1.52.0
Add influx-cli v2.8.0
Add uv v0.11.7
Remove uv v0.8.16
Add kubebuilder v4.13.1
Add hugo v0.160.1
Remove hugo v0.139.4