### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/dev/github-cli/ops2deb.lock.yml
+++ b/blueprints/dev/github-cli/ops2deb.lock.yml
@@ -10,15 +10,6 @@
 - url: https://github.com/cli/cli/releases/download/v2.5.0/gh_2.5.0_linux_armv6.tar.gz
   sha256: 44e44829a5361957217bfd7c2c8c6dc88fc5f56a72f2e4df772e0ea551a493bd
   timestamp: 2022-02-02 23:13:50+00:00
-- url: https://github.com/cli/cli/releases/download/v2.55.0/gh_2.55.0_linux_amd64.tar.gz
-  sha256: 49700b3fedb5bfcbef696fe9f1f69091ceb9caf2d40bd872b5028c451efc52bc
-  timestamp: 2024-08-20 18:07:10+00:00
-- url: https://github.com/cli/cli/releases/download/v2.55.0/gh_2.55.0_linux_arm64.tar.gz
-  sha256: 2d5d2b965e0122c41752e64873dc33c213b068c1e7a9c396cbd8f6895fb9685f
-  timestamp: 2024-08-20 18:07:10+00:00
-- url: https://github.com/cli/cli/releases/download/v2.55.0/gh_2.55.0_linux_armv6.tar.gz
-  sha256: 7a7f496e4e952867582fcbbd959b8a7cbbfdf715625e396e03f3f2fbd97f26da
-  timestamp: 2024-08-20 18:07:10+00:00
 - url: https://github.com/cli/cli/releases/download/v2.56.0/gh_2.56.0_linux_amd64.tar.gz
   sha256: 82174795823a712c01bb4c81ae00b2bde122b1e956ccb01baec542a3a862f37a
   timestamp: 2024-09-09 15:06:02+00:00
@@ -460,3 +451,12 @@
 - url: https://github.com/cli/cli/releases/download/v2.95.0/gh_2.95.0_linux_armv6.tar.gz
   sha256: b345c22bf9aaf88dcedc6bcb65a3f9b229840a2ec069674f4be813265ad51cb5
   timestamp: 2026-06-18 00:37:26+00:00
+- url: https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz
+  sha256: 83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60
+  timestamp: 2026-07-03 00:27:32+00:00
+- url: https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_arm64.tar.gz
+  sha256: 06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909
+  timestamp: 2026-07-03 00:27:32+00:00
+- url: https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_armv6.tar.gz
+  sha256: 14ff25ec64823415086214fb05b3e85aef21deba6a8d723a7ef8ead1cb977826
+  timestamp: 2026-07-03 00:27:32+00:00

--- a/blueprints/dev/github-cli/ops2deb.yml
+++ b/blueprints/dev/github-cli/ops2deb.yml
@@ -38,7 +38,6 @@
       - arm64
       - armhf
     versions:
-      - 2.55.0
       - 2.56.0
       - 2.57.0
       - 2.58.0
@@ -88,6 +87,7 @@
       - 2.93.0
       - 2.94.0
       - 2.95.0
+      - 2.96.0
   homepage: https://github.com/cli/cli
   summary: GitHub on the command line
   description: |-

--- a/blueprints/dev/go-task/ops2deb.lock.yml
+++ b/blueprints/dev/go-task/ops2deb.lock.yml
@@ -232,3 +232,9 @@
 - url: https://github.com/go-task/task/releases/download/v3.51.1/task_linux_arm64.tar.gz
   sha256: 49c58bb00eff2449a5553f3b3e694fc424e0dc04d5c669d8831126daee1000f8
   timestamp: 2026-05-17 00:26:15+00:00
+- url: https://github.com/go-task/task/releases/download/v3.52.0/task_linux_amd64.tar.gz
+  sha256: 02c679ffae53dca791804847d78b31731615894e292948397c971c87ac9e95bd
+  timestamp: 2026-07-03 00:27:33+00:00
+- url: https://github.com/go-task/task/releases/download/v3.52.0/task_linux_arm64.tar.gz
+  sha256: 7e0044108830cec0534577b289564e3b7c83e6df276feb631a1edc63d04e4ebe
+  timestamp: 2026-07-03 00:27:33+00:00

--- a/blueprints/dev/go-task/ops2deb.yml
+++ b/blueprints/dev/go-task/ops2deb.yml
@@ -43,6 +43,7 @@ matrix:
     - 3.49.1
     - 3.50.0
     - 3.51.1
+    - 3.52.0
 homepage: https://taskfile.dev/
 summary: task runner / simpler Make alternative written in Go
 fetch: https://github.com/go-task/task/releases/download/v{{version}}/task_linux_{{arch}}.tar.gz

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.176.0/mirrord_linux_aarch64.zip
-  sha256: d2f72ef08745037ed1be762798914feb72d923c705c5c738954294cc5db69d8f
-  timestamp: 2025-12-08 06:04:09+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.176.0/mirrord_linux_x86_64.zip
-  sha256: ebd5b9c5c16fd0e4d853842d05f29dbaf613bf9987f1508557b142b8aeabae36
-  timestamp: 2025-12-08 06:04:09+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.177.0/mirrord_linux_aarch64.zip
   sha256: a5efebd573ff0497c81cc670f34782d4b6fc94dfd43b4eab61745c3d80963a9b
   timestamp: 2025-12-19 00:09:36+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.226.0/mirrord_linux_x86_64.zip
   sha256: 7f34a9d943f1aeb6788d354fa241dd9236081067e8638ceec4d8e29c7b064a10
   timestamp: 2026-07-01 18:36:33+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.227.0/mirrord_linux_aarch64.zip
+  sha256: 4d244660330ca41e732de17768ee11afb7016b7cd570ba5ce7585f33a18039d3
+  timestamp: 2026-07-03 00:27:33+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.227.0/mirrord_linux_x86_64.zip
+  sha256: e60ebaeffe0e9cd4c98eb9cd8189d1b0a9d2f98993c5c853760a09def3b119fc
+  timestamp: 2026-07-03 00:27:33+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.176.0
     - 3.177.0
     - 3.178.0
     - 3.179.0
@@ -54,6 +53,7 @@ matrix:
     - 3.224.0
     - 3.225.0
     - 3.226.0
+    - 3.227.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-


### PR DESCRIPTION
Add github-cli v2.96.0
Remove github-cli v2.55.0
Add go-task v3.52.0
Add mirrord v3.227.0
Remove mirrord v3.176.0