### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/desktop/mattermost-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/mattermost-desktop/ops2deb.lock.yml
@@ -70,3 +70,6 @@
 - url: https://releases.mattermost.com/desktop/6.2.2/mattermost-desktop-6.2.2-linux-x64.tar.gz
   sha256: c7369925307ccd48d5a8a74be6188a64c4458a61453f4c4ab0a5faa63eb421e8
   timestamp: 2026-06-23 07:09:51+00:00
+- url: https://releases.mattermost.com/desktop/6.3.0/mattermost-desktop-6.3.0-linux-x64.tar.gz
+  sha256: 34d0b9c3c67eed0b77cc417758008f17dbd3ee9ab9fda535983e7fb85fcdb7aa
+  timestamp: 2026-08-18 06:06:56+00:00

--- a/blueprints/desktop/mattermost-desktop/ops2deb.yml
+++ b/blueprints/desktop/mattermost-desktop/ops2deb.yml
@@ -4,6 +4,7 @@ matrix:
     - 6.0.4
     - 6.1.2
     - 6.2.2
+    - 6.3.0
 homepage: https://mattermost.com
 summary: desktop application for Mattermost
 description: |-

--- a/blueprints/desktop/signal-desktop/ops2deb.lock.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.lock.yml
@@ -217,3 +217,6 @@
 - url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_8.22.0_amd64.deb
   sha256: 1d92e0986a9b1895f43a1e2e726e85f69c627c621e1d090477b261b4e26ee870
   timestamp: 2026-08-06 00:20:47+00:00
+- url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_8.23.0_amd64.deb
+  sha256: 0de0f0f1e34975a0bfb70e26ff745487255d8c2c0871e1d25f2e2b5a0cffef28
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/desktop/signal-desktop/ops2deb.yml
+++ b/blueprints/desktop/signal-desktop/ops2deb.yml
@@ -27,6 +27,7 @@ matrix:
     - 8.20.0
     - 8.21.0
     - 8.22.0
+    - 8.23.0
 homepage: https://github.com/signalapp/signal-desktop
 summary: private messaging from your desktop
 description: |-

--- a/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.11.5/teams-for-linux_1.11.5_amd64.deb
-  sha256: 4cff078c16636fd3dfb81961c2722b9fde4b9b0bdaccf706500e43703a28d916
-  timestamp: 2024-11-15 06:16:56+00:00
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.12.3/teams-for-linux_1.12.3_amd64.deb
   sha256: 7665b7b8ae3caf4df72d04d609c4969738840bb35d3a3972377fb7ddf1edff68
   timestamp: 2024-12-09 21:06:26+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.14.1/teams-for-linux_2.14.1_amd64.deb
   sha256: c65281d7991d8cec60903d852e5b2a8d8b831d6f7dd032ea7f6b63030aa7a504
   timestamp: 2026-08-02 12:20:12+00:00
+- url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v2.16.0/teams-for-linux_2.16.0_amd64.deb
+  sha256: 1101ebeb89fd6eefa24954c656b18f8f4e2e651ac2195ed697b6905436eb9a71
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/desktop/teams-for-linux/ops2deb.yml
+++ b/blueprints/desktop/teams-for-linux/ops2deb.yml
@@ -1,7 +1,6 @@
 name: teams-for-linux
 matrix:
   versions:
-    - 1.11.5
     - 1.12.3
     - 1.12.5
     - 1.12.6
@@ -51,6 +50,7 @@ matrix:
     - 2.11.1
     - 2.13.0
     - 2.14.1
+    - 2.16.0
 homepage: https://github.com/IsmaelMartinez/teams-for-linux/
 summary: unofficial Microsoft Teams for Linux client
 description: |-

--- a/blueprints/dev/atlas/ops2deb.lock.yml
+++ b/blueprints/dev/atlas/ops2deb.lock.yml
@@ -178,3 +178,9 @@
 - url: https://release.ariga.io/atlas/atlas-community-linux-arm64-v1.3.0
   sha256: 082188c57a53439596a3ee52173b12e785aa83ec718505674e2052db0fec0c4c
   timestamp: 2026-08-02 12:20:12+00:00
+- url: https://release.ariga.io/atlas/atlas-community-linux-amd64-v1.3.1
+  sha256: 521aafcdc4c81a6aee3d553adc97633821a7cb28076ffcdf4add27add930c804
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://release.ariga.io/atlas/atlas-community-linux-arm64-v1.3.1
+  sha256: 4be348491a34610eacd7fd38989f99a565d0c6967172e8784c7db500ec17fae7
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/dev/atlas/ops2deb.yml
+++ b/blueprints/dev/atlas/ops2deb.yml
@@ -34,6 +34,7 @@ matrix:
     - 1.2.2
     - 1.2.3
     - 1.3.0
