### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -178,3 +178,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_8.8.0_amd64.deb
   sha256: 8e9c4a4e188c541daf01a402b5ac3c9f8c068f99adc6022c946a00ea68665d09
   timestamp: 2026-04-26 18:11:59+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_8.10.0_amd64.deb
+  sha256: 6b8f4bf6810c8daf14ff38ef739331afeb89ea56801dfc6079f559746f536d24
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -14,6 +14,7 @@ matrix:
     - 8.3.0
     - 8.7.0
     - 8.8.0
+    - 8.10.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/dev/bun/ops2deb.lock.yml
+++ b/blueprints/dev/bun/ops2deb.lock.yml
@@ -16,3 +16,9 @@
 - url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-x64.zip
   sha256: 79c0771fa8b92c33aae41e15a0e0d307ea99d0e2f00317c71c6c53237a78e25a
   timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64.zip
+  sha256: a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip
+  sha256: 951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/dev/bun/ops2deb.yml
+++ b/blueprints/dev/bun/ops2deb.yml
@@ -7,6 +7,7 @@ matrix:
     - 1.3.10
     - 1.3.11
     - 1.3.13
+    - 1.3.14
 homepage: https://bun.sh/
 summary: all-in-one JavaScript runtime, bundler, and package manager
 description: |-

--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -199,12 +199,6 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.46.1/downloads/glab_1.46.1_Linux_x86_64.deb
   sha256: bf8c53df12d23bf204cba7ae499c4721009e64b2a39277c814759000ac4d3fdd
   timestamp: 2024-09-10 21:06:11+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.54.0/downloads/glab_1.54.0_linux_amd64.deb
-  sha256: 90b622082b90cc98251dfb72d0441f49642b540649df4820149f0021390646ad
-  timestamp: 2025-03-23 18:08:35+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.54.0/downloads/glab_1.54.0_linux_arm64.deb
-  sha256: 0c1fdb4f57d1e3b2e5e1676b6e2ab99a1a4bb3c01ea58af2e51d5d4845f7b5ed
-  timestamp: 2025-03-23 18:08:35+00:00
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.55.0/downloads/glab_1.55.0_linux_amd64.deb
   sha256: ae3feac2aa1034a585e4a24787970dacd30f07906cdc75af8911c32d158b44e8
   timestamp: 2025-04-02 21:25:10+00:00
@@ -499,3 +493,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.94.0/downloads/glab_1.94.0_linux_arm64.deb
   sha256: 3a542c3be164c9c8ca76b7bae73a9079eae16d2f6b8c653bf4b58d3e0d95e949
   timestamp: 2026-05-06 18:30:46+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.97.0/downloads/glab_1.97.0_linux_amd64.deb
+  sha256: 41df64133bc5fa1ecb752f09d8cbe3d36ced85d5b68c669e234bae48252edc86
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.97.0/downloads/glab_1.97.0_linux_arm64.deb
+  sha256: 3238f78ba94dd13d785e4902cfdf23ccdf6116b4d776c71eb8760231ade7de68
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -56,7 +56,6 @@
       - amd64
       - arm64
     versions:
-      - 1.54.0
       - 1.55.0
       - 1.56.0
       - 1.57.0
@@ -106,6 +105,7 @@
       - 1.90.0
       - 1.93.0
       - 1.94.0
+      - 1.97.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-

--- a/blueprints/dev/k6/ops2deb.lock.yml
+++ b/blueprints/dev/k6/ops2deb.lock.yml
@@ -130,3 +130,9 @@
 - url: https://github.com/grafana/k6/releases/download/v1.7.1/k6-v1.7.1-linux-arm64.tar.gz
   sha256: 5a91fa37d89d1fe776aea590d689029ffc2d2f2634a6c61eb51c982ff50700d7
   timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/grafana/k6/releases/download/v2.0.0/k6-v2.0.0-linux-amd64.tar.gz
+  sha256: 2ae87d976f6cdba17185bdd980d8819a3a98e9092c6f0638cd58272ecefc8b90
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/grafana/k6/releases/download/v2.0.0/k6-v2.0.0-linux-arm64.tar.gz
+  sha256: 397d338c0c50821994aa51a630e511c599c2e903d00f7fa6c55a82258e7a84e6
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/dev/k6/ops2deb.yml
+++ b/blueprints/dev/k6/ops2deb.yml
@@ -26,6 +26,7 @@ matrix:
     - 1.6.0
     - 1.6.1
     - 1.7.1
+    - 2.0.0
 homepage: https://k6.io
 summary: modern load testing tool, using Go and JavaScript
 description: |-

--- a/blueprints/dev/pdm/ops2deb.lock.yml
+++ b/blueprints/dev/pdm/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.13.3.tar.gz
-  sha256: fef20178ae809c36379464946e97f069b83ce41997bf43edee34141acdf18468
-  timestamp: 2024-04-08 12:08:11+00:00
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.14.0.tar.gz
   sha256: 7d82b6f3f451362696962851721f47c58074491895fd1a84eda3ff528e159641
   timestamp: 2024-04-12 09:06:06+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.26.8.tar.gz
   sha256: 0820b1d0a8ee64a4bb7f8a5c20a70e323c99d413b8583c0f0957d99e0212aae5
   timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.26.9.tar.gz
+  sha256: 3e4e80e13c1deb5e52dccd2a69e08b22a79fc19e3d624443cb349f8199d44de7
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/dev/pdm/ops2deb.yml
+++ b/blueprints/dev/pdm/ops2deb.yml
@@ -1,7 +1,6 @@
 name: pdm
 matrix:
   versions:
-    - 2.13.3
     - 2.14.0
     - 2.15.0
     - 2.15.1
@@ -51,6 +50,7 @@ matrix:
     - 2.26.5
     - 2.26.6
     - 2.26.8
+    - 2.26.9
 homepage: https://pdm.fming.dev/
 summary: modern Python package and dependency manager supporting the latest PEP standards
 description: |-

--- a/blueprints/dev/poetry/ops2deb.lock.yml
+++ b/blueprints/dev/poetry/ops2deb.lock.yml
@@ -94,3 +94,6 @@
 - url: https://github.com/python-poetry/poetry/archive/refs/tags/2.4.0.tar.gz
   sha256: 7bd6db257a00ebafe149cf5fe0ef8cd3ee05b5bdf19d74d65748ac56a46fe429
   timestamp: 2026-05-03 18:15:44+00:00
