### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/dev/typos-cli/ops2deb.lock.yml
+++ b/blueprints/dev/typos-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/crate-ci/typos/releases/download/v1.31.1/typos-v1.31.1-x86_64-unknown-linux-musl.tar.gz
-  sha256: f683c2abeaff70379df7176110100e18150ecd17a4b9785c32908aca11929993
-  timestamp: 2025-04-02 21:25:10+00:00
 - url: https://github.com/crate-ci/typos/releases/download/v1.31.2/typos-v1.31.2-x86_64-unknown-linux-musl.tar.gz
   sha256: db179d95b35b5e84e7e85e85aef6302c93ffc26e849fe966e1bb7f121d97976e
   timestamp: 2025-04-29 18:10:09+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/crate-ci/typos/releases/download/v1.49.0/typos-v1.49.0-x86_64-unknown-linux-musl.tar.gz
   sha256: 48bd2d58e02ce713b8c0f1aa239e68ee4f7d8c551013135806e6aed3938d9e10
   timestamp: 2026-08-03 18:33:02+00:00
+- url: https://github.com/crate-ci/typos/releases/download/v1.49.1/typos-v1.49.1-x86_64-unknown-linux-musl.tar.gz
+  sha256: 467c88326d29b225263a64efcc47729bfea2b5b9b5e787de0002b8ddb9f2efc9
+  timestamp: 2026-08-27 21:10:30+00:00

--- a/blueprints/dev/typos-cli/ops2deb.yml
+++ b/blueprints/dev/typos-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: typos-cli
 matrix:
   versions:
-    - 1.31.1
     - 1.31.2
     - 1.32.0
     - 1.33.1
@@ -51,6 +50,7 @@ matrix:
     - 1.47.2
     - 1.48.0
     - 1.49.0
+    - 1.49.1
 homepage: https://github.com/crate-ci/typos/
 summary: source code spell checker
 description: |-

--- a/blueprints/devops/logcli/ops2deb.lock.yml
+++ b/blueprints/devops/logcli/ops2deb.lock.yml
@@ -1,12 +1,3 @@
-- url: https://github.com/grafana/loki/releases/download/v2.7.2/logcli-linux-amd64.zip
-  sha256: ae9d78a6703b4593a973e3add8f11abac54246626a2be2443e400093a3a354ab
-  timestamp: 2023-01-26 22:16:31+00:00
-- url: https://github.com/grafana/loki/releases/download/v2.7.2/logcli-linux-arm.zip
-  sha256: 70c51bb938998c8e61d307abe601da6d45ff7559c7b424e2321685a765a48228
-  timestamp: 2023-01-26 22:16:31+00:00
-- url: https://github.com/grafana/loki/releases/download/v2.7.2/logcli-linux-arm64.zip
-  sha256: 149e645cc68a38f0ba2316cabd8dce75609ce069b9af73a7a6875298f0e0fcd7
-  timestamp: 2023-01-26 22:16:31+00:00
 - url: https://github.com/grafana/loki/releases/download/v2.7.3/logcli-linux-amd64.zip
   sha256: d295d510e5eca6f2437acc085aba399ea4274705d1fec436cf916919c75cec45
   timestamp: 2023-02-01 16:20:09+00:00
@@ -448,3 +439,12 @@
 - url: https://github.com/grafana/loki/releases/download/v3.7.6/logcli-linux-arm64.zip
   sha256: 9223db8936987910a39d3063945e7024e1abe454fea25b5bf7dc1f429c8ab246
   timestamp: 2026-08-06 12:34:44+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.7.7/logcli-linux-amd64.zip
+  sha256: 4b1c7177291056c3c0ab9a40745b73ec9d9daf3efa3ff857c923ef1cf4a96d23
+  timestamp: 2026-08-27 21:10:30+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.7.7/logcli-linux-arm.zip
+  sha256: 1aac0127c40c12b13b2668b14582b0f50d73fbbabf284a091c185c8c1bbbe12f
+  timestamp: 2026-08-27 21:10:30+00:00
+- url: https://github.com/grafana/loki/releases/download/v3.7.7/logcli-linux-arm64.zip
+  sha256: 39d138cd3f9959b6d297d111f2c44ab10a0a6f2bb8fc1d8f7967e8368b324f75
+  timestamp: 2026-08-27 21:10:30+00:00

--- a/blueprints/devops/logcli/ops2deb.yml
+++ b/blueprints/devops/logcli/ops2deb.yml
@@ -5,7 +5,6 @@ matrix:
     - arm64
     - armhf
   versions:
-    - 2.7.2
     - 2.7.3
     - 2.7.4
     - 2.7.5
@@ -55,6 +54,7 @@ matrix:
     - 3.7.4
     - 3.7.5
     - 3.7.6
+    - 3.7.7
 homepage: https://github.com/grafana/loki
 summary: command-line interface for loki
 description: It facilitates running LogQL queries against a Loki instance.