+    - 1.3.1
 homepage: https://atlasgo.io
 summary: manage your database schema as code
 description: |-

--- a/blueprints/dev/containerlab/ops2deb.lock.yml
+++ b/blueprints/dev/containerlab/ops2deb.lock.yml
@@ -52,3 +52,9 @@
 - url: https://github.com/srl-labs/containerlab/releases/download/v0.78.1/containerlab_0.78.1_linux_arm64.pkg.tar.zst
   sha256: a80fb50721f720b72f2ca751deddb6d333a8a6c6d273c3f22706dbac59133859
   timestamp: 2026-08-12 12:15:13+00:00
+- url: https://github.com/srl-labs/containerlab/releases/download/v0.78.2/containerlab_0.78.2_linux_amd64.pkg.tar.zst
+  sha256: 26fc652811fb4698dbef9ef5beff4d050370a342454d6a7c576260a62fb0ea1a
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/srl-labs/containerlab/releases/download/v0.78.2/containerlab_0.78.2_linux_arm64.pkg.tar.zst
+  sha256: 787a10d653f35768df3663373012e465490449f6e2257e68fb34eff2129069e2
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/dev/containerlab/ops2deb.yml
+++ b/blueprints/dev/containerlab/ops2deb.yml
@@ -13,6 +13,7 @@ matrix:
     - 0.77.0
     - 0.78.0
     - 0.78.1
+    - 0.78.2
 homepage: https://containerlab.dev/
 summary: tool for orchestrating and managing container-based networking labs
 description: |-

--- a/blueprints/dev/pdm/ops2deb.lock.yml
+++ b/blueprints/dev/pdm/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.15.2.tar.gz
-  sha256: 6c2fb315bb7aab18d9f63c428ea7bfef1276b56149d50e488fa729e9cd8a63c8
-  timestamp: 2024-05-08 09:06:10+00:00
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.15.3.tar.gz
   sha256: 3c333e25cf1d2d4f1302a12fe53d0844053a51f49245b11ed2ae9c2f9e48661e
   timestamp: 2024-05-20 12:10:04+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/pdm-project/pdm/archive/refs/tags/2.28.1.tar.gz
   sha256: 6e1e49df91444d754fba37d8253193a2b39804459ee2c911290a00c595bd13f3
   timestamp: 2026-08-11 12:15:00+00:00
+- url: https://github.com/pdm-project/pdm/archive/refs/tags/2.28.2.tar.gz
+  sha256: 800d84951c5f85f38cbf45b555daa80f3e1904c51075d7d96c9ce5f357c3f819
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/dev/pdm/ops2deb.yml
+++ b/blueprints/dev/pdm/ops2deb.yml
@@ -1,7 +1,6 @@
 name: pdm
 matrix:
   versions:
-    - 2.15.2
     - 2.15.3
     - 2.15.4
     - 2.16.0
@@ -51,6 +50,7 @@ matrix:
     - 2.27.0
     - 2.28.0
     - 2.28.1
+    - 2.28.2
 homepage: https://pdm.fming.dev/
 summary: modern Python package and dependency manager supporting the latest PEP standards
 description: |-

--- a/blueprints/dev/pipx/ops2deb.lock.yml
+++ b/blueprints/dev/pipx/ops2deb.lock.yml
@@ -91,3 +91,6 @@
 - url: https://github.com/pypa/pipx/releases/download/1.16.6/pipx.pyz
   sha256: 56900d9a1612b1e58041d8d266b512253f02892f7b857b0744b3ca3e981f0ed2
   timestamp: 2026-08-04 18:30:31+00:00
+- url: https://github.com/pypa/pipx/releases/download/1.16.7/pipx.pyz
+  sha256: 302633d0061e0ab4269257501cbe1338cde5f00f22f121543706624aada0145e
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/dev/pipx/ops2deb.yml
+++ b/blueprints/dev/pipx/ops2deb.yml
@@ -32,6 +32,7 @@ matrix:
     - 1.16.4
     - 1.16.5
     - 1.16.6
+    - 1.16.7
 architecture: all
 homepage: https://github.com/pypa/pipx
 summary: execute binaries from Python packages in isolated environments

--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.19.zip
-  sha256: 3e924e66052f12c2250a92b02222a0a64f83bcc98b600fe10bef780a706d5a75
-  timestamp: 2024-11-20 21:06:28+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.20.zip
   sha256: cf47422cd7fae8fc605e5e1b30202be1ca339861808cb4e242902fd240b9c0e6
   timestamp: 2024-12-04 03:20:42+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.8.3.zip
   sha256: 6105ccede66cc7ee0d5e45ddd0ac7808f527e9b25efbbec5a7098f39068d9186
   timestamp: 2026-08-06 00:20:47+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.8.4.zip