+- url: https://github.com/python-poetry/poetry/archive/refs/tags/2.4.1.tar.gz
+  sha256: 93a189a01f6cb812d12b9bc9b64733b05c89deb915aff67c35bf07894967c1af
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/dev/poetry/ops2deb.yml
+++ b/blueprints/dev/poetry/ops2deb.yml
@@ -124,6 +124,7 @@
       - 2.3.2
       - 2.3.4
       - 2.4.0
+      - 2.4.1
   homepage: https://python-poetry.org
   summary: tool for dependency management and packaging in Python
   description: |-

--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.10.zip
-  sha256: a7524176b07b01c4b925e78e465cf1bfd0447d5686029a43936d9db6ed3a2538
-  timestamp: 2024-08-07 18:07:14+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.11.zip
   sha256: c187870cea2a738a5ff39ba80b191338a1efe708a743659eadc2bf3ba7731978
   timestamp: 2024-09-04 21:05:53+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.28.zip
   sha256: f021d3a9e78910f125398017417d5d19d608d01fc0ab70d04d42d13a0150c5b7
   timestamp: 2026-04-29 06:47:10+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.6.31.zip
+  sha256: 7435b8c1481043e48c838ba40d5c8bc724c23d4c94e531adc283a7c121757ad4
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.4.10
       - 2.4.11
       - 2.4.12
       - 2.4.13
@@ -73,6 +72,7 @@
       - 2.6.26
       - 2.6.27
       - 2.6.28
+      - 2.6.31
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/dev/typos-cli/ops2deb.lock.yml
+++ b/blueprints/dev/typos-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/crate-ci/typos/releases/download/v1.29.0/typos-v1.29.0-x86_64-unknown-linux-musl.tar.gz
-  sha256: d936bdd241fd7e5cf30802ad60d942169f6e2f4197444824ccb8bd7bdebb1245
-  timestamp: 2024-12-31 18:07:51+00:00
 - url: https://github.com/crate-ci/typos/releases/download/v1.29.1/typos-v1.29.1-x86_64-unknown-linux-musl.tar.gz
   sha256: f4d9630c51bdf9398ebcd70bee485302eb14b9e4ddf1f8101deab8d30621ffda
   timestamp: 2025-01-02 18:08:03+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/crate-ci/typos/releases/download/v1.46.0/typos-v1.46.0-x86_64-unknown-linux-musl.tar.gz
   sha256: c62a626df385c96574743fd4974aeb271a41a67d080a0398e36e1a42782f614a
   timestamp: 2026-04-30 18:27:14+00:00
+- url: https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-unknown-linux-musl.tar.gz
+  sha256: c574fa505596922ba2e7b1027a0a5b2df528f399b86b6915d85748186a65ca44
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/dev/typos-cli/ops2deb.yml
+++ b/blueprints/dev/typos-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: typos-cli
 matrix:
   versions:
-    - 1.29.0
     - 1.29.1
     - 1.29.3
     - 1.29.4
@@ -51,6 +50,7 @@ matrix:
     - 1.45.1
     - 1.45.2
     - 1.46.0
+    - 1.46.1
 homepage: https://github.com/crate-ci/typos/
 summary: source code spell checker
 description: |-

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -448,15 +448,6 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.6.7/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 601c2b1147117c4471a154b4cebbdb31c818105f796d5f8115fe42d2526689c8
   timestamp: 2025-03-18 03:17:18+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.8.21/uv-aarch64-unknown-linux-musl.tar.gz
-  sha256: 2afeee16b09d40cbe4de445fe82e1ecc00ed51dd8e118ed7800ca537ee4cf0c2
-  timestamp: 2025-09-23 18:03:23+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.8.21/uv-armv7-unknown-linux-gnueabihf.tar.gz
-  sha256: f6b5fa5a6cfad7fd9fa80c11b24cef18acb8d99c137a6144a4bb1c50dbfb5b1b
-  timestamp: 2025-09-23 18:03:23+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.8.21/uv-x86_64-unknown-linux-gnu.tar.gz
-  sha256: 166bfa522cc836a3b68bdcef78e40b263ea62f12bb80a8d9c6fda4ce5f2a3994
-  timestamp: 2025-09-23 18:03:23+00:00
 - url: https://github.com/astral-sh/uv/releases/download/0.8.22/uv-aarch64-unknown-linux-musl.tar.gz
   sha256: 3cb3c891f56891f0027f0287980014930b18875c9396c1d8a19d607b0a6049d9
   timestamp: 2025-09-24 00:08:07+00:00
@@ -898,3 +889,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.11.11/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: a767848254391855c96df271e9ca8b7f72dd172d310460447853d25d907b9ae0
   timestamp: 2026-05-07 00:23:55+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.11.14/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: d7d3966e46915c5f6932692aaf152a2473eecb1d2517ca4f8e88a07484b380b6
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.11.14/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: 2aca3925d7ad91d2e02a0f9cf75974ebd077ec5cb939a5eb66aba096d5666819
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.11.14/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: f3b623eb0e6141a7053d571d59a0bdc341e0f238ea8f5f0b4815ddbec9a2a296
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -87,7 +87,6 @@
       - arm64
       - armhf
     versions:
-      - 0.8.21
       - 0.8.22
       - 0.8.23
       - 0.8.24
@@ -137,6 +136,7 @@
       - 0.11.9
       - 0.11.10
       - 0.11.11
+      - 0.11.14
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/devops/argocd/ops2deb.lock.yml
+++ b/blueprints/devops/argocd/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/argoproj/argo-cd/releases/download/v2.12.1/argocd-linux-amd64
-  sha256: 6b08b92c20af25a50cb8ab6bd46a935a666f41801e1d9d1ffee2acc59b752d09
-  timestamp: 2024-08-16 18:07:37+00:00
-- url: https://github.com/argoproj/argo-cd/releases/download/v2.12.1/argocd-linux-arm64
-  sha256: fd2f976c607130bab6f5f722ddaaed82ca14b81eb7db8283daa1dae4176e9fa1
-  timestamp: 2024-08-16 18:07:37+00:00
 - url: https://github.com/argoproj/argo-cd/releases/download/v2.12.2/argocd-linux-amd64
   sha256: 97a6017702acf7369d29fbaee58aaec7007144939b4cc764ce184efdf11e3c3b
   timestamp: 2024-08-23 06:07:42+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/argoproj/argo-cd/releases/download/v3.4.1/argocd-linux-arm64
   sha256: 764844e421aef30bd21d886465c959870f61af7f21712db92fe114e5c5ef1a8d
   timestamp: 2026-05-06 12:33:18+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v3.4.2/argocd-linux-amd64
