### PR TITLE
feat(devops): update minikube to v1.38.1

### DIFF
--- a/blueprints/devops/minikube/ops2deb.lock.yml
+++ b/blueprints/devops/minikube/ops2deb.lock.yml
@@ -184,3 +184,15 @@
 - url: https://storage.googleapis.com/minikube/releases/v1.37.0/minikube-linux-arm64
   sha256: 32f95860fffbbc825be38d05888542f10d3d580fe4d138f4aad71339b8038fb1
   timestamp: 2025-09-10 00:08:08+00:00
+- url: https://storage.googleapis.com/minikube/releases/v1.38.0/minikube-linux-amd64
+  sha256: 6f3fa62bbc3820dbe1f1cffe4beef62c466a8fb1058837781d20d36233dcfa12
+  timestamp: 2026-07-16 11:06:26+00:00
+- url: https://storage.googleapis.com/minikube/releases/v1.38.0/minikube-linux-arm64
+  sha256: e40a00cd9d6ee5d529e3bbff0638d49df644cb3cc4b41841ca3fe7fc2970f392
+  timestamp: 2026-07-16 11:06:26+00:00
+- url: https://storage.googleapis.com/minikube/releases/v1.38.1/minikube-linux-amd64
+  sha256: 099477eaf248bcb5bcea8ce78a2898e93ac01461c35189da1848c3de82ecd22e
+  timestamp: 2026-07-16 11:06:26+00:00
+- url: https://storage.googleapis.com/minikube/releases/v1.38.1/minikube-linux-arm64
+  sha256: a0b8a1ebfc8c07a247271d8df98ac0ddd7c8c855b601d402463e2e50c08c6bab
+  timestamp: 2026-07-16 11:06:26+00:00

--- a/blueprints/devops/minikube/ops2deb.yml
+++ b/blueprints/devops/minikube/ops2deb.yml
@@ -113,3 +113,26 @@
   fetch: https://storage.googleapis.com/minikube/releases/v{{version}}/minikube-linux-{{goarch}}
   install:
     - minikube-linux-{{goarch}}:/usr/bin/minikube
+
+- name: minikube
+  matrix:
+    architectures:
+      - amd64
+      - arm64
+    versions:
+      - 1.38.0
+      - 1.38.1
+  homepage: https://minikube.sigs.k8s.io
+  summary: quickly set up a local Kubernetes cluster
+  description: |-
+    Focus on helping application developers and new Kubernetes users.
+    Supports the latest Kubernetes release (+6 previous minor versions)
+    Cross-platform (Linux, macOS, Windows)
+    Deploy as a VM, a container, or on bare-metal
+    Multiple container runtimes (CRI-O, containerd, docker)
+    Docker API endpoint for blazing fast image pushes
+    Advanced features such as LoadBalancer, filesystem mounts, and FeatureGates
+    Addons for easily installed Kubernetes applications
+  fetch: https://storage.googleapis.com/minikube/releases/v{{version}}/minikube-linux-{{goarch}}
+  install:
+    - minikube-linux-{{goarch}}:/usr/bin/minikube


### PR DESCRIPTION
Upstream stopped publishing 32-bit arm builds with v1.38.0, which stalled the blueprint auto-updater at v1.37.0 — 1.38.x is added as an amd64/arm64-only matrix entry.