+  sha256: 9a49ded453d32835e224e7638016844183d76e60e15956fb0d8e078a56d3fcd8
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.4.19
       - 2.4.20
       - 2.4.21
       - 2.4.22
@@ -73,6 +72,7 @@
       - 2.8.1
       - 2.8.2
       - 2.8.3
+      - 2.8.4
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/dev/uv/ops2deb.lock.yml
+++ b/blueprints/dev/uv/ops2deb.lock.yml
@@ -448,15 +448,6 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.6.7/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 601c2b1147117c4471a154b4cebbdb31c818105f796d5f8115fe42d2526689c8
   timestamp: 2025-03-18 03:17:18+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.9.21/uv-aarch64-unknown-linux-musl.tar.gz
-  sha256: 03a49fb609888032dbc3be9fd114b50fc9bce8b73b3df319746ae08d1fbdea83
-  timestamp: 2025-12-30 18:03:11+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.9.21/uv-armv7-unknown-linux-gnueabihf.tar.gz
-  sha256: 74b2a73b3569cbba8c73470eb45dfba393401c834dd432fc8bd2039b40b1dde6
-  timestamp: 2025-12-30 18:03:11+00:00
-- url: https://github.com/astral-sh/uv/releases/download/0.9.21/uv-x86_64-unknown-linux-gnu.tar.gz
-  sha256: 0a1ab27383c28ef1c041f85cbbc609d8e3752dfb4b238d2ad97b208a52232baf
-  timestamp: 2025-12-30 18:03:11+00:00
 - url: https://github.com/astral-sh/uv/releases/download/0.9.22/uv-aarch64-unknown-linux-musl.tar.gz
   sha256: a400eaede62557af86bed6c5252a101aa1efd596698bb10c9400334fcc2847ec
   timestamp: 2026-01-06 12:04:28+00:00
@@ -898,3 +889,12 @@
 - url: https://github.com/astral-sh/uv/releases/download/0.12.3/uv-x86_64-unknown-linux-gnu.tar.gz
   sha256: 600cf9a742aca00d292673b16b5acffaa7b8c269a364ad0c2e79498dcb1fe101
   timestamp: 2026-08-07 18:14:43+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.12.5/uv-aarch64-unknown-linux-musl.tar.gz
+  sha256: 8767a0e77f2cd45436401b1b42bf7e9ed5a4a91a74a5305d6fe93249d0f6dbc5
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.12.5/uv-armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: 63f86f3cd92de223c2680dee5149ed3f317ad7aeac774fd7e6fe1f86f53e85da
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/astral-sh/uv/releases/download/0.12.5/uv-x86_64-unknown-linux-gnu.tar.gz
+  sha256: 68a509da24b06b4223a1c0175fb5eb5bc79342b76cbeff0cfe51ac3f5b17b6b2
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/dev/uv/ops2deb.yml
+++ b/blueprints/dev/uv/ops2deb.yml
@@ -87,7 +87,6 @@
       - arm64
       - armhf
     versions:
-      - 0.9.21
       - 0.9.22
       - 0.9.24
       - 0.9.25
@@ -137,6 +136,7 @@
       - 0.12.1
       - 0.12.2
       - 0.12.3
+      - 0.12.5
   homepage: https://github.com/astral-sh/uv
   summary: extremely fast Python package installer and resolver
   description: |-

--- a/blueprints/devops/argo/ops2deb.lock.yml
+++ b/blueprints/devops/argo/ops2deb.lock.yml
@@ -238,3 +238,9 @@
 - url: https://github.com/argoproj/argo-workflows/releases/download/v4.1.0/argo-linux-arm64.gz
   sha256: 426df551c35dff9a5065f22de15ffac81ec2377f316735864d50b4ffe2324259
   timestamp: 2026-08-11 18:16:20+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v4.1.1/argo-linux-amd64.gz
+  sha256: 1d8c374916a2f172f1019c8c38653a1678abcbdc03f53df1e27fae391b250b3b
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/argoproj/argo-workflows/releases/download/v4.1.1/argo-linux-arm64.gz
+  sha256: 3d395d46449cfbd153e459f61c52f87c666a2b207f2a1bbf17856d5b0384df3f
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/devops/argo/ops2deb.yml
+++ b/blueprints/devops/argo/ops2deb.yml
@@ -44,6 +44,7 @@ matrix:
     - 4.0.7
     - 4.0.8
     - 4.1.0
+    - 4.1.1
 homepage: https://argo-workflows.readthedocs.io
 summary: Workflow Engine for Kubernetes
 description: |-

