### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/dev/hugo/ops2deb.lock.yml
+++ b/blueprints/dev/hugo/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/gohugoio/hugo/releases/download/v0.147.0/hugo_extended_0.147.0_linux-amd64.tar.gz
-  sha256: 8dc6e2d7c7c1a3ecf7abf756068af1b30c8197108ae0cc7ffd83ef2b88f0c26d
-  timestamp: 2025-04-29 18:10:09+00:00
-- url: https://github.com/gohugoio/hugo/releases/download/v0.147.0/hugo_extended_0.147.0_linux-arm64.tar.gz
-  sha256: dc85bc0101c03a8eb5238bbc1e44ed9ce586f4eb294696f9f8d8a6d4232934b5
-  timestamp: 2025-04-29 18:10:09+00:00
 - url: https://github.com/gohugoio/hugo/releases/download/v0.147.1/hugo_extended_0.147.1_linux-amd64.tar.gz
   sha256: 7822d40360c8123a624ac8f3e4305b83908dd76cc7885ae4b00e985dac0b920f
   timestamp: 2025-05-02 00:31:12+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/gohugoio/hugo/releases/download/v0.164.0/hugo_extended_0.164.0_linux-arm64.tar.gz
   sha256: 232d3bc2d1d9510625985ff7c89767598ffea5bc6e5e2882c791313f5a43f723
   timestamp: 2026-07-06 18:36:02+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.165.0/hugo_extended_0.165.0_linux-amd64.tar.gz
+  sha256: f43494894cdf4a8630a201d5c828051c77f523cc66bb3938b30806835470ac20
+  timestamp: 2026-08-12 18:16:32+00:00
+- url: https://github.com/gohugoio/hugo/releases/download/v0.165.0/hugo_extended_0.165.0_linux-arm64.tar.gz
+  sha256: f40ebc44dfda3896cecd3ae7ed44f5c44c4b4a30a2b7d976ece6da62da699a58
+  timestamp: 2026-08-12 18:16:32+00:00

--- a/blueprints/dev/hugo/ops2deb.yml
+++ b/blueprints/dev/hugo/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 0.147.0
     - 0.147.1
     - 0.147.2
     - 0.147.5
@@ -54,6 +53,7 @@ matrix:
     - 0.163.2
     - 0.163.3
     - 0.164.0
+    - 0.165.0
 revision: "2"
 homepage: https://gohugo.io/
 summary: fast and flexible Static Site Generator

--- a/blueprints/dev/lazygit/ops2deb.lock.yml
+++ b/blueprints/dev/lazygit/ops2deb.lock.yml
@@ -172,3 +172,9 @@
 - url: https://github.com/jesseduffield/lazygit/releases/download/v0.64.0/lazygit_0.64.0_Linux_x86_64.tar.gz
   sha256: 7996236f2c1dd2643d96c3d67a1f7fcd2560bf08bcb7f6be073e26fb29167ac6
   timestamp: 2026-08-04 12:35:10+00:00
+- url: https://github.com/jesseduffield/lazygit/releases/download/v0.64.1/lazygit_0.64.1_Linux_arm64.tar.gz
+  sha256: 8b7ca3b344e60340ad1f89f29b9868ee39bcaba5bb92ee818bbe65476bb8b6e7
+  timestamp: 2026-08-12 18:16:32+00:00
+- url: https://github.com/jesseduffield/lazygit/releases/download/v0.64.1/lazygit_0.64.1_Linux_x86_64.tar.gz
+  sha256: f8ea237c41f194cd799b48505518bfdaae4edf5a2ad6bd3d898e939785ee4532
+  timestamp: 2026-08-12 18:16:32+00:00

--- a/blueprints/dev/lazygit/ops2deb.yml
+++ b/blueprints/dev/lazygit/ops2deb.yml
@@ -33,6 +33,7 @@ matrix:
     - 0.63.0
     - 0.63.1
     - 0.64.0
+    - 0.64.1
 homepage: https://github.com/jesseduffield/lazygit
 summary: a lazier way to manage everything git
 description: A simple terminal UI for git, written in Go with the gocui library.

--- a/blueprints/devops/jfrog-cli/ops2deb.lock.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.78.0/jfrog-cli-linux-amd64/jf
-  sha256: 8f6420d26e97c1d8ffb8626ff92f60083b14dd319edf62f003a3e563e5863778
-  timestamp: 2025-07-21 12:03:58+00:00
-- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.78.0/jfrog-cli-linux-arm64/jf
-  sha256: d916cf39b7c3ce11b0e650e27ff183d2a6a697db9f82efb03f04547aea37c0db
-  timestamp: 2025-07-21 12:03:58+00:00
 - url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.78.1/jfrog-cli-linux-amd64/jf
   sha256: 76a1a99c50622cc3f9cd8db7a50f5eb4f8d662a77a2e019fe44703c872d43ac7
   timestamp: 2025-07-23 18:02:52+00:00