+  sha256: d4cb1ac8002baab8afaca2da3de597b613df8459074bc7c6d96dc95161c2a33f
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/argoproj/argo-cd/releases/download/v3.4.2/argocd-linux-arm64
+  sha256: d0b74511242b2b4827dea6435092ef8b1402eb26c29c00944934e546a6445944
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/devops/argocd/ops2deb.yml
+++ b/blueprints/devops/argocd/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 2.12.1
     - 2.12.2
     - 2.12.3
     - 2.12.4
@@ -54,6 +53,7 @@ matrix:
     - 3.3.8
     - 3.3.9
     - 3.4.1
+    - 3.4.2
 homepage: https://github.com/argoproj/argo-cd
 summary: continuous delivery tool for Kubernetes
 description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.

--- a/blueprints/devops/carvel-ytt/ops2deb.lock.yml
+++ b/blueprints/devops/carvel-ytt/ops2deb.lock.yml
@@ -208,3 +208,9 @@
 - url: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.54.0/ytt-linux-arm64
   sha256: 2ee1dee5c952a081896ac5b30853b6e59bd77b5fdd244bff2ea16a3172e8fb5a
   timestamp: 2026-04-27 18:25:01+00:00
+- url: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.55.0/ytt-linux-amd64
+  sha256: 013adf9ed2fbd392b9861e5ec34015dabfcfa2e82da9e8cc0ee1e5c6a7f9b64b
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.55.0/ytt-linux-arm64
+  sha256: 14e0a83a793c04bd26b2a2328f6df169b38ddf24257a64ffde23038f4ecab0bf
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/carvel-ytt/ops2deb.yml
+++ b/blueprints/devops/carvel-ytt/ops2deb.yml
@@ -39,6 +39,7 @@ matrix:
     - 0.53.1
     - 0.53.2
     - 0.54.0
+    - 0.55.0
 homepage: https://carvel.dev/ytt/
 summary: YAML templating tool that works on YAML structure instead of text
 description: |-

--- a/blueprints/devops/clusterctl/ops2deb.lock.yml
+++ b/blueprints/devops/clusterctl/ops2deb.lock.yml
@@ -178,3 +178,9 @@
 - url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.1/clusterctl-linux-arm64
   sha256: 6ac2380628b71a534f1fa87babff01ad9080f14a125dd7eff91c12942446de47
   timestamp: 2026-04-28 12:31:42+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/clusterctl-linux-amd64
+  sha256: ae1d0a60e7101eb6c5cea650740b3d8d3b50cd8c724a2a375ddd5744df6ea544
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/clusterctl-linux-arm64
+  sha256: d1b97f0a31180accf73a20112a5e746c6cadcd58324b38bc8438a591ef9ecaa1
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/clusterctl/ops2deb.yml
+++ b/blueprints/devops/clusterctl/ops2deb.yml
@@ -34,6 +34,7 @@ matrix:
     - 1.12.4
     - 1.13.0
     - 1.13.1
+    - 1.13.2
 homepage: https://cluster-api.sigs.k8s.io/
 summary: Kubernetes project offering declarative APIs for managing multiple clusters
 description: |-

--- a/blueprints/devops/flux/ops2deb.lock.yml
+++ b/blueprints/devops/flux/ops2deb.lock.yml
@@ -16,15 +16,6 @@
 - url: https://github.com/fluxcd/flux2/releases/download/v0.24.1/flux_0.24.1_linux_amd64.tar.gz
   sha256: 3373a272ff888772e40647e90ba41dfa232e7482df62b10735cdd86a25e42178
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_linux_amd64.tar.gz
-  sha256: c94a42e96620848f9aed69a130c01b7d740412f6f2b3ad3c95fe23471f2b8e4e
-  timestamp: 2022-08-11 17:24:09+00:00
-- url: https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_linux_arm.tar.gz
-  sha256: 9a76e273107ce617a9fc1b7895297aa63e75006cbe1f03b9f0606539f54e08da
-  timestamp: 2022-08-11 17:24:09+00:00
-- url: https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_linux_arm64.tar.gz
-  sha256: 6834c6fde64df9883b76c6b3a3111a6d00f88553373b892f363491b0896c0654
-  timestamp: 2022-08-11 17:24:09+00:00
 - url: https://github.com/fluxcd/flux2/releases/download/v0.33.0/flux_0.33.0_linux_amd64.tar.gz
   sha256: b640626c705fb71eb8c676700257a7092178968f9e06c3e62c87d827cfa35017
   timestamp: 2022-08-30 08:55:12+00:00
@@ -466,3 +457,12 @@
 - url: https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_linux_arm64.tar.gz
   sha256: bc460320c2d33ad833791277896dd1aaf1cff6b3e64ba397c44238f00d4ae5bc
   timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/fluxcd/flux2/releases/download/v2.8.7/flux_2.8.7_linux_amd64.tar.gz
+  sha256: 493a8df42bf89f8481f03afb44b6f4801a76ec0f0b9233042487d0cb5c6cf4e3
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/fluxcd/flux2/releases/download/v2.8.7/flux_2.8.7_linux_arm.tar.gz
+  sha256: 137cf912271f3a76d49ad7c5cb315ca10849d213ac7fabe23a0556660505a6a8
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/fluxcd/flux2/releases/download/v2.8.7/flux_2.8.7_linux_arm64.tar.gz
+  sha256: f6b19f6f2d85dd47cecb9169111c3f35f220217ab488d254ca3d8faba58e0217
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/flux/ops2deb.yml
+++ b/blueprints/devops/flux/ops2deb.yml
@@ -36,7 +36,6 @@
       - arm64
       - armhf
     versions:
-      - 0.32.0
       - 0.33.0
       - 0.34.0
       - 0.35.0
@@ -86,6 +85,7 @@
       - 2.8.1
       - 2.8.3
       - 2.8.6
+      - 2.8.7
   homepage: https://fluxcd.io
   summary: open and extensible continuous delivery solution for Kubernetes
   description: |-

--- a/blueprints/devops/helm/ops2deb.lock.yml
+++ b/blueprints/devops/helm/ops2deb.lock.yml
@@ -52,12 +52,6 @@
 - url: https://get.helm.sh/helm-v3.9.1-linux-arm64.tar.gz
   sha256: 655dbceb4ab4b246af2214e669b9d44e3a35f170f39df8eebdb8d87619c585d1
   timestamp: 2022-07-13 20:26:10+00:00