--- a/blueprints/devops/carvel-ytt/ops2deb.lock.yml
+++ b/blueprints/devops/carvel-ytt/ops2deb.lock.yml
@@ -220,3 +220,9 @@
 - url: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.55.1/ytt-linux-arm64
   sha256: ce61f7aee3f66f9b78d5781ef8528b7c8e199a2747796ef17a954118d3e65724
   timestamp: 2026-06-01 13:55:08+00:00
+- url: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.55.2/ytt-linux-amd64
+  sha256: 512cc21193d3b0ce307b6e8db6ba8d40831f16e02526e1c753416456ea4319af
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.55.2/ytt-linux-arm64
+  sha256: 6b09566cd9cbe90050c8685889aa1eef050c3f1168809df2486062e8a3ed1ec0
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/devops/carvel-ytt/ops2deb.yml
+++ b/blueprints/devops/carvel-ytt/ops2deb.yml
@@ -41,6 +41,7 @@ matrix:
     - 0.54.0
     - 0.55.0
     - 0.55.1
+    - 0.55.2
 homepage: https://carvel.dev/ytt/
 summary: YAML templating tool that works on YAML structure instead of text
 description: |-

--- a/blueprints/devops/docker-compose/ops2deb.lock.yml
+++ b/blueprints/devops/docker-compose/ops2deb.lock.yml
@@ -1,15 +1,6 @@
 - url: https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64
   sha256: f3f10cf3dbb8107e9ba2ea5f23c1d2159ff7321d16f0a23051d68d8e2547b323
   timestamp: 2021-12-14 15:37:09+00:00
-- url: https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-linux-aarch64
-  sha256: 7f0023ba726b90347e4ebc1d94ec5970390b8bddb86402c0429f163dca70d745
-  timestamp: 2024-07-23 15:09:36+00:00
-- url: https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-linux-armv7
-  sha256: 0d675f39b3089050d0630a7151580a58abc6c189e64209c6403598b6e9fc0b21
-  timestamp: 2024-07-23 15:09:36+00:00
-- url: https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-linux-x86_64
-  sha256: 5ea89dd65d33912a83737d8a4bf070d5de534a32b8493a21fbefc924484786a9
-  timestamp: 2024-07-23 15:09:36+00:00
 - url: https://github.com/docker/compose/releases/download/v2.29.2/docker-compose-linux-aarch64
   sha256: 1caa6c39b9df88dbd8522403d78b786a4151fa4e881c866725f75b5d99500a9d
   timestamp: 2024-08-16 12:10:01+00:00
@@ -451,3 +442,12 @@
 - url: https://github.com/docker/compose/releases/download/v5.4.0/docker-compose-linux-x86_64
   sha256: 837fd1d35bf6a494f41b5b5988269a7be79de337cf1a1a6ff0e45ab51bb4e9be
   timestamp: 2026-08-03 18:33:02+00:00
+- url: https://github.com/docker/compose/releases/download/v5.5.0/docker-compose-linux-aarch64
+  sha256: ff42489f5a9b879d5d117c5ffea6defc27390b3286da8ad52cbc9c6ab5df590e
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/docker/compose/releases/download/v5.5.0/docker-compose-linux-armv7
+  sha256: 50a7c5bc659f0d619f71f5600b1f15981b99f86df6167d600e0445ef179d5a06
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/docker/compose/releases/download/v5.5.0/docker-compose-linux-x86_64
+  sha256: c57ab918abd5b05ca7e7d0f275875dd1330a695074f309dc9eab1b49efafcd4b
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/devops/docker-compose/ops2deb.yml
+++ b/blueprints/devops/docker-compose/ops2deb.yml
@@ -18,7 +18,6 @@
       - arm64
       - armhf
     versions:
-      - 2.29.1
       - 2.29.2
       - 2.29.3
       - 2.29.4
@@ -68,6 +67,7 @@
       - 5.3.0
       - 5.3.1
       - 5.4.0
+      - 5.5.0
   homepage: https://docs.docker.com/compose
   summary: lightweight development environments using Docker
   description: |-

--- a/blueprints/devops/helm/ops2deb.lock.yml
+++ b/blueprints/devops/helm/ops2deb.lock.yml
@@ -52,12 +52,6 @@
 - url: https://get.helm.sh/helm-v3.9.1-linux-arm64.tar.gz
   sha256: 655dbceb4ab4b246af2214e669b9d44e3a35f170f39df8eebdb8d87619c585d1
   timestamp: 2022-07-13 20:26:10+00:00
