### PR TITLE
chore(bot): update blueprints

### DIFF
--- a/blueprints/dev/glab/ops2deb.lock.yml
+++ b/blueprints/dev/glab/ops2deb.lock.yml
@@ -199,12 +199,6 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.46.1/downloads/glab_1.46.1_Linux_x86_64.deb
   sha256: bf8c53df12d23bf204cba7ae499c4721009e64b2a39277c814759000ac4d3fdd
   timestamp: 2024-09-10 21:06:11+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.68.0/downloads/glab_1.68.0_linux_amd64.deb
-  sha256: 7e0956336acac6e97fdf0d7406dc244bb99e5130bbf34347ee3f7c5bf7d3c0c0
-  timestamp: 2025-09-05 00:08:35+00:00
-- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.68.0/downloads/glab_1.68.0_linux_arm64.deb
-  sha256: 395bc7cd72fe77aaa975c3c055ce81f66ed64e92d5d37dc80d72befea485454e
-  timestamp: 2025-09-05 00:08:35+00:00
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.70.0/downloads/glab_1.70.0_linux_amd64.deb
   sha256: 9774a782531139c23d56a538c819690244a44465ad6c324295f79db058de16fa
   timestamp: 2025-11-01 11:48:24+00:00
@@ -499,3 +493,9 @@
 - url: https://gitlab.com/gitlab-org/cli/-/releases/v1.115.0/downloads/glab_1.115.0_linux_arm64.deb
   sha256: 47378f8c7d431dc927a662b5f966ce4ae1b26e760617276eefff9de585df7914
   timestamp: 2026-08-26 00:07:13+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.116.0/downloads/glab_1.116.0_linux_amd64.deb
+  sha256: c04a2413b12b9ff17047f430d2ef0e93ef9713f5650e06a61ae7092fdfdd284d
+  timestamp: 2026-09-01 18:05:54+00:00
+- url: https://gitlab.com/gitlab-org/cli/-/releases/v1.116.0/downloads/glab_1.116.0_linux_arm64.deb
+  sha256: be786ecf935dc7947b78f8e2c7cf720db3853798ec6414e79ecf806290b1f4f7
+  timestamp: 2026-09-01 18:05:54+00:00

--- a/blueprints/dev/glab/ops2deb.yml
+++ b/blueprints/dev/glab/ops2deb.yml
@@ -56,7 +56,6 @@
       - amd64
       - arm64
     versions:
-      - 1.68.0
       - 1.70.0
       - 1.71.0
       - 1.71.1
@@ -106,6 +105,7 @@
       - 1.113.0
       - 1.114.0
       - 1.115.0
+      - 1.116.0
   homepage: https://gitlab.com/gitlab-org/cli
   summary: Gitlab on the command line
   description: |-

--- a/blueprints/dev/pyenv/ops2deb.lock.yml
+++ b/blueprints/dev/pyenv/ops2deb.lock.yml
@@ -4,9 +4,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.2.4-1.zip
   sha256: 6e5e8223de00c28b8ab5de89bf8a7a12e944d0d1a1570682a7bc102538833da2
   timestamp: 2022-01-27 19:24:18+00:00
-- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.20.zip
-  sha256: cf47422cd7fae8fc605e5e1b30202be1ca339861808cb4e242902fd240b9c0e6
-  timestamp: 2024-12-04 03:20:42+00:00
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.21.zip
   sha256: d15fd4656bfc9e8cc363c3b2ae6ee19c62060b810354a1e619ab2750776d6374
   timestamp: 2024-12-06 00:29:36+00:00
@@ -154,3 +151,6 @@
 - url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.8.4.zip
   sha256: 9a49ded453d32835e224e7638016844183d76e60e15956fb0d8e078a56d3fcd8
   timestamp: 2026-08-18 06:06:55+00:00
+- url: https://github.com/pyenv/pyenv/archive/refs/tags/v2.8.5.zip
+  sha256: 5233bd3c5bd4fdccd7bbe217104afaa90ff42a671dce0bc37e0c0f6f60c30317
+  timestamp: 2026-09-01 18:05:54+00:00

--- a/blueprints/dev/pyenv/ops2deb.yml
+++ b/blueprints/dev/pyenv/ops2deb.yml
@@ -23,7 +23,6 @@
 - name: pyenv
   matrix:
     versions:
-      - 2.4.20
       - 2.4.21
       - 2.4.22
       - 2.4.23
@@ -73,6 +72,7 @@
       - 2.8.2
       - 2.8.3
       - 2.8.4
+      - 2.8.5
   architecture: all
   homepage: https://github.com/pyenv/pyenv
   summary: simple Python version management