-- url: https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz
-  sha256: 6c3440d829a56071a4386dd3ce6254eab113bc9b1fe924a6ee99f7ff869b9e0b
-  timestamp: 2023-01-18 19:22:55+00:00
-- url: https://get.helm.sh/helm-v3.11.0-linux-arm.tar.gz
-  sha256: cddbef72886c82a123038883f32b04e739cc4bd7b9e5f869740d51e50a38be01
-  timestamp: 2023-01-18 19:22:55+00:00
 - url: https://get.helm.sh/helm-v3.11.1-linux-amd64.tar.gz
   sha256: 0b1be96b66fab4770526f136f5f1a385a47c41923d33aab0dcb500e0f6c1bf7c
   timestamp: 2023-02-08 19:24:44+00:00
@@ -352,3 +346,9 @@
 - url: https://get.helm.sh/helm-v4.1.4-linux-arm.tar.gz
   sha256: c4a7d37032379cc7e82c9c76487d1041b193c9a0fbb4b8f3790230899b830a4f
   timestamp: 2026-04-24 06:37:37+00:00
+- url: https://get.helm.sh/helm-v4.2.0-linux-amd64.tar.gz
+  sha256: 97dbeb971be4ac4b27e3839976d9564c0fb35c6f3b1da89dd1e292d236af4096
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://get.helm.sh/helm-v4.2.0-linux-arm.tar.gz
+  sha256: ae624870b2d50e655b6462daff117eb9d28c4bad45234ef24c1275113540fcb0
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/helm/ops2deb.yml
+++ b/blueprints/devops/helm/ops2deb.yml
@@ -42,7 +42,6 @@
       - amd64
       - armhf
     versions:
-      - 3.11.0
       - 3.11.1
       - 3.11.2
       - 3.11.3
@@ -92,6 +91,7 @@
       - 4.1.1
       - 4.1.3
       - 4.1.4
+      - 4.2.0
   homepage: https://helm.sh
   summary: Kubernetes package manager
   description: |-

--- a/blueprints/devops/helmfile/ops2deb.lock.yml
+++ b/blueprints/devops/helmfile/ops2deb.lock.yml
@@ -40,12 +40,6 @@
 - url: https://github.com/roboll/helmfile/releases/download/v0.144.0/helmfile_linux_arm64
   sha256: 8461bbb13ba23f4333dc99d96bf7a24c283cd7683e746acf639d80bbd828926a
   timestamp: 2022-03-31 05:32:30+00:00
-- url: https://github.com/helmfile/helmfile/releases/download/v0.145.5/helmfile_0.145.5_linux_amd64.tar.gz
-  sha256: 5342ac7ec7df19f30432b8cef0efa341c9430945ae2f9704daca2a933aa360a4
-  timestamp: 2022-09-14 04:34:00+00:00
-- url: https://github.com/helmfile/helmfile/releases/download/v0.145.5/helmfile_0.145.5_linux_arm64.tar.gz
-  sha256: 275e1aedaccf230c729a10aba2a45dc5c75b2f32e6479740d4fdd579d55f274b
-  timestamp: 2022-09-14 04:34:00+00:00
 - url: https://github.com/helmfile/helmfile/releases/download/v0.146.0/helmfile_0.146.0_linux_amd64.tar.gz
   sha256: 3be02c2f02d022b50706b1dad8ce5dba2d740031dc425bb8c6c76fa09bcfff3d
   timestamp: 2022-09-20 04:31:29+00:00
@@ -340,3 +334,9 @@
 - url: https://github.com/helmfile/helmfile/releases/download/v1.5.0/helmfile_1.5.0_linux_arm64.tar.gz
   sha256: d98ae0a480a3020ab361fea6b5973e28f976caf392c8ac84157a05796247a7fe
   timestamp: 2026-05-03 18:15:44+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.5.1/helmfile_1.5.1_linux_amd64.tar.gz
+  sha256: 4c0c92f711aaf95b953065a0a76c6adfd4f7fb9f8c7065db5c94d32a0caf288f
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.5.1/helmfile_1.5.1_linux_arm64.tar.gz
+  sha256: 580984c7c2785d6c7255dc49cc24d3a4c70dae5d7f25a80f58f93b08d91cf753
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/helmfile/ops2deb.yml
+++ b/blueprints/devops/helmfile/ops2deb.yml
@@ -79,7 +79,6 @@
       - amd64
       - arm64
     versions:
-      - 0.145.5
       - 0.146.0
       - 0.147.0
       - 0.148.0
@@ -129,6 +128,7 @@
       - 1.4.4
       - 1.4.5
       - 1.5.0
+      - 1.5.1
   homepage: https://helmfile.readthedocs.io/
   summary: deploy Kubernetes Helm Charts
   description: |-

--- a/blueprints/devops/kubectl/ops2deb.lock.yml
+++ b/blueprints/devops/kubectl/ops2deb.lock.yml
@@ -514,3 +514,12 @@
 - url: https://dl.k8s.io/release/v1.36.0/bin/linux/arm64/kubectl
   sha256: 9f9d9c44a7b5264515ac9da5991584e2395bd50662e651132337e7b4d0c56f8f
   timestamp: 2026-04-24 06:37:37+00:00
+- url: https://dl.k8s.io/release/v1.36.1/bin/linux/amd64/kubectl
+  sha256: 629d3f410e09bf49b64ae7079f7f0bda1191efed311f7d37fdbab0ad5b0ec2b7
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://dl.k8s.io/release/v1.36.1/bin/linux/arm/kubectl
+  sha256: 0f5f7530e6ac3b887e01c963b5eea477cc6f590ec5e3a4e23a5485e6d9227761
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://dl.k8s.io/release/v1.36.1/bin/linux/arm64/kubectl
+  sha256: 59f7ee8e477fae658447607dc3c8790ac17a1b016c01c622c12070e969e2d4e7
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/kubectl/ops2deb.yml
+++ b/blueprints/devops/kubectl/ops2deb.yml
@@ -106,6 +106,7 @@
       - 1.35.2
       - 1.35.3
       - 1.36.0
+      - 1.36.1
   homepage: https://github.com/kubernetes/kubectl
   summary: command line client for controlling a Kubernetes cluster
   description: |-