-- url: https://get.helm.sh/helm-v3.12.0-linux-amd64.tar.gz
-  sha256: da36e117d6dbc57c8ec5bab2283222fbd108db86c83389eebe045ad1ef3e2c3b
-  timestamp: 2023-05-10 18:32:14+00:00
-- url: https://get.helm.sh/helm-v3.12.0-linux-arm.tar.gz
-  sha256: 1d1d3b0b6397825c3f91ec5f5e66eb415a4199ccfaf063ca399d64854897f3f0
-  timestamp: 2023-05-10 18:32:14+00:00
 - url: https://get.helm.sh/helm-v3.12.1-linux-amd64.tar.gz
   sha256: 1a7074f58ef7190f74ce6db5db0b70e355a655e2013c4d5db2317e63fa9e3dea
   timestamp: 2023-06-14 21:14:57+00:00
@@ -352,3 +346,9 @@
 - url: https://get.helm.sh/helm-v4.2.3-linux-arm.tar.gz
   sha256: ba00678361ca7a03ec42ca1ea459543e1d8eab2a7d5429a5eda71dc9741c8a9b
   timestamp: 2026-07-10 00:27:56+00:00
+- url: https://get.helm.sh/helm-v4.2.4-linux-amd64.tar.gz
+  sha256: c306b46f719b0a4da32d0f78ee21bf90ce8d602f15b22ab753f0674d1670a7f3
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://get.helm.sh/helm-v4.2.4-linux-arm.tar.gz
+  sha256: 894e901f7daaf9b458baad7b5c685bfeef49070d7d53f99687bd5846a6c13639
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/devops/helm/ops2deb.yml
+++ b/blueprints/devops/helm/ops2deb.yml
@@ -42,7 +42,6 @@
       - amd64
       - armhf
     versions:
-      - 3.12.0
       - 3.12.1
       - 3.12.2
       - 3.12.3
@@ -92,6 +91,7 @@
       - 4.2.1
       - 4.2.2
       - 4.2.3
+      - 4.2.4
   homepage: https://helm.sh
   summary: Kubernetes package manager
   description: |-

--- a/blueprints/devops/helmfile/ops2deb.lock.yml
+++ b/blueprints/devops/helmfile/ops2deb.lock.yml
@@ -40,12 +40,6 @@
 - url: https://github.com/roboll/helmfile/releases/download/v0.144.0/helmfile_linux_arm64
   sha256: 8461bbb13ba23f4333dc99d96bf7a24c283cd7683e746acf639d80bbd828926a
   timestamp: 2022-03-31 05:32:30+00:00
-- url: https://github.com/helmfile/helmfile/releases/download/v0.154.0/helmfile_0.154.0_linux_amd64.tar.gz
-  sha256: bc6ace0d37459f5f4f1f3949590e4e7975581ba4dedaf7ba978288ae968c7228
-  timestamp: 2023-05-24 01:35:33+00:00
-- url: https://github.com/helmfile/helmfile/releases/download/v0.154.0/helmfile_0.154.0_linux_arm64.tar.gz
-  sha256: 2f8775448c42e9865a969f8227763db01ad6cde5898646619ccdaea7c06d4434
-  timestamp: 2023-05-24 01:35:33+00:00
 - url: https://github.com/helmfile/helmfile/releases/download/v0.155.0/helmfile_0.155.0_linux_amd64.tar.gz
   sha256: 2c9cf4e2e41207f066a0b6013ce878f49492fe7126c69a7718d3e0a637d2649c
   timestamp: 2023-06-29 06:25:18+00:00
@@ -340,3 +334,9 @@
 - url: https://github.com/helmfile/helmfile/releases/download/v1.7.3/helmfile_1.7.3_linux_arm64.tar.gz
   sha256: 4a2346df40362f49f395e47d5d6a16a29322b5c6968720c1bde60d101ae97e3b
   timestamp: 2026-08-05 00:24:41+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.7.4/helmfile_1.7.4_linux_amd64.tar.gz
+  sha256: f96ef0a015df06b29d7f38bf0ca08821018ae25eb96bf2c7abd3affa1b84e112
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/helmfile/helmfile/releases/download/v1.7.4/helmfile_1.7.4_linux_arm64.tar.gz
+  sha256: 0292f57a4638a21e775b0ce8bde37ee3fdd65dbbdbe0e5b9a06718f1dd04c7fa
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/devops/helmfile/ops2deb.yml
+++ b/blueprints/devops/helmfile/ops2deb.yml
@@ -79,7 +79,6 @@
       - amd64
       - arm64
     versions:
-      - 0.154.0
       - 0.155.0
       - 0.155.1
       - 0.156.0
@@ -129,6 +128,7 @@
       - 1.7.1
       - 1.7.2
       - 1.7.3