--- a/blueprints/devops/oc/ops2deb.lock.yml
+++ b/blueprints/devops/oc/ops2deb.lock.yml
@@ -4,12 +4,6 @@
 - url: https://github.com/okd-project/okd/releases/download/4.15.0-0.okd-2024-03-10-010116/openshift-client-linux-4.15.0-0.okd-2024-03-10-010116.tar.gz
   sha256: 90a357d420008494e0ea898801ddf39da11cab4270b778ee01a72bda7835a3a9
   timestamp: 2024-11-25 11:13:58+00:00
-- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.19.0/openshift-client-linux-arm64.tar.gz
-  sha256: 4e503d9aa789c64af3ed5b77c3dcb9fb2daf8dad66a8e323310a069b28b2bf49
-  timestamp: 2025-06-13 18:09:26+00:00
-- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.19.0/openshift-client-linux.tar.gz
-  sha256: c90254d7ededb6da4f6d3911fbe6d7d2e35654a480d684f5d2e502e8be7cd6fd
-  timestamp: 2025-06-13 18:09:26+00:00
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.19.1/openshift-client-linux-arm64.tar.gz
   sha256: ce32a6b97b996c55314123d4fc6c05e0241112121794a12e6996a4dcea7bf2c2
   timestamp: 2025-06-20 06:10:27+00:00
@@ -304,3 +298,9 @@
 - url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.22.11/openshift-client-linux.tar.gz
   sha256: b2dde2a24ed069623579e5624c2f8ed6818c7c123e99b3729366afc7d8bc9629
   timestamp: 2026-08-22 00:06:46+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.22.12/openshift-client-linux-arm64.tar.gz
+  sha256: 38ebb9606454ceb81cfffd0356ce72fa29b91a27ba1597177d2e3c98136bf904
+  timestamp: 2026-08-27 21:10:30+00:00
+- url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.22.12/openshift-client-linux.tar.gz
+  sha256: 0234aed5f4f13fbd0ff693c9eb8011bbfd97f1829296157c39810494b98cf84c
+  timestamp: 2026-08-27 21:10:30+00:00

--- a/blueprints/devops/oc/ops2deb.yml
+++ b/blueprints/devops/oc/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 4.19.0
     - 4.19.1
     - 4.19.2
     - 4.19.3
@@ -54,6 +53,7 @@ matrix:
     - 4.22.9
     - 4.22.10
     - 4.22.11
+    - 4.22.12
 homepage: https://openshift.com
 summary: command line client for controlling an Openshift cluster
 description: |-

--- a/blueprints/devops/terragrunt/ops2deb.lock.yml
+++ b/blueprints/devops/terragrunt/ops2deb.lock.yml
@@ -28,12 +28,6 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.36.7/terragrunt_linux_arm64
   sha256: fd52f5113ef9ba0e54bfbc8a2b82a9532814ceeafe505ecba2de76d5b19f105a
   timestamp: 2022-04-15 14:36:34+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.89.2/terragrunt_linux_amd64
-  sha256: 6a1f5b06c5a0f66e93eafc0b0f70bf1f57b54c56a350815b0498eee8aa3a48fa
-  timestamp: 2025-10-08 00:07:59+00:00
-- url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.89.2/terragrunt_linux_arm64
-  sha256: 48ec0e6d48dd246813730338e344fb9bc46525530068d658879a508e23abf357
-  timestamp: 2025-10-08 00:07:59+00:00
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v0.89.3/terragrunt_linux_amd64
   sha256: 738c3094442d72ca4bd0cf0eaef097f2f4c0bfd0e6f742597318257c3e95fef0
   timestamp: 2025-10-08 18:03:16+00:00
@@ -328,3 +322,9 @@
 - url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.3/terragrunt_linux_arm64
   sha256: 5e9b388402ab7075e907e8d8511662e2a828008129746e4e5e23de04c7b78ef4
   timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.4/terragrunt_linux_amd64
+  sha256: a2640da8455fa5f3671167e6373832b0907b9dc972dd01c2093cc7808934e158
+  timestamp: 2026-08-27 21:10:30+00:00
+- url: https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.4/terragrunt_linux_arm64
+  sha256: c65d1897446590ebb3c695835cc956c12c5374a9add8312517c83c9fd7a1c06b
+  timestamp: 2026-08-27 21:10:30+00:00

--- a/blueprints/devops/terragrunt/ops2deb.yml
+++ b/blueprints/devops/terragrunt/ops2deb.yml
@@ -25,7 +25,6 @@
       - amd64
       - arm64
     versions:
-      - 0.89.2
       - 0.89.3
       - 0.89.4
       - 0.90.0
@@ -75,6 +74,7 @@
       - 1.1.1
       - 1.1.2
       - 1.1.3
+      - 1.1.4
   homepage: https://terragrunt.gruntwork.io/
   summary: provides extra tools for working with multiple Terraform modules
   description: |-


### PR DESCRIPTION
Add terragrunt v1.1.4
Remove terragrunt v0.89.2
Add logcli v3.7.7
Remove logcli v2.7.2
Add oc v4.22.12
Remove oc v4.19.0
Add typos-cli v1.49.1
Remove typos-cli v1.31.1