--- a/blueprints/devops/logcli/ops2deb.lock.yml
+++ b/blueprints/devops/logcli/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/grafana/loki/releases/download/v2.5.0/logcli-linux-amd64.zip
-  sha256: ba034c3c56e121697a6bcec7a51b012e946a4f449a757a0ce594cd689c3e6648
-  timestamp: 2022-04-11 20:28:57+00:00
-- url: https://github.com/grafana/loki/releases/download/v2.5.0/logcli-linux-arm.zip
-  sha256: 6db5b6108a5a9ba9f1a0be9244db3c83026506fa4b254e454644dbcf2bc209f6
-  timestamp: 2022-04-11 20:28:57+00:00
-- url: https://github.com/grafana/loki/releases/download/v2.5.0/logcli-linux-arm64.zip
-  sha256: 61a35f694bdc75c7c9a4cfabc84edcd1ea827084c102a68d7130a5dadfb98f2f
-  timestamp: 2022-04-11 20:28:57+00:00
 - url: https://github.com/grafana/loki/releases/download/v2.6.0/logcli-linux-amd64.zip
   sha256: ec390ceb802b5295f8abbd3b14c46b90c86ee332a86e86de3e6ba782ae0cbda7
   timestamp: 2022-07-08 20:27:36+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/grafana/loki/releases/download/v3.7.1/logcli-linux-arm64.zip
   sha256: b3cf8e9b842c406b93cb8c1788bbfeee68ccb449d8c24e86c71469009266e870
   timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.7.2/logcli-linux-amd64.zip
+  sha256: 7850d566d2af10d7adf255ed9452de632ab20c0f269dc61fac7f70bed4d99e48
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.7.2/logcli-linux-arm.zip
+  sha256: ba9031d9c999d9348802393857d8528b08327ac85fab256a1d6c65135b25376a
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.7.2/logcli-linux-arm64.zip
+  sha256: 2fec7cbf4c0929f2fbd1e339753b14bc6432aadb41abf4b4155b00d3f6509e4e
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/logcli/ops2deb.yml
+++ b/blueprints/devops/logcli/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 2.5.0
     - 2.6.0
     - 2.6.1
     - 2.7.0
@@ -55,6 +54,7 @@ matrix:
     - 3.6.6
     - 3.6.7
     - 3.7.1
+    - 3.7.2
 homepage: https://github.com/grafana/loki
 summary: command-line interface for loki
 description: It facilitates running LogQL queries against a Loki instance.

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.159.1/mirrord_linux_aarch64.zip
-  sha256: 8d7263b4f22df82da6ec8b0be7699da4ce11f13d82aa82ad83bb8a276215d7ae
-  timestamp: 2025-08-27 18:02:55+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.159.1/mirrord_linux_x86_64.zip
-  sha256: ec3673db5f4b3e72714cd2b2799015d9e3b3ad771f92553234fc26243d8901ea
-  timestamp: 2025-08-27 18:02:55+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.159.2/mirrord_linux_aarch64.zip
   sha256: 13b2c1bf6822eb7fa2afbfea1091bcf7a4573ce1040b134363b28ede753910a0
   timestamp: 2025-09-01 12:03:55+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.209.1/mirrord_linux_x86_64.zip
   sha256: 48791841954bd22146cd797645bf6205195ad46f4dbab64ff61d65ddd3805271
   timestamp: 2026-05-01 12:17:03+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.210.0/mirrord_linux_aarch64.zip
+  sha256: c75b26fc9abca5efe90e123ebe3768bbfb075cbb8196c144912140afe4fcb138
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.210.0/mirrord_linux_x86_64.zip
+  sha256: ef96e596b63a691019ab858d922825b05228ab78490a8eddb1f07929872148a8
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.159.1
     - 3.159.2
     - 3.160.0
     - 3.161.0
@@ -54,6 +53,7 @@ matrix:
     - 3.208.0
     - 3.209.0
     - 3.209.1
+    - 3.210.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -4,12 +4,6 @@
 - url: https://github.com/okd-project/okd/releases/download/4.15.0-0.okd-2024-03-10-010116/openshift-client-linux-4.15.0-0.okd-2024-03-10-010116.tar.gz
   sha256: 90a357d420008494e0ea898801ddf39da11cab4270b778ee01a72bda7835a3a9
   timestamp: 2024-11-25 11:13:58+00:00
-- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.17.14/openshift-client-linux-arm64.tar.gz
-  sha256: cb966364a865d16fed878e355716adfcdd040bbc871b8da59d74cc70693b0c08
-  timestamp: 2025-01-28 09:07:22+00:00
-- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.17.14/openshift-client-linux.tar.gz
-  sha256: 3d696605ef1ef33b49546ed7f6498458ff704935aad4fe9fcc3bab297b9ff80e
-  timestamp: 2025-01-28 09:07:22+00:00
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.17.15/openshift-client-linux-arm64.tar.gz
   sha256: 5a2ed1437cba0b156381a86e5439e0a09390a1d445df2dc205f18bfff309a779
   timestamp: 2025-01-31 15:06:21+00:00
@@ -304,3 +298,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.14/openshift-client-linux.tar.gz
   sha256: 966f7531d9189456173750b2cc32f8183c6aecf659e24c394f6eceaa1c89df03
   timestamp: 2026-05-06 06:51:42+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.15/openshift-client-linux-arm64.tar.gz
+  sha256: 632c94bee2f0c002d5f9a348687becc71eff8914d0cea70509ace754b7860f23
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.15/openshift-client-linux.tar.gz
+  sha256: f5c51db199993654c1d3223222ee8110ff1f69331b06b4ec39c20c8f07e389f4
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 4.17.14
     - 4.17.15
     - 4.17.16
     - 4.17.17
@@ -54,6 +53,7 @@ matrix:
     - 4.21.12
     - 4.21.13
     - 4.21.14
+    - 4.21.15
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/opentofu/ops2deb.lock.yml
+++ b/blueprints/devops/opentofu/ops2deb.lock.yml
@@ -202,3 +202,9 @@
 - url: https://github.com/opentofu/opentofu/releases/download/v1.11.6/tofu_1.11.6_linux_arm64.zip
   sha256: 273f107f1f64734fcae4753796803a24b86ae0c383e433ab64bd5542ccd18772
   timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/opentofu/opentofu/releases/download/v1.12.0/tofu_1.12.0_linux_amd64.zip