--- a/blueprints/dev/typos-cli/ops2deb.lock.yml
+++ b/blueprints/dev/typos-cli/ops2deb.lock.yml
@@ -1,6 +1,3 @@
-- url: https://github.com/crate-ci/typos/releases/download/v1.32.0/typos-v1.32.0-x86_64-unknown-linux-musl.tar.gz
-  sha256: 4c8e7e360fc855a6f9b721c2eab22966a0f33aa0f284772b136ea8847f136864
-  timestamp: 2025-05-02 15:06:57+00:00
 - url: https://github.com/crate-ci/typos/releases/download/v1.33.1/typos-v1.33.1-x86_64-unknown-linux-musl.tar.gz
   sha256: ab807b29e9d759428c8a0444c14973225b6710a286f264574892972428c3d18b
   timestamp: 2025-06-02 18:09:23+00:00
@@ -148,3 +145,6 @@
 - url: https://github.com/crate-ci/typos/releases/download/v1.50.0/typos-v1.50.0-x86_64-unknown-linux-musl.tar.gz
   sha256: a1497c9626ba0bab731b3e37c12ac9051bbfa2a253463d4d574c28f190b5497b
   timestamp: 2026-08-28 21:22:26+00:00
+- url: https://github.com/crate-ci/typos/releases/download/v1.50.1/typos-v1.50.1-x86_64-unknown-linux-musl.tar.gz
+  sha256: edf0545109aee6a22751d04ddecb97c45be47d3aa0409564fb895eeeace91b1e
+  timestamp: 2026-09-01 18:05:54+00:00

--- a/blueprints/dev/typos-cli/ops2deb.yml
+++ b/blueprints/dev/typos-cli/ops2deb.yml
@@ -1,7 +1,6 @@
 name: typos-cli
 matrix:
   versions:
-    - 1.32.0
     - 1.33.1
     - 1.34.0
     - 1.35.1
@@ -51,6 +50,7 @@ matrix:
     - 1.49.0
     - 1.49.1
     - 1.50.0
+    - 1.50.1
 homepage: https://github.com/crate-ci/typos/
 summary: source code spell checker
 description: |-

--- a/blueprints/devops/mirrord/ops2deb.lock.yml
+++ b/blueprints/devops/mirrord/ops2deb.lock.yml
@@ -1,9 +1,3 @@
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.206.1/mirrord_linux_aarch64.zip
-  sha256: 1a763ef213011ea5674ca63599f4a9a9f15e92e3013a4d5447a876c112df42c8
-  timestamp: 2026-04-25 00:18:50+00:00
-- url: https://github.com/metalbear-co/mirrord/releases/download/3.206.1/mirrord_linux_x86_64.zip
-  sha256: dbbe8bdf173339195bb5b14696b0823fe957822d52f2f5dc4300faf0aa0316b4
-  timestamp: 2026-04-25 00:18:50+00:00
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.207.0/mirrord_linux_aarch64.zip
   sha256: 51cb36e5bba327b17e1bfaae95b403e54392c60a8851f46d6e704b7bef713dd0
   timestamp: 2026-04-28 18:29:23+00:00
@@ -298,3 +292,9 @@
 - url: https://github.com/metalbear-co/mirrord/releases/download/3.252.1/mirrord_linux_x86_64.zip
   sha256: a0469b85b85dc3d1a0640daf7a24525dc5a972969677d79185f5921fa29c659d
   timestamp: 2026-08-31 18:05:33+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.253.0/mirrord_linux_aarch64.zip
+  sha256: 5a23b86c191d335e7f2877eceb8a2829038a8ef7910d17bc94a4a36d1cc5fd05
+  timestamp: 2026-09-01 18:05:54+00:00
+- url: https://github.com/metalbear-co/mirrord/releases/download/3.253.0/mirrord_linux_x86_64.zip
+  sha256: bdb7a4b08fd731889c07eb9d666730b1226eecf2c0b45668184150bdc617501f
+  timestamp: 2026-09-01 18:05:54+00:00

--- a/blueprints/devops/mirrord/ops2deb.yml
+++ b/blueprints/devops/mirrord/ops2deb.yml
@@ -4,7 +4,6 @@ matrix:
     - amd64
     - arm64
   versions:
-    - 3.206.1
     - 3.207.0
     - 3.208.0
     - 3.209.0
@@ -54,6 +53,7 @@ matrix:
     - 3.250.0
     - 3.251.0
     - 3.252.1
+    - 3.253.0
 homepage: https://mirrord.dev/
 summary: develop locally with your kubernetes environment
 description: |-


### PR DESCRIPTION
Add mirrord v3.253.0
Remove mirrord v3.206.1
Add glab v1.116.0
Remove glab v1.68.0
Add typos-cli v1.50.1
Remove typos-cli v1.32.0
Add pyenv v2.8.5
Remove pyenv v2.4.20