+      - 1.7.4
   homepage: https://helmfile.readthedocs.io/
   summary: deploy Kubernetes Helm Charts
   description: |-

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.194.0/mirrord_linux_aarch64.zip
-  sha256: fe4ce9c62dbacaf5e1c1c20e362c91f79b9355c4fda37de26ce98d1a140489c7
-  timestamp: 2026-03-20 06:16:04+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.194.0/mirrord_linux_x86_64.zip
-  sha256: 0eb15fb27264d08a234219cb11d57ea074099448aa3474171d4c3057c63dc1f8
-  timestamp: 2026-03-20 06:16:04+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.204.1/mirrord_linux_aarch64.zip
   sha256: 2f6d343d7ce8e7e3c1204add492eff802b667ecf6e76e7387aafa028a679f696
   timestamp: 2026-04-24 06:37:37+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.247.0/mirrord_linux_x86_64.zip
   sha256: 2a7c4b7ae1421bf99f92390f5e941f053be6b2bc74d13bc0710c6df8eae8f9b2
   timestamp: 2026-08-12 18:16:32+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.249.0/mirrord_linux_aarch64.zip
+  sha256: 9c8e8274924c6934fea14c9dc039f612271dc827125a6d8aaaae80aa62acee84
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.249.0/mirrord_linux_x86_64.zip
+  sha256: c5c8bff4b6fc9f8b569a8bea4f3d6227584771238597f2445e43ca8b94c5d775
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.194.0
     - 3.204.1
     - 3.205.0
     - 3.206.0
@@ -54,6 +53,7 @@ matrix:
     - 3.245.0
     - 3.246.0
     - 3.247.0
+    - 3.249.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -4,12 +4,6 @@
 - url: https://github.com/okd-project/okd/releases/download/4.15.0-0.okd-2024-03-10-010116/openshift-client-linux-4.15.0-0.okd-2024-03-10-010116.tar.gz
   sha256: 90a357d420008494e0ea898801ddf39da11cab4270b778ee01a72bda7835a3a9
   timestamp: 2024-11-25 11:13:58+00:00
-- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.16/openshift-client-linux-arm64.tar.gz
-  sha256: da8f1d9170956d6bd891e5ee6e9cf49c89e98a6483a4a01fc134173717c52bbb
-  timestamp: 2025-05-29 21:06:50+00:00
-- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.16/openshift-client-linux.tar.gz
-  sha256: 746073ce8409476078102bed7b26316c419c192aa27c69de0ce01b5774958d00
-  timestamp: 2025-05-29 21:06:50+00:00
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.17/openshift-client-linux-arm64.tar.gz
   sha256: afc352ddcaac65e6f58e632de0ecaffe7cf4e64dc8a062fa32dbc55405d03f1e
   timestamp: 2025-06-05 15:07:37+00:00
@@ -304,3 +298,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.22.9/openshift-client-linux.tar.gz
   sha256: 76e22160684a4313daec380437abf54a029bddc3249a824928a84379069840d1
   timestamp: 2026-08-07 01:08:55+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.22.10/openshift-client-linux-arm64.tar.gz
+  sha256: 11a1a741343fbd943dd4c11282be4c38d2db6200c6d362dfe4697156bc3f1fc3
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.22.10/openshift-client-linux.tar.gz
+  sha256: f426abdc0bafd712ddac75444e88cd01bb47a331f1a9a3128419afd19848670b
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 4.18.16
     - 4.18.17
     - 4.19.0
     - 4.19.1
@@ -54,6 +53,7 @@ matrix:
     - 4.22.7
     - 4.22.8
     - 4.22.9
+    - 4.22.10
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.89.1/terragrunt_linux_amd64
-  sha256: 5dad2962dce8dbe867a457e3ac6b0d9298ff557dc5d4e675064235360bc6f381
-  timestamp: 2025-10-07 18:03:28+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.89.1/terragrunt_linux_arm64
-  sha256: fb4515134c21601f21a4823e4331a53ed344baf68df41f039477a0678349ca79
-  timestamp: 2025-10-07 18:03:28+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.89.2/terragrunt_linux_amd64
   sha256: 6a1f5b06c5a0f66e93eafc0b0f70bf1f57b54c56a350815b0498eee8aa3a48fa
   timestamp: 2025-10-08 00:07:59+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.2/terragrunt_linux_arm64
   sha256: 256c434e48afa9827f591e7aa059d283b57225c1bd951c5b9544469b3b5406f0
   timestamp: 2026-07-30 00:22:42+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.3/terragrunt_linux_amd64
+  sha256: d5da6a66741f4ee752aa3b502b57e47fd6d5c178942861b2507f14f083e7606e
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.3/terragrunt_linux_arm64
+  sha256: 5e9b388402ab7075e907e8d8511662e2a828008129746e4e5e23de04c7b78ef4
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.89.1
       - 0.89.2
       - 0.89.3
       - 0.89.4
@@ -75,6 +74,7 @@
       - 1.1.0
       - 1.1.1
       - 1.1.2
+      - 1.1.3
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-