+  sha256: 8d7650fd42b6d790f9f747604393ccd0a9035376bccc4f1688b905d7c5bb1137
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/opentofu/opentofu/releases/download/v1.12.0/tofu_1.12.0_linux_arm64.zip
+  sha256: 466bf912404b4ab0f0b3a043073d68ad34f11d55ad7a483957d94f0733169f8d
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/devops/opentofu/ops2deb.yml
+++ b/blueprints/devops/opentofu/ops2deb.yml
@@ -38,6 +38,7 @@ matrix:
     - 1.11.4
     - 1.11.5
     - 1.11.6
+    - 1.12.0
 homepage: https://opentofu.org
 summary: lets you declaratively manage your cloud infrastructure
 description: |-

--- a/blueprints/devops/rclone/ops2deb.lock.yml
+++ b/blueprints/devops/rclone/ops2deb.lock.yml
@@ -403,3 +403,12 @@
 - url: https://github.com/rclone/rclone/releases/download/v1.74.0/rclone-v1.74.0-linux-arm64.zip
   sha256: c28148f72e82e16953a9f7eedbe610736968240318ff33872f90bfdd689cc72f
   timestamp: 2026-05-01 18:20:20+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.74.1/rclone-v1.74.1-linux-amd64.zip
+  sha256: 67df3059a6233b6e32e604bcd637654bb294ff86291b65ede77123e94818d911
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.74.1/rclone-v1.74.1-linux-arm.zip
+  sha256: 703e7a2dd1f2a26e60d190d1da4cbd68b8a1c2b897675becbea9e42ec8b99d46
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/rclone/rclone/releases/download/v1.74.1/rclone-v1.74.1-linux-arm64.zip
+  sha256: c816ed0e568de4dd1bba1a4d0cd47523d3dd54337dd5fde73f1b068857ecf877
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/rclone/ops2deb.yml
+++ b/blueprints/devops/rclone/ops2deb.yml
@@ -82,6 +82,7 @@
       - 1.73.3
       - 1.73.5
       - 1.74.0
+      - 1.74.1
   revision: "2"
   homepage: https://rclone.org/
   summary: rsync for cloud storage

--- a/blueprints/devops/rpk/ops2deb.lock.yml
+++ b/blueprints/devops/rpk/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/redpanda-data/redpanda/releases/download/v24.2.1/rpk-linux-amd64.zip
-  sha256: be211696e9e62d50ba74f61c6176624473389bfb1a37ef6ec9ad47264ddde845
-  timestamp: 2024-07-31 21:05:56+00:00
-- url: https://github.com/redpanda-data/redpanda/releases/download/v24.2.1/rpk-linux-arm64.zip
-  sha256: 0a4d3b69d93a0650d823e17e0955474ca034e1a6e8beb01982c999e6b02f073d
-  timestamp: 2024-07-31 21:05:56+00:00
 - url: https://github.com/redpanda-data/redpanda/releases/download/v24.2.2/rpk-linux-amd64.zip
   sha256: 5681c5f8adf30a8e2cf3d0858c8263d179392e0731238177c6bffa07ebb984cc
   timestamp: 2024-08-07 18:07:14+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/redpanda-data/redpanda/releases/download/v26.1.6/rpk-linux-arm64.zip
   sha256: 325a62c10e104f9b26190f3a87346a799eb79d4d1c33ec54b0b95210fbb564f3
   timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v26.1.8/rpk-linux-amd64.zip
+  sha256: 203099f08abe3aa0c2c247d2f11f396f7007effda5e63c70feae4c4cfceb989c
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/redpanda-data/redpanda/releases/download/v26.1.8/rpk-linux-arm64.zip
+  sha256: 4f0faa8b8723549abdeefff935214c05208bba99e0219168b43a3117c22ef4bc
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/devops/rpk/ops2deb.yml
+++ b/blueprints/devops/rpk/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 24.2.1
     - 24.2.2
     - 24.2.3
     - 24.2.4
@@ -54,6 +53,7 @@ matrix:
     - 25.3.9
     - 25.3.10
     - 26.1.6
+    - 26.1.8
 homepage: https://redpanda.com/
 summary: interact with your Redpanda clusters
 description: |-

--- a/blueprints/devops/terraform-docs/ops2deb.lock.yml
+++ b/blueprints/devops/terraform-docs/ops2deb.lock.yml
@@ -49,3 +49,9 @@
 - url: https://github.com/terraform-docs/terraform-docs/releases/download/v0.23.0/terraform-docs-v0.23.0-linux-arm64.tar.gz
   sha256: f3be6f09fb0913c752b78480fac1eb4916e9ee50da7e3eb0bdaa356d80ed16b5
   timestamp: 2026-05-06 06:51:42+00:00
+- url: https://github.com/terraform-docs/terraform-docs/releases/download/v0.24.0/terraform-docs-v0.24.0-linux-arm.tar.gz
+  sha256: 78020b9dce7c1d1d7f98ef94b513686c76c32ec30d0e852ce2960db66d597e33
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/terraform-docs/terraform-docs/releases/download/v0.24.0/terraform-docs-v0.24.0-linux-arm64.tar.gz
+  sha256: d12bd7b73c1fc9c64efc79f8157dd713dabd559f1ecf3cfc0f42e32279a155fd
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/devops/terraform-docs/ops2deb.yml
+++ b/blueprints/devops/terraform-docs/ops2deb.yml
@@ -23,6 +23,7 @@
       - 0.21.0
       - 0.22.0
       - 0.23.0
+      - 0.24.0
   homepage: https://terraform-docs.io
   summary: generate documentation from Terraform modules in various output formats
   description: |-

--- a/blueprints/devops/terraform/ops2deb.lock.yml
+++ b/blueprints/devops/terraform/ops2deb.lock.yml
@@ -28,15 +28,6 @@
 - url: https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_arm64.zip
   sha256: 2f72982008c52d2d57294ea50794d7c6ae45d2948e08598bfec3e492bce8d96e
   timestamp: 2022-03-02 22:16:55+00:00
-- url: https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_linux_amd64.zip
-  sha256: 2bac080244845ebd434baf5e8557bd06d53b3c8bc01b7e496b390a56cb40ac5c
-  timestamp: 2024-01-17 21:15:51+00:00
-- url: https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_linux_arm.zip
-  sha256: ee7f75ed10e6f37e93d6ea23728d724def42082af909c7ab3886c19d0cfa9652
-  timestamp: 2024-01-17 21:15:51+00:00
-- url: https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_linux_arm64.zip
-  sha256: 33094b8c677460e7c6496a89770ae702bb8d9c6613d4a8485897da006d1919b5
-  timestamp: 2024-01-17 21:15:51+00:00
 - url: https://releases.hashicorp.com/terraform/1.7.1/terraform_1.7.1_linux_amd64.zip
   sha256: 64ea53ae52a7e199bd6f647c31613ea4ef18f58116389051b4a34a29fb04624a
   timestamp: 2024-01-24 15:19:06+00:00