@@ -298,3 +292,9 @@
 - url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.119.0/jfrog-cli-linux-arm64/jf
   sha256: 156a6a4f89df70076cfe46ab089444da074b4e297b8b2958cb43399247550384
   timestamp: 2026-08-07 12:14:36+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.120.0/jfrog-cli-linux-amd64/jf
+  sha256: 9ec57d052c478719ac72f6ce25ffdb068952640214e3140052da854187c812b1
+  timestamp: 2026-08-12 18:16:32+00:00
+- url: https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.120.0/jfrog-cli-linux-arm64/jf
+  sha256: 7ff002f099c611d2d2c90353275a417fe1254490f1bd63f13ab24aaff5452b5c
+  timestamp: 2026-08-12 18:16:32+00:00

--- a/blueprints/devops/jfrog-cli/ops2deb.yml
+++ b/blueprints/devops/jfrog-cli/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 2.78.0
     - 2.78.1
     - 2.78.2
     - 2.78.3
@@ -54,6 +53,7 @@ matrix:
     - 2.117.0
     - 2.118.0
     - 2.119.0
+    - 2.120.0
 homepage: https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli
 summary: client that provides a simple interface that automates access to the JFrog
   products

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.193.0/mirrord_linux_aarch64.zip
-  sha256: 8bc4e3b30b09e68cba1c294232304f7c6daefb4d2259d79abb62970837aafe5f
-  timestamp: 2026-03-05 18:33:39+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.193.0/mirrord_linux_x86_64.zip
-  sha256: d732f9fc0921986554d47db70abd0ed96d6688168f68d9481ae865857565fbf8
-  timestamp: 2026-03-05 18:33:39+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.194.0/mirrord_linux_aarch64.zip
   sha256: fe4ce9c62dbacaf5e1c1c20e362c91f79b9355c4fda37de26ce98d1a140489c7
   timestamp: 2026-03-20 06:16:04+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.246.0/mirrord_linux_x86_64.zip
   sha256: 9df23ce5e764ee7b1578122f7799c8c5aec3bae94d81e7c34b05eece2a6c0407
   timestamp: 2026-08-10 18:15:13+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.247.0/mirrord_linux_aarch64.zip
+  sha256: a1959ee70a4bbb0b0c81f9e8c26ea445f129af627418c7997bae3c186c0d1bdd
+  timestamp: 2026-08-12 18:16:32+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.247.0/mirrord_linux_x86_64.zip
+  sha256: 2a7c4b7ae1421bf99f92390f5e941f053be6b2bc74d13bc0710c6df8eae8f9b2
+  timestamp: 2026-08-12 18:16:32+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.193.0
     - 3.194.0
     - 3.204.1
     - 3.205.0
@@ -54,6 +53,7 @@ matrix:
     - 3.244.1
     - 3.245.0
     - 3.246.0
+    - 3.247.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-

--- a/blueprints/devops/nats-server/ops2deb.lock.yml
+++ b/blueprints/devops/nats-server/ops2deb.lock.yml
@@ -151,3 +151,12 @@
 - url: https://github.com/nats-io/nats-server/releases/download/v2.14.4/nats-server-v2.14.4-linux-arm7.tar.gz
   sha256: 52b6039d5652264d1d528650a8feded0a61ad92c5bc2a8cd25e95d6e2606d0e2
   timestamp: 2026-07-30 18:28:02+00:00
+- url: https://github.com/nats-io/nats-server/releases/download/v2.14.5/nats-server-v2.14.5-linux-amd64.tar.gz
+  sha256: 5e3b603d47c447bda1f77f9ac16dbf91c90aac4ff3681f8fbbc7201e4ed99355
+  timestamp: 2026-08-12 18:16:32+00:00
+- url: https://github.com/nats-io/nats-server/releases/download/v2.14.5/nats-server-v2.14.5-linux-arm64.tar.gz
+  sha256: 673a98d3faa79dde3f9ebf16d6dfac36a5f694e7ad2015e4954dd7939c85cd4c
+  timestamp: 2026-08-12 18:16:32+00:00
+- url: https://github.com/nats-io/nats-server/releases/download/v2.14.5/nats-server-v2.14.5-linux-arm7.tar.gz
+  sha256: c8796b63a8603fdebabd63146ac3d3997c29a2829fdd2af6db320f4a287f2e71
+  timestamp: 2026-08-12 18:16:32+00:00

--- a/blueprints/devops/nats-server/ops2deb.yml
+++ b/blueprints/devops/nats-server/ops2deb.yml
@@ -22,6 +22,7 @@ matrix:
     - 2.14.2
     - 2.14.3
     - 2.14.4
+    - 2.14.5
 homepage: https://github.com/nats-io/nats-server
 summary: NATS server implementation
 description: |-


### PR DESCRIPTION
Add hugo v0.165.0
Remove hugo v0.147.0
Add lazygit v0.64.1
Add jfrog-cli v2.120.0
Remove jfrog-cli v2.78.0
Add nats-server v2.14.5
Add mirrord v3.247.0
Remove mirrord v3.193.0