--- a/blueprints/secops/trivy/ops2deb.lock.yml
+++ b/blueprints/secops/trivy/ops2deb.lock.yml
@@ -412,12 +412,6 @@
 - url: https://github.com/aquasecurity/trivy/releases/download/v0.42.1/trivy_0.42.1_Linux-ARM64.tar.gz
   sha256: cad74fc7c0a6a96ad0721987acda2e529b0b77db754c67e65bec8667b50d9ca5
   timestamp: 2023-06-08 15:17:30+00:00
-- url: https://github.com/aquasecurity/trivy/releases/download/v0.50.2/trivy_0.50.2_Linux-64bit.tar.gz
-  sha256: 86c71ebfefcc6c816f072704e4b20e815cee9caa9c403572825318fbc810cb39
-  timestamp: 2024-04-22 15:05:56+00:00
-- url: https://github.com/aquasecurity/trivy/releases/download/v0.50.2/trivy_0.50.2_Linux-ARM64.tar.gz
-  sha256: 95184e6f9c82c6b6c19653f0c095789cf237c268e1311461aa3de08aea85ac7d
-  timestamp: 2024-04-22 15:05:56+00:00
 - url: https://github.com/aquasecurity/trivy/releases/download/v0.50.4/trivy_0.50.4_Linux-64bit.tar.gz
   sha256: b0d135815867246baba52f608f4af84beca90cfeb17a9ce407a21acca760ace1
   timestamp: 2024-04-24 15:05:59+00:00
@@ -712,3 +706,9 @@
 - url: https://github.com/aquasecurity/trivy/releases/download/v0.73.0/trivy_0.73.0_Linux-ARM64.tar.gz
   sha256: 13833d97e8a1a5367471c372a173180157f593bece570e20d5d925fef552f5dd
   timestamp: 2026-08-03 12:59:59+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.74.0/trivy_0.74.0_Linux-64bit.tar.gz
+  sha256: 2ae6fe3ee734b7fdf11335663e18c75ea12dccc76062f09f164a3b0f8be4371a
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/aquasecurity/trivy/releases/download/v0.74.0/trivy_0.74.0_Linux-ARM64.tar.gz
+  sha256: b94ce1976bbf3c15b514b605ee88be7c6d94a29be2302847ff01cb794d47aad5
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/secops/trivy/ops2deb.yml
+++ b/blueprints/secops/trivy/ops2deb.yml
@@ -70,7 +70,6 @@
       - amd64
       - arm64
     versions:
-      - 0.50.2
       - 0.50.4
       - 0.51.0
       - 0.51.1
@@ -120,6 +119,7 @@
       - 0.71.2
       - 0.72.0
       - 0.73.0
+      - 0.74.0
   homepage: https://www.aquasec.com/products/trivy/
   summary: vulnerability and misconfiguration scanner
   description: |-

--- a/blueprints/terminal/bottom/ops2deb.lock.yml
+++ b/blueprints/terminal/bottom/ops2deb.lock.yml
@@ -196,3 +196,9 @@
 - url: https://github.com/ClementTsang/bottom/releases/download/0.14.7/bottom_x86_64-unknown-linux-gnu.tar.gz
   sha256: 60d772f8227793ef205c2bb52e396e26c328cd910e96026cd3009c3c68f37c27
   timestamp: 2026-07-27 18:29:52+00:00
+- url: https://github.com/ClementTsang/bottom/releases/download/0.14.8/bottom_armv7-unknown-linux-gnueabihf.tar.gz
+  sha256: 4c296b5d0bbe164d630c4ae64d09ee12e15c9635c4c02957871f8089b3a3ef89
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/ClementTsang/bottom/releases/download/0.14.8/bottom_x86_64-unknown-linux-gnu.tar.gz
+  sha256: 1e29fb2b0230c8285665d107fc370493e61369433d9e0b9398f6bec19624fa50
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/terminal/bottom/ops2deb.yml
+++ b/blueprints/terminal/bottom/ops2deb.yml
@@ -56,6 +56,7 @@
       - 0.14.5
       - 0.14.6
       - 0.14.7
+      - 0.14.8
   homepage: https://clementtsang.github.io/bottom
   summary: cross-platform graphical process/system monitor
   description: |-

--- a/blueprints/terminal/fzf/ops2deb.lock.yml
+++ b/blueprints/terminal/fzf/ops2deb.lock.yml
@@ -154,3 +154,9 @@
 - url: https://github.com/junegunn/fzf/releases/download/v0.74.2/fzf-0.74.2-linux_arm64.tar.gz
   sha256: 1373e3f5ed3c468179d4529942ddd96c234bcad1bcacaf238916e26a5234b5b2
   timestamp: 2026-08-01 00:23:40+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.74.3/fzf-0.74.3-linux_amd64.tar.gz