@@ -478,3 +469,12 @@
 - url: https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_linux_arm64.zip
   sha256: cf27657e96bbdc6116f4c16a0c801d36ae6410d7210183a520ac6b2198fb723e
   timestamp: 2026-05-06 18:30:46+00:00
+- url: https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_linux_amd64.zip
+  sha256: c3d4b579064745a5f7e918125db23b12ba52a8a7287adb9f32c49d637e02e3bf
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_linux_arm.zip
+  sha256: 17e75bf2abb1dc5283e12855a30eb68c4feb14794a94d4cae912f2245115f377
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://releases.hashicorp.com/terraform/1.15.3/terraform_1.15.3_linux_arm64.zip
+  sha256: 9824eb010b835b2c872440a337a69acfa1782d36c24d3c09fe5defe75defc511
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/devops/terraform/ops2deb.yml
+++ b/blueprints/devops/terraform/ops2deb.yml
@@ -40,7 +40,6 @@
       - arm64
       - armhf
     versions:
-      - 1.7.0
       - 1.7.1
       - 1.7.2
       - 1.7.3
@@ -90,6 +89,7 @@
       - 1.15.0
       - 1.15.1
       - 1.15.2
+      - 1.15.3
   homepage: https://www.terraform.io
   summary: tool for building, changing, and versioning infrastructure safely
   description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.87.3/terragrunt_linux_amd64
-  sha256: 36f957ded8f40af9f62ef4faff8dbf958c005c266117b241b1576d32717a8c39
-  timestamp: 2025-09-15 18:03:08+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.87.3/terragrunt_linux_arm64
-  sha256: 1c39c89cf313878399fcb495e5971f0c5da74526a8dc60c0ddc415ece9f17cd6
-  timestamp: 2025-09-15 18:03:08+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.87.4/terragrunt_linux_amd64
   sha256: dd167600fd5e99e02cbb6e7e70ac1f8adbf7ef1c7a32e5afb647656238e1035f
   timestamp: 2025-09-17 00:07:52+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.0.3/terragrunt_linux_arm64
   sha256: 434e32ac6b9add72c411c6ef075db24b1508e0c79f8102b8d05e85f4f2b4b24b
   timestamp: 2026-04-27 18:25:01+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.0.4/terragrunt_linux_amd64
+  sha256: 387509aa15d3f38a93d0888ace2bd67c3e5eea841e1f4d585ea2174d566f35e9
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.0.4/terragrunt_linux_arm64
+  sha256: 64f4e6b062e481e82c06d45d9e78af4d95687da79faec489b208b8cc8f6037ee
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.87.3
       - 0.87.4
       - 0.87.5
       - 0.87.6
@@ -75,6 +74,7 @@
       - 0.99.4
       - 1.0.2
       - 1.0.3
+      - 1.0.4
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/devops/tflint/ops2deb.lock.yml
+++ b/blueprints/devops/tflint/ops2deb.lock.yml
@@ -220,3 +220,9 @@
 - url: https://github.com/terraform-linters/tflint/releases/download/v0.62.0/tflint_linux_arm64.zip
   sha256: 064206ec85adaf90f637c880eb3cd5a8e07ddce09e4da7c813eb362cb794f95f
   timestamp: 2026-04-24 06:37:37+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.62.1/tflint_linux_amd64.zip
+  sha256: c004ec45ade3caf87cd4089feb1d2af9f7df57b13140a36df8a63c0a8cc69f14
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/terraform-linters/tflint/releases/download/v0.62.1/tflint_linux_arm64.zip
+  sha256: 9f3bce43f7f58f05ddcf193f0bf1f7e7a9c7a79d7f46f72dd38e97f96fcaf14c
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/devops/tflint/ops2deb.yml
+++ b/blueprints/devops/tflint/ops2deb.yml
@@ -41,6 +41,7 @@ matrix:
     - 0.60.0
     - 0.61.0
     - 0.62.0
+    - 0.62.1
 homepage: https://github.com/terraform-linters/tflint
 summary: pluggable Terraform linter
 description: |-

--- a/blueprints/secops/sops/ops2deb.lock.yml
+++ b/blueprints/secops/sops/ops2deb.lock.yml
@@ -82,3 +82,9 @@
 - url: https://github.com/getsops/sops/releases/download/v3.12.2/sops-v3.12.2.linux.arm64
   sha256: f66de6f528dca946e910d74fa36a62a7714c11d0db16bd3c9bd8acf73b66704b
   timestamp: 2026-03-20 00:13:29+00:00
+- url: https://github.com/getsops/sops/releases/download/v3.13.0/sops-v3.13.0.linux.amd64
+  sha256: f2e5ed5e57376789b0e12793adc848e54c2338906e51392246dd03461b320157
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/getsops/sops/releases/download/v3.13.0/sops-v3.13.0.linux.arm64
+  sha256: ca39dc61be763583c12690e4c55883449c6997274f5c24757f1fd86f7e47acd8
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/secops/sops/ops2deb.yml
+++ b/blueprints/secops/sops/ops2deb.yml
@@ -18,6 +18,7 @@ matrix:
     - 3.11.0
     - 3.12.1
     - 3.12.2
+    - 3.13.0
 homepage: https://age-encryption.org/
 summary: simple and flexible tool for managing secrets
 description: |-

--- a/blueprints/secops/vuls-scanner/ops2deb.lock.yml
+++ b/blueprints/secops/vuls-scanner/ops2deb.lock.yml
@@ -496,3 +496,9 @@
 - url: https://github.com/future-architect/vuls/releases/download/v0.38.6/vuls-scanner_0.38.6_linux_arm64.tar.gz
   sha256: 07da0dccf900b2d6dda0b602601feb54bb5c73a4b797e3530aac7d99d18c5593
   timestamp: 2026-03-11 06:13:49+00:00
+- url: https://github.com/future-architect/vuls/releases/download/v0.39.0/vuls-scanner_0.39.0_linux_amd64.tar.gz
+  sha256: 241f79ea213c9e6491ba63fd06daf901b9c0ee3b66765d80b706a82e29ee45c0
+  timestamp: 2026-05-14 12:33:16+00:00
+- url: https://github.com/future-architect/vuls/releases/download/v0.39.0/vuls-scanner_0.39.0_linux_arm64.tar.gz
+  sha256: e369194eec347557e107f3b1dcd5e57e34ac1c1fd78f4ffbc76f17d302ebcc38
+  timestamp: 2026-05-14 12:33:16+00:00

