### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/dev/github-cli/ops2deb.lock.yml
+++ b/blueprints/dev/github-cli/ops2deb.lock.yml
@@ -10,15 +10,6 @@
 - url: https://github.com/cli/cli/releases/download/v2.5.0/gh_2.5.0_linux_armv6.tar.gz
   sha256: 44e44829a5361957217bfd7c2c8c6dc88fc5f56a72f2e4df772e0ea551a493bd
   timestamp: 2022-02-02 23:13:50+00:00
-- url: https://github.com/cli/cli/releases/download/v2.56.0/gh_2.56.0_linux_amd64.tar.gz
-  sha256: 82174795823a712c01bb4c81ae00b2bde122b1e956ccb01baec542a3a862f37a
-  timestamp: 2024-09-09 15:06:02+00:00
-- url: https://github.com/cli/cli/releases/download/v2.56.0/gh_2.56.0_linux_arm64.tar.gz
-  sha256: 3b15b92705f58a29bb59808fd72b78c6586cfd439b0baa297a1d924f7f016864
-  timestamp: 2024-09-09 15:06:02+00:00
-- url: https://github.com/cli/cli/releases/download/v2.56.0/gh_2.56.0_linux_armv6.tar.gz
-  sha256: 8b58378f46ed6b7edde2e7fe11248ae329347359171703e8a235cbb749f3a4d5
-  timestamp: 2024-09-09 15:06:02+00:00
 - url: https://github.com/cli/cli/releases/download/v2.57.0/gh_2.57.0_linux_amd64.tar.gz
   sha256: d6b3621aa0ca383866716fc664d827a21bd1ac4a918a10c047121d8031892bf8
   timestamp: 2024-09-16 18:07:35+00:00
@@ -460,3 +451,12 @@
 - url: https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_armv6.tar.gz
   sha256: 14ff25ec64823415086214fb05b3e85aef21deba6a8d723a7ef8ead1cb977826
   timestamp: 2026-07-03 00:27:32+00:00
+- url: https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_amd64.tar.gz
+  sha256: a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112
+  timestamp: 2026-07-31 06:55:46+00:00
+- url: https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_arm64.tar.gz
+  sha256: 73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5
+  timestamp: 2026-07-31 06:55:46+00:00
+- url: https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_armv6.tar.gz
+  sha256: 83698de1d91d201cc3b9d9b0beb346c221cadb53a68fb82f741ef0a0efc4502c
+  timestamp: 2026-07-31 06:55:46+00:00

--- a/blueprints/dev/github-cli/ops2deb.yml
+++ b/blueprints/dev/github-cli/ops2deb.yml
@@ -38,7 +38,6 @@
       - arm64
       - armhf
     versions:
-      - 2.56.0
       - 2.57.0
       - 2.58.0
       - 2.59.0
@@ -88,6 +87,7 @@
       - 2.94.0
       - 2.95.0
       - 2.96.0
+      - 2.97.0
   homepage: https://github.com/cli/cli
   summary: GitHub on the command line
   description: |-


### PR DESCRIPTION
Add github-cli v2.97.0
Remove github-cli v2.56.0