+  sha256: 3501a595e4b5c40a6b047340a0e8f805c46fd4e61ef95ef8a136ba8c61cf6f22
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/junegunn/fzf/releases/download/v0.74.3/fzf-0.74.3-linux_arm64.tar.gz
+  sha256: 4a17a17b46bd0c4873e995533de508995c11572c0be0664a5dbcf13f60463046
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/terminal/fzf/ops2deb.yml
+++ b/blueprints/terminal/fzf/ops2deb.yml
@@ -30,6 +30,7 @@ matrix:
     - 0.74.0
     - 0.74.1
     - 0.74.2
+    - 0.74.3
 homepage: https://junegunn.github.io/fzf/
 summary: A command-line fuzzy finder in Go
 description: |-

--- a/blueprints/terminal/nushell/ops2deb.lock.yml
+++ b/blueprints/terminal/nushell/ops2deb.lock.yml
@@ -34,12 +34,6 @@
 - url: https://github.com/nushell/nushell/releases/download/0.70.0/nu-0.70.0-x86_64-unknown-linux-gnu.tar.gz
   sha256: 97c4ec8f7167fe13411556e38533cdb72e76fd5858ee49d7772728e9f6b8dcc7
   timestamp: 2022-10-19 04:33:25+00:00
-- url: https://github.com/nushell/nushell/releases/download/0.79.0/nu-0.79.0-aarch64-unknown-linux-gnu.tar.gz
-  sha256: db65aa46b74720cd0aa73c313ccda8a359a34b8a07a45996b04c234a9f25efad
-  timestamp: 2023-04-26 01:23:39+00:00
-- url: https://github.com/nushell/nushell/releases/download/0.79.0/nu-0.79.0-x86_64-unknown-linux-gnu.tar.gz
-  sha256: 49b8b37ac084327478a029381ff33d123029b2efaee5fde84c9fd3f2838984bb
-  timestamp: 2023-04-26 01:23:39+00:00
 - url: https://github.com/nushell/nushell/releases/download/0.80.0/nu-0.80.0-aarch64-unknown-linux-gnu.tar.gz
   sha256: b02d8a002926e12e5d0b0a04d4af887c7053deb2aaf11e49f6ed82b63ecc25b8
   timestamp: 2023-05-17 01:26:26+00:00
@@ -334,3 +328,9 @@
 - url: https://github.com/nushell/nushell/releases/download/0.114.1/nu-0.114.1-x86_64-unknown-linux-gnu.tar.gz
   sha256: 8802b26edcdf1a64477567b5ce909fbae3d72d731c8f0847892ea16c6fa73c53
   timestamp: 2026-07-11 18:16:51+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.115.0/nu-0.115.0-aarch64-unknown-linux-gnu.tar.gz
+  sha256: 508f00f858474e754335bea741c8f729b8ae526451aa01b9c1e36944311b846a
+  timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/nushell/nushell/releases/download/0.115.0/nu-0.115.0-x86_64-unknown-linux-gnu.tar.gz
+  sha256: da83cfe482060d2c34b6b9af829975a313bce6b92e0398c3b2a59cb38630c7b2
+  timestamp: 2026-08-18 06:06:55+00:00

--- a/blueprints/terminal/nushell/ops2deb.yml
+++ b/blueprints/terminal/nushell/ops2deb.yml
@@ -72,7 +72,6 @@
       - amd64
       - arm64
     versions:
-      - 0.79.0
       - 0.80.0
       - 0.81.0
       - 0.82.0
@@ -122,6 +121,7 @@
       - 0.113.1
       - 0.114.0
       - 0.114.1
+      - 0.115.0
   homepage: https://www.nushell.sh/
   summary: new type of shell written in rust
   description: |-


### PR DESCRIPTION
Add mirrord v3.249.0
Remove mirrord v3.194.0
Add helmfile v1.7.4
Remove helmfile v0.154.0
Add terragrunt v1.1.3
Remove terragrunt v0.89.1
Add helm v4.2.4
Remove helm v3.12.0
Add carvel-ytt v0.55.2
Add docker-compose v5.5.0
Remove docker-compose v2.29.1
Add oc v4.22.10
Remove oc v4.18.16
Add argo v4.1.1
Add nushell v0.115.0
Remove nushell v0.79.0
Add bottom v0.14.8
Add fzf v0.74.3
Add trivy v0.74.0
Remove trivy v0.50.2
Add atlas v1.3.1
Add uv v0.12.5
Remove uv v0.9.21
Add containerlab v0.78.2
Add pdm v2.28.2
Remove pdm v2.15.2
Add pyenv v2.8.4
Remove pyenv v2.4.19
Add pipx v1.16.7
Add teams-for-linux v2.16.0
Remove teams-for-linux v1.11.5
Add signal-desktop v8.23.0
Add mattermost-desktop v6.3.0