--- a/blueprints/secops/vuls-scanner/ops2deb.yml
+++ b/blueprints/secops/vuls-scanner/ops2deb.yml
@@ -104,6 +104,7 @@
       - 0.38.4
       - 0.38.5
       - 0.38.6
+      - 0.39.0
   homepage: https://vuls.io/
   summary: agent-less vulnerability scanner
   description: |-

--- a/blueprints/terminal/dasel/ops2deb.lock.yml
+++ b/blueprints/terminal/dasel/ops2deb.lock.yml
@@ -169,3 +169,12 @@
 - url: https://github.com/TomWright/dasel/releases/download/v3.8.1/dasel_linux_arm64
   sha256: d3a1e6e03162304009f0c4d47c8b993053e52af75fc7d8e3dc74f37a64ab62c0
   timestamp: 2026-04-30 18:27:14+00:00
+- url: https://github.com/TomWright/dasel/releases/download/v3.10.1/dasel_linux_amd64
+  sha256: e35d899a846828c87884e1834ac1f58df2d4d03b32af0d6ee12c8d207b81b1fb
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/TomWright/dasel/releases/download/v3.10.1/dasel_linux_arm32
+  sha256: d225a4688ad97b20937bc7c14e6362ed514d469a2b3f6a51bae1c8421b469895
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/TomWright/dasel/releases/download/v3.10.1/dasel_linux_arm64
+  sha256: 01a03cf8149fab32dc1b9534d1b2b532952c7032166ee7452f2eb98f17937c35
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/terminal/dasel/ops2deb.yml
+++ b/blueprints/terminal/dasel/ops2deb.yml
@@ -24,6 +24,7 @@ matrix:
     - 3.4.1
     - 3.8.0
     - 3.8.1
+    - 3.10.1
 homepage: https://daseldocs.tomwright.me
 summary: allows to query and modify data structures using selector strings
 description: |-

--- a/blueprints/terminal/ghorg/ops2deb.lock.yml
+++ b/blueprints/terminal/ghorg/ops2deb.lock.yml
@@ -220,3 +220,9 @@
 - url: https://github.com/gabrie30/ghorg/releases/download/v1.11.10/ghorg_1.11.10_Linux_x86_64.tar.gz
   sha256: 28ccf93b5a320ec31589e1b84d3e58fc5661fbbeb1b6e892ca59346790c96850
   timestamp: 2026-04-24 06:37:36+00:00
+- url: https://github.com/gabrie30/ghorg/releases/download/v1.11.11/ghorg_1.11.11_Linux_arm64.tar.gz
+  sha256: 4c7452fdf81730187579359f6a621139252e4fe5c11f2083b850d514c7f0b310
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/gabrie30/ghorg/releases/download/v1.11.11/ghorg_1.11.11_Linux_x86_64.tar.gz
+  sha256: 3f479d2e6d376114ddb0a24af4774d2f28eb6a735f5d9f3a2d1847df61d85752
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/terminal/ghorg/ops2deb.yml
+++ b/blueprints/terminal/ghorg/ops2deb.yml
@@ -41,6 +41,7 @@ matrix:
     - 1.11.8
     - 1.11.9
     - 1.11.10
+    - 1.11.11
 homepage: https://github.com/gabrie30/ghorg
 summary: quickly clone an entire org/users repositories into one directory
 description: |-

--- a/blueprints/terminal/zellij/ops2deb.lock.yml
+++ b/blueprints/terminal/zellij/ops2deb.lock.yml
@@ -154,3 +154,9 @@
 - url: https://github.com/zellij-org/zellij/releases/download/v0.44.2/zellij-x86_64-unknown-linux-musl.tar.gz
   sha256: 26e1753b4c8451912523c7d8700c5aed75392ea57f0b1c988560f3bbc7775744
   timestamp: 2026-05-05 12:21:36+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.44.3/zellij-aarch64-unknown-linux-musl.tar.gz
+  sha256: 15e6534d42644d66973d136c590c49739dcfd6a1a2a0d3d917973f16c81b45fb
+  timestamp: 2026-05-14 12:33:15+00:00
+- url: https://github.com/zellij-org/zellij/releases/download/v0.44.3/zellij-x86_64-unknown-linux-musl.tar.gz
+  sha256: 0f7c346788627f506c0a28296517768633cff24fc822a739f8264b640ecad751
+  timestamp: 2026-05-14 12:33:15+00:00

--- a/blueprints/terminal/zellij/ops2deb.yml
+++ b/blueprints/terminal/zellij/ops2deb.yml
@@ -30,6 +30,7 @@ matrix:
     - 0.44.0
     - 0.44.1
     - 0.44.2
+    - 0.44.3
 homepage: https://zellij.dev
 summary: terminal workspace with batteries included
 description: |-


### PR DESCRIPTION
Add signal-desktop v8.10.0
Add uv v0.11.14
Remove uv v0.8.21
Add bun v1.3.14
Add pdm v2.26.9
Remove pdm v2.13.3
Add glab v1.97.0
Remove glab v1.54.0
Add typos-cli v1.46.1
Remove typos-cli v1.29.0
Add poetry v2.4.1
Add k6 v2.0.0
Add pyenv v2.6.31
Remove pyenv v2.4.10
Add ghorg v1.11.11
Add zellij v0.44.3
Add dasel v3.10.1
Add oc v4.21.15
Remove oc v4.17.14
Add argocd v3.4.2
Remove argocd v2.12.1
Add tflint v0.62.1
Add terragrunt v1.0.4
Remove terragrunt v0.87.3
Add terraform v1.15.3
Remove terraform v1.7.0
Add rpk v26.1.8
Remove rpk v24.2.1
Add opentofu v1.12.0
Add helmfile v1.5.1
Remove helmfile v0.145.5
Add terraform-docs v0.24.0
Add kubectl v1.36.1
Add helm v4.2.0
Remove helm v3.11.0
Add carvel-ytt v0.55.0
Add clusterctl v1.13.2
Add logcli v3.7.2
Remove logcli v2.5.0
Add mirrord v3.210.0
Remove mirrord v3.159.1
Add rclone v1.74.1
Add flux v2.8.7
Remove flux v0.32.0
Add vuls-scanner v0.39.0
Add sops